### PR TITLE
Refactored the code behind getOrCreateBench into a more generic getOr…

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/ContainerService.java
+++ b/src/main/java/com/labsynch/labseer/service/ContainerService.java
@@ -12,6 +12,7 @@ import com.labsynch.labseer.domain.ContainerLabel;
 import com.labsynch.labseer.domain.ContainerState;
 import com.labsynch.labseer.domain.ContainerValue;
 import com.labsynch.labseer.domain.ItxContainerContainer;
+import com.labsynch.labseer.domain.LsTransaction;
 import com.labsynch.labseer.dto.CodeLabelDTO;
 import com.labsynch.labseer.dto.CodeTableDTO;
 import com.labsynch.labseer.dto.ContainerBatchCodeDTO;
@@ -161,6 +162,8 @@ public interface ContainerService {
 
 	List<ContainerLocationTreeDTO> getLocationCodeByLabelBreadcrumbByRecursiveQuery(String rootLabel, List<String> breadcrumbList) throws SQLException;
 
-	Container getOrCreateTrash() throws Exception;
+	Container getOrCreateTrash(String recordedBy) throws Exception;
+
+	Container getOrCreateBench(String recordedBy, LsTransaction lsTransaction) throws SQLException;
 	
 }

--- a/src/main/java/com/labsynch/labseer/utils/PropertiesUtilService.java
+++ b/src/main/java/com/labsynch/labseer/utils/PropertiesUtilService.java
@@ -45,5 +45,11 @@ public interface PropertiesUtilService {
 
 	String getChemistryPackage();
 
+	String getRootLocationLabel();
+
+	String getTrashLocationLabel();
+
+	String getBenchesLocationLabel();
+
 	
 }

--- a/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
@@ -246,4 +246,39 @@ public class PropertiesUtilServiceImpl implements PropertiesUtilService{
 	public String getChemistryPackage() {
 	    return this.chemistryPackage;
 	}
+	
+	String rootLocationLabel;
+	@Value("${client.compoundInventory.rootLocationLabel}")
+	public void setRootLocationLabel(String rootLocationLabel) {
+		this.rootLocationLabel = rootLocationLabel;
+		if (this.rootLocationLabel.startsWith("${")) this.rootLocationLabel = null;
+	}
+	
+	@Override
+	public String getRootLocationLabel() {
+	    return this.rootLocationLabel;
+	}
+	
+	String trashLocationLabel;
+	@Value("${client.compoundInventory.trashLocationLabel}")
+	public void setTrashLocationLabel(String trashLocationLabel) {
+		this.trashLocationLabel = trashLocationLabel;
+		if (this.trashLocationLabel.startsWith("${")) this.trashLocationLabel = null;
+	}
+	
+	@Override
+	public String getTrashLocationLabel() {
+	    return this.trashLocationLabel;
+	}
+	String benchesLocationLabel;
+	@Value("${client.compoundInventory.benchesLocationLabel}")
+	public void setBenchesLocationLabel(String benchesLocationLabel) {
+		this.benchesLocationLabel = benchesLocationLabel;
+		if (this.benchesLocationLabel.startsWith("${")) this.benchesLocationLabel = null;
+	}
+	
+	@Override
+	public String getBenchesLocationLabel() {
+	    return this.benchesLocationLabel;
+	}
 }

--- a/src/test/java/com/labsynch/labseer/service/ContainerLSServiceTests.java
+++ b/src/test/java/com/labsynch/labseer/service/ContainerLSServiceTests.java
@@ -1376,12 +1376,16 @@ public class ContainerLSServiceTests {
 	@Transactional
 	@Rollback(value=false)
 	public void getOrCreateTrash() throws Exception {
-		containerService.getOrCreateTrash();
+		containerService.getOrCreateTrash("acas test");
 	}
 	
+	@Test
+	@Transactional
+	@Rollback(value=false)
+	public void getOrCreateBench() throws Exception {
+		containerService.getOrCreateBench("bfrost", null);
+	}
 	
-	
-	
-	
+
 	
 }


### PR DESCRIPTION
…CreateLocation utility function. Refactored both getOrCreateBench and getOrCreateTrash to use this same service. Added logic to getOrCreateTrash so if it is not in any location and a root location is configured, then getOrCreate the root location if it is configured, and put the trash inside the root location. Added similar logic to getOrCreateBench to put user benches into a new "Benches" location, whose label is configurable by a new config. By default, user benches will be put into the "Benches" location, which will itself be put into the root location if there is a root location configured. Fixes https://github.com/mcneilco/acas/issues/380