### PR TITLE
fixes mcneilco/acas#696 add optional ls kind parameter to generic thing search

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiLsThingController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiLsThingController.java
@@ -69,11 +69,11 @@ public class ApiLsThingController {
 	@RequestMapping(value = "/search", method = RequestMethod.GET)
 	@ResponseBody
 	public ResponseEntity<String> genericLsThingSearch(@RequestParam(value="lsType", required = false) String lsType, @RequestParam("q") String searchQuery,
-														@RequestParam(value = "with", required = false) String with) {
+														@RequestParam(value="lsKind", required = false) String lsKind, @RequestParam(value = "with", required = false) String with) {
 		HttpHeaders headers = new HttpHeaders();
 		headers.add("Content-Type", "application/json");
 		try {
-			Collection<LsThing> results = lsThingService.findLsThingsByGenericMetaDataSearch(searchQuery, lsType);
+			Collection<LsThing> results = lsThingService.findLsThingsByGenericMetaDataSearch(searchQuery, lsType, lsKind);
 			if (with != null) {
 				if (with.equalsIgnoreCase("nestedfull")) {
 					return new ResponseEntity<String>(LsThing.toJsonArrayWithNestedFull(results), headers, HttpStatus.OK);

--- a/src/main/java/com/labsynch/labseer/service/LsThingService.java
+++ b/src/main/java/com/labsynch/labseer/service/LsThingService.java
@@ -62,8 +62,13 @@ public interface LsThingService {
 
 	Collection<LsThing> findLsThingsByGenericMetaDataSearch(String searchQuery);
 
-	Collection<LsThing> findLsThingsByGenericMetaDataSearch(String lsType,
-			String searchQuery);
+	Collection<LsThing> findLsThingsByGenericMetaDataSearch(String searchQuery,
+			String lsType);
+
+	Collection<LsThing> findLsThingsByGenericMetaDataSearch(String searchQuery,
+			String lsType,
+			String lsKind
+	);
 
 	Collection<CodeTableDTO> getCodeTableLsThings(String lsType, String lsKind, boolean includeIgnored);
 

--- a/src/main/java/com/labsynch/labseer/service/LsThingServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LsThingServiceImpl.java
@@ -1030,7 +1030,7 @@ public class LsThingServiceImpl implements LsThingService {
 	@Override
 	public Collection<LsThing> findLsThingsByGenericMetaDataSearch(
 			String searchQuery, String lsType) {
-		return findLsThingsByGenericMetaDataSearch(searchQuery, null, null);
+		return findLsThingsByGenericMetaDataSearch(searchQuery, lsType, null);
 	}
 
 	@Override

--- a/src/main/java/com/labsynch/labseer/service/LsThingServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LsThingServiceImpl.java
@@ -1026,8 +1026,12 @@ public class LsThingServiceImpl implements LsThingService {
 			String searchQuery) {
 		return findLsThingsByGenericMetaDataSearch(searchQuery, null);
 	}
-	
 
+	@Override
+	public Collection<LsThing> findLsThingsByGenericMetaDataSearch(
+			String searchQuery, String lsType) {
+		return findLsThingsByGenericMetaDataSearch(searchQuery, null, null);
+	}
 
 	@Override
 	public Collection<LsThing> findLsThingProjectsByGenericMetaDataSearch(
@@ -1049,7 +1053,7 @@ public class LsThingServiceImpl implements LsThingService {
 
 	@Override
 	public Collection<LsThing> findLsThingsByGenericMetaDataSearch(
-			String queryString, String lsType){
+			String queryString, String lsType, String lsKind){
 		List<Long> lsThingIdList = new ArrayList<Long>();
 		queryString = queryString.replaceAll("\\*", "%");
 		List<String> splitQuery = SimpleUtil.splitSearchString(queryString);
@@ -1073,6 +1077,10 @@ public class LsThingServiceImpl implements LsThingService {
 		List<Predicate> predicateList = new ArrayList<Predicate>();
 		if (lsType != null && lsType.length() > 0){
 			Predicate predicate = criteriaBuilder.equal(lsThingRoot.<String>get("lsType"), lsType);
+			predicateList.add(predicate);
+		}
+		if (lsKind != null && lsKind.length() > 0){
+			Predicate predicate = criteriaBuilder.equal(lsThingRoot.<String>get("lsKind"), lsKind);
 			predicateList.add(predicate);
 		}
 		for (String term : splitQuery){


### PR DESCRIPTION
This is an additional commit I made on the generic thing search branch addition from last week.

It adds an optional lsKind parmeter to the generic search route.