### PR TITLE
Switched protocols/codename/{codeName} route to use toJsonStub instea…

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiProtocolController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiProtocolController.java
@@ -334,7 +334,7 @@ public class ApiProtocolController {
         } catch (EmptyResultDataAccessException e){
         	return new ResponseEntity<String>(headers, HttpStatus.NOT_FOUND);
         }
-        return new ResponseEntity<String>(protocol.toJson(), headers, HttpStatus.OK);
+        return new ResponseEntity<String>(protocol.toJsonStub(), headers, HttpStatus.OK);
     }
 
     @Transactional


### PR DESCRIPTION
…d of toJson. In this case, that means the full protocol with states and values but with no nested experiments, as opposed to with nested experiments complete with labels, states, and values. Fixes #72