### PR TITLE
bugfix/batch-corpName-sorting-fix: Batch corpName sorting splits on d…

### DIFF
--- a/src/main/java/com/labsynch/labseer/utils/LsThingComparatorByBatchNumber.java
+++ b/src/main/java/com/labsynch/labseer/utils/LsThingComparatorByBatchNumber.java
@@ -9,9 +9,11 @@ public class LsThingComparatorByBatchNumber implements Comparator<LsThing> {
 	@Override
 	public int compare(LsThing o1, LsThing o2){
 		String o1CorpName = o1.pickBestCorpName().getLabelText();
-		int o1BatchNumber = Integer.parseInt(o1CorpName.split("-")[1]);
+		String[] splitO1CorpName = o1CorpName.split("\\D+");
+		int o1BatchNumber = Integer.parseInt(splitO1CorpName[splitO1CorpName.length-1]);
 		String o2CorpName = o2.pickBestCorpName().getLabelText();
-		int o2BatchNumber = Integer.parseInt(o2CorpName.split("-")[1]);
+		String[] splitO2CorpName = o2CorpName.split("\\D+");
+		int o2BatchNumber = Integer.parseInt(splitO2CorpName[splitO2CorpName.length-1]);
 		return o1BatchNumber - o2BatchNumber;
 	}
 


### PR DESCRIPTION
…ashes and uses incorrect part of the name for batch sorting. Fixes Issue #137