### PR TITLE
Added "unassigned" to allowed project list by default so experiments …

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
@@ -1082,6 +1082,7 @@ public class ExperimentServiceImpl implements ExperimentService {
 		if (propertiesUtilService.getRestrictExperiments()){
 			Collection<LsThing> projects = authorService.getUserProjects(userName);
 			List<String> allowedProjectCodeNames = new ArrayList<String>();
+			allowedProjectCodeNames.add("unassigned");
 			for (LsThing project : projects){
 				allowedProjectCodeNames.add(project.getCodeName());
 			}

--- a/src/main/java/com/labsynch/labseer/service/ProtocolServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ProtocolServiceImpl.java
@@ -273,6 +273,7 @@ public class ProtocolServiceImpl implements ProtocolService {
 		Collection<Protocol> rawResults = findProtocolsByGenericMetaDataSearch(queryString);
 		Collection<LsThing> projects = authorService.getUserProjects(userName);
 		List<String> allowedProjectCodeNames = new ArrayList<String>();
+		allowedProjectCodeNames.add("unassigned");
 		for (LsThing project : projects){
 			allowedProjectCodeNames.add(project.getCodeName());
 		}


### PR DESCRIPTION
…and protocols with project set to the default "unassigned" are not filtered.