### PR TITLE
Added "labelNumber" attribute to AutoLabelDTO that contains the raw n…

### DIFF
--- a/src/main/java/com/labsynch/labseer/domain/LabelSequence.java
+++ b/src/main/java/com/labsynch/labseer/domain/LabelSequence.java
@@ -36,6 +36,7 @@ import org.springframework.roo.addon.json.RooJson;
 import org.springframework.roo.addon.tostring.RooToString;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.labsynch.labseer.dto.AutoLabelDTO;
 import com.labsynch.labseer.utils.ExcludeNulls;
 
 import flexjson.JSONSerializer;
@@ -108,23 +109,24 @@ public class LabelSequence {
 		return this;
 	}
 
-	public List<String> generateNextLabels(Long numberOfLabels){
-		List<String> labels = new ArrayList<String>();
+	public List<AutoLabelDTO> generateNextLabels(Long numberOfLabels){
+		List<AutoLabelDTO> labels = new ArrayList<AutoLabelDTO>();
 		int numGenerated = 0;
 		while (numGenerated < numberOfLabels) {
-			String label = this.generateNextLabel();
+			AutoLabelDTO label = this.generateNextLabel();
 			labels.add(label);
 			numGenerated++;
 		}
 		return labels;
 	}
 
-	public String generateNextLabel() {
+	public AutoLabelDTO generateNextLabel() {
 		Long labelNumber = this.incrementSequence(this.getDbSequence());
 		String formatLabelNumber = "%";
 		formatLabelNumber = formatLabelNumber.concat("0").concat(this.getDigits().toString()).concat("d");
 		String label = this.getLabelPrefix().concat(this.getLabelSeparator()).concat(String.format(formatLabelNumber, labelNumber));
-		return label;
+		AutoLabelDTO autoLabel = new AutoLabelDTO(label, labelNumber);
+		return autoLabel;
 
 	}
 

--- a/src/main/java/com/labsynch/labseer/dto/AutoLabelDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/AutoLabelDTO.java
@@ -11,5 +11,15 @@ public class AutoLabelDTO {
 	
     private String autoLabel;
 
+    private Long labelNumber;
+    
+    public AutoLabelDTO () {
+    	
+    }
+    
+    public AutoLabelDTO (String autoLabel, Long labelNumber){
+    		this.autoLabel = autoLabel;
+    		this.labelNumber = labelNumber;
+    }
 
 }

--- a/src/main/java/com/labsynch/labseer/dto/AutoLabelDTO_Roo_JavaBean.aj
+++ b/src/main/java/com/labsynch/labseer/dto/AutoLabelDTO_Roo_JavaBean.aj
@@ -15,4 +15,12 @@ privileged aspect AutoLabelDTO_Roo_JavaBean {
         this.autoLabel = autoLabel;
     }
     
+    public Long AutoLabelDTO.getLabelNumber() {
+        return this.labelNumber;
+    }
+    
+    public void AutoLabelDTO.setLabelNumber(Long labelNumber) {
+        this.labelNumber = labelNumber;
+    }
+    
 }

--- a/src/main/java/com/labsynch/labseer/service/AutoLabelServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/AutoLabelServiceImpl.java
@@ -333,14 +333,7 @@ public class AutoLabelServiceImpl implements AutoLabelService {
 	}
 
 	private List<AutoLabelDTO> generateAutoLabels(LabelSequence labelSequence, Long numberOfLabels) {
-		List<AutoLabelDTO> autoLabels = new ArrayList<AutoLabelDTO>();
-		List<String> labels = labelSequence.generateNextLabels(numberOfLabels);
-		for (String label : labels) {
-			AutoLabelDTO autoLabel = new AutoLabelDTO();
-			autoLabel.setAutoLabel(label);
-			autoLabels.add(autoLabel);
-		}
-		return autoLabels;
+		return labelSequence.generateNextLabels(numberOfLabels);
 	}
 
 	private LabelSequence createLabelSequence(String thingTypeAndKind, String labelTypeAndKind) {

--- a/src/test/java/com/labsynch/labseer/service/AutoLabelServiceTest.java
+++ b/src/test/java/com/labsynch/labseer/service/AutoLabelServiceTest.java
@@ -111,11 +111,11 @@ public class AutoLabelServiceTest {
 	@Rollback(value=false)
 	public void incrementSequence() {
 		LabelSequence testSeq = LabelSequence.findLabelSequencesByThingTypeAndKindEqualsAndLabelTypeAndKindEquals("compound_parent", "id_corpName").getSingleResult();
-		String testLabel = testSeq.generateNextLabel();
-		logger.info(testLabel);
-		List<String> testLabels = testSeq.generateNextLabels(100L);
-		for (String label : testLabels) {
-			logger.info(label);
+		AutoLabelDTO testLabel = testSeq.generateNextLabel();
+		logger.info(testLabel.getAutoLabel());
+		List<AutoLabelDTO> testLabels = testSeq.generateNextLabels(100L);
+		for (AutoLabelDTO label : testLabels) {
+			logger.info(label.getAutoLabel());
 		}
 	}
 }


### PR DESCRIPTION
…umeric value pulled from the sequence. Refactored some AutoLabel methods to pass this through, so it can be used as the parentNumber in CReg. Fixes https://github.com/mcneilco/acas-cmpdreg-roo-server/issues/31