### PR TITLE
Fixed issue in SEL with Japanese characters where csv is written prop…

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiExperimentController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiExperimentController.java
@@ -1564,7 +1564,7 @@ public class ApiExperimentController {
 	@ResponseBody
 	public ResponseEntity<String> experimentBrowserSearch(@RequestParam(value="userName", required = false) String userName, @RequestParam(value="q", required = true) String searchQuery) {
 		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/json");
+		headers.add("Content-Type", "application/json; charset=utf-8");
 		
 		logger.debug("############# the search query string is: " + searchQuery);
 		

--- a/src/main/java/com/labsynch/labseer/api/ApiProtocolController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiProtocolController.java
@@ -443,7 +443,7 @@ public class ApiProtocolController {
 	@ResponseBody
 	public ResponseEntity<String> protocolBrowserSearch(@RequestParam(value="userName", required = true) String userName, @RequestParam("q") String searchQuery) {
 		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/json");
+		headers.add("Content-Type", "application/json; charset=utf-8");
 		try {
 		Collection<ProtocolDTO> result = ProtocolDTO.convertCollectionToProtocolDTO(protocolService.findProtocolsByGenericMetaDataSearch(searchQuery, userName));
 		return new ResponseEntity<String>(ProtocolDTO.toJsonArrayStub(result), headers, HttpStatus.OK);

--- a/src/main/java/com/labsynch/labseer/service/AnalysisGroupServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/AnalysisGroupServiceImpl.java
@@ -288,7 +288,7 @@ public class AnalysisGroupServiceImpl implements AnalysisGroupService {
 				logger.info("read csv delimited file");
 				//InputStream is = CreateAnalysisGroupsFromCSVFileTests.class.getClassLoader().getResourceAsStream(inputFileName);
 				InputStream is = new FileInputStream(absoluteFilePath);  
-				InputStreamReader isr = new InputStreamReader(is);  
+				InputStreamReader isr = new InputStreamReader(is, "UTF-8");  
 				BufferedReader br = new BufferedReader(isr);
 
 				beanReader = new CsvBeanReader(br, CsvPreference.TAB_PREFERENCE);


### PR DESCRIPTION
Fixed issue in SEL with Japanese characters where csv is written properly, but then read with system default encoding instead of actual file encoding, resulting in unknown characters and a value_kind ls_type_and_kind foreign key constraint violation.

Tested that both files with and without Japanese characters load successfully with this change.
This also seems to fix the issue with using "µ" in units.