### PR TITLE
Roll back AspectJ version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -538,7 +538,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.]]>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>aspectj-maven-plugin</artifactId>
-				<version>1.9</version>
+				<version>1.8</version>
 				<!-- NB: do not use 1.3 or 1.3.x due to MASPECTJ-90 and do not use 1.4 
 					due to declare parents issue -->
 				<dependencies>


### PR DESCRIPTION
### Stack trace

Running: `docker build -t mcneilco/acas-roo-server-oss:latest .`

```bash
AspectJ Internal Error: unable to add stackmap attributes. Java heap space
[ERROR] Internal compiler error: org.aspectj.weaver.BCException: Unable to find Asm for stackmap generation (Looking for 'aj.org.objectweb.asm.ClassReader'). Stackmap generation for woven code is required to avoid verify errors on a Java 1.7 or higher runtime
when weaving type com.labsynch.labseer.domain.LsSeqExpt
when weaving classes
when weaving
when batch building BuildConfig[null] #Files=1796 AopXmls=#0
 when weaving type com.labsynch.labseer.domain.LsSeqExpt
	/src/src/main/java/com/labsynch/labseer/domain/LsSeqExpt.java:0
(no source information available)

[ERROR] ABORT
May 17, 2019 6:21:13 PM org.aspectj.weaver.tools.Jdk14Trace info
INFO: Dumping to /src/./ajcore.20190517.182113.848.txt
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 06:34 min
[INFO] Finished at: 2019-05-17T18:21:15Z
[INFO] Final Memory: 384M/444M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.codehaus.mojo:aspectj-maven-plugin:1.9:compile (default) on project acas: AJC compiler errors:
[ERROR] error at (no source information available)
[ERROR] /src/src/main/java/com/labsynch/labseer/domain/LsSeqExpt.java:0::0 Internal compiler error: org.aspectj.weaver.BCException: Unable to find Asm for stackmap generation (Looking for 'aj.org.objectweb.asm.ClassReader'). Stackmap generation for woven code is required to avoid verify errors on a Java 1.7 or higher runtime
[ERROR] when weaving type com.labsynch.labseer.domain.LsSeqExpt
[ERROR] when weaving classes
[ERROR] when weaving
[ERROR] when batch building BuildConfig[null] #Files=1796 AopXmls=#0
[ERROR]  when weaving type com.labsynch.labseer.domain.LsSeqExpt
[ERROR] abort ABORT -- (BCException) Unable to find Asm for stackmap generation (Looking for 'aj.org.objectweb.asm.ClassReader'). Stackmap generation for woven code is required to avoid verify errors on a Java 1.7 or higher runtime
[ERROR] when weaving type com.labsynch.labseer.domain.LsSeqExpt
[ERROR] when weaving classes
[ERROR] when weaving
[ERROR] when batch building BuildConfig[null] #Files=1796 AopXmls=#0
[ERROR]
[ERROR] Unable to find Asm for stackmap generation (Looking for 'aj.org.objectweb.asm.ClassReader'). Stackmap generation for woven code is required to avoid verify errors on a Java 1.7 or higher runtime
[ERROR] when weaving type com.labsynch.labseer.domain.LsSeqExpt
[ERROR] when weaving classes
[ERROR] when weaving
[ERROR] when batch building BuildConfig[null] #Files=1796 AopXmls=#0
[ERROR]
[ERROR] org.aspectj.weaver.BCException: Unable to find Asm for stackmap generation (Looking for 'aj.org.objectweb.asm.ClassReader'). Stackmap generation for woven code is required to avoid verify errors on a Java 1.7 or higher runtime
[ERROR] when weaving type com.labsynch.labseer.domain.LsSeqExpt
[ERROR] when weaving classes
[ERROR] when weaving
[ERROR] when batch building BuildConfig[null] #Files=1796 AopXmls=#0
[ERROR]
[ERROR] 	at org.aspectj.weaver.bcel.LazyClassGen.getJavaClassBytesIncludingReweavable(LazyClassGen.java:703)
[ERROR] 	at org.aspectj.weaver.bcel.BcelWeaver.getClassFilesFor(BcelWeaver.java:1451)
[ERROR] 	at org.aspectj.weaver.bcel.BcelWeaver.weaveAndNotify(BcelWeaver.java:1413)
[ERROR] 	at org.aspectj.weaver.bcel.BcelWeaver.weave(BcelWeaver.java:1191)
[ERROR] 	at org.aspectj.ajdt.internal.compiler.AjPipeliningCompilerAdapter.weaveQueuedEntries(AjPipeliningCompilerAdapter.java:514)
[ERROR] 	at org.aspectj.ajdt.internal.compiler.AjPipeliningCompilerAdapter.queueForWeaving(AjPipeliningCompilerAdapter.java:447)
[ERROR] 	at org.aspectj.ajdt.internal.compiler.AjPipeliningCompilerAdapter.afterProcessing(AjPipeliningCompilerAdapter.java:432)
[ERROR] 	at org.aspectj.ajdt.internal.compiler.CompilerAdapter.ajc$after$org_aspectj_ajdt_internal_compiler_CompilerAdapter$5$6b855184(CompilerAdapter.aj:103)
[ERROR] 	at org.aspectj.org.eclipse.jdt.internal.compiler.Compiler.process(Compiler.java:909)
[ERROR] 	at org.aspectj.org.eclipse.jdt.internal.compiler.Compiler.processCompiledUnits(Compiler.java:550)
[ERROR] 	at org.aspectj.org.eclipse.jdt.internal.compiler.Compiler.compile(Compiler.java:462)
[ERROR] 	at org.aspectj.org.eclipse.jdt.internal.compiler.Compiler.compile(Compiler.java:417)
[ERROR] 	at org.aspectj.ajdt.internal.core.builder.AjBuildManager.performCompilation(AjBuildManager.java:1036)
[ERROR] 	at org.aspectj.ajdt.internal.core.builder.AjBuildManager.performBuild(AjBuildManager.java:272)
[ERROR] 	at org.aspectj.ajdt.internal.core.builder.AjBuildManager.batchBuild(AjBuildManager.java:185)
[ERROR] 	at org.aspectj.ajdt.ajc.AjdtCommand.doCommand(AjdtCommand.java:114)
[ERROR] 	at org.aspectj.ajdt.ajc.AjdtCommand.runCommand(AjdtCommand.java:60)
[ERROR] 	at org.aspectj.tools.ajc.Main.run(Main.java:371)
[ERROR] 	at org.aspectj.tools.ajc.Main.runMain(Main.java:248)
[ERROR] 	at org.codehaus.mojo.aspectj.AbstractAjcCompiler.execute(AbstractAjcCompiler.java:537)
[ERROR] 	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:154)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:146)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
[ERROR] 	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:309)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:194)
[ERROR] 	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:107)
[ERROR] 	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:955)
[ERROR] 	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:290)
[ERROR] 	at org.apache.maven.cli.MavenCli.main(MavenCli.java:194)
[ERROR] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[ERROR] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR] 	at java.lang.reflect.Method.invoke(Method.java:498)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
[ERROR]
[ERROR]
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
The command '/bin/sh -c mvn compile war:war' returned a non-zero code: 1
```

### Fix

@kramschu found that rolling back the AspectJ Maven plugin version to `1.8` fixes this and the docker image will build successfully. 