### PR TITLE
fixes mcneilco/acas#720 Ls thing advanced search of character string on a numericValue field

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/LsThingServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LsThingServiceImpl.java
@@ -2582,22 +2582,29 @@ public class LsThingServiceImpl implements LsThingService {
 							}
 						}
 					}else if (valueQuery.getValueType().equalsIgnoreCase("numericValue")){
-					if (valueQuery.getOperator() != null && valueQuery.getOperator().equals(">")){
-						Predicate valueGreaterThan = criteriaBuilder.greaterThan(value.<BigDecimal>get("numericValue"), new BigDecimal(valueQuery.getValue()));
-						valuePredicatesList.add(valueGreaterThan);
-					}else if (valueQuery.getOperator() != null && valueQuery.getOperator().equals("<=")){
-						Predicate valueGreaterThan = criteriaBuilder.greaterThanOrEqualTo(value.<BigDecimal>get("numericValue"), new BigDecimal(valueQuery.getValue()));
-						valuePredicatesList.add(valueGreaterThan);
-					}else if (valueQuery.getOperator() != null && valueQuery.getOperator().equals("<")){
-						Predicate valueLessThan = criteriaBuilder.lessThan(value.<BigDecimal>get("numericValue"), new BigDecimal(valueQuery.getValue()));
-						valuePredicatesList.add(valueLessThan);
-					}else if (valueQuery.getOperator() != null && valueQuery.getOperator().equals("<=")){
-						Predicate valueLessThan = criteriaBuilder.lessThanOrEqualTo(value.<BigDecimal>get("numericValue"), new BigDecimal(valueQuery.getValue()));
-						valuePredicatesList.add(valueLessThan);
-					}else{
-						Predicate valueEquals = criteriaBuilder.equal(value.<BigDecimal>get("numericValue"), new BigDecimal(valueQuery.getValue()));
-						valuePredicatesList.add(valueEquals);
-					}
+						try{
+							BigDecimal numberValue = new BigDecimal(valueQuery.getValue());
+							if (valueQuery.getOperator() != null && valueQuery.getOperator().equals(">")){
+								Predicate valueGreaterThan = criteriaBuilder.greaterThan(value.<BigDecimal>get("numericValue"), numberValue);
+								valuePredicatesList.add(valueGreaterThan);
+							}else if (valueQuery.getOperator() != null && valueQuery.getOperator().equals("<=")){
+								Predicate valueGreaterThan = criteriaBuilder.greaterThanOrEqualTo(value.<BigDecimal>get("numericValue"), numberValue);
+								valuePredicatesList.add(valueGreaterThan);
+							}else if (valueQuery.getOperator() != null && valueQuery.getOperator().equals("<")){
+								Predicate valueLessThan = criteriaBuilder.lessThan(value.<BigDecimal>get("numericValue"), numberValue);
+								valuePredicatesList.add(valueLessThan);
+							}else if (valueQuery.getOperator() != null && valueQuery.getOperator().equals("<=")){
+								Predicate valueLessThan = criteriaBuilder.lessThanOrEqualTo(value.<BigDecimal>get("numericValue"), numberValue);
+								valuePredicatesList.add(valueLessThan);
+							}else{
+								Predicate valueEquals = criteriaBuilder.equal(value.<BigDecimal>get("numericValue"), numberValue);
+								valuePredicatesList.add(valueEquals);
+							}
+						} catch (NumberFormatException e){
+							logger.warn("Failed to parse number in LsThing generic query for value",e);
+							valuePredicatesList.add(criteriaBuilder.disjunction());
+
+						}
 				}else{
 					//string value types: stringValue, codeValue, fileValue, clobValue
 					if (valueQuery.getOperator() != null && valueQuery.getOperator().equals("=")){


### PR DESCRIPTION
Currently if a numericValue is used in advanced search, the code will fail if the search value cannot be coerced to numeric.

E.g.  'asdf'

This code change will return a negative condition `criteriaBuilder.disjunction()` to return a false for the value being searched on for this field,  this does not affect other parts of the query where there may be a match. See `0=1` in the sql produced below

```sql
select distinct lsthing0_.id as col_0_0_
from ls_thing lsthing0_
inner join ls_thing_state lsstates1_ on lsthing0_.id=lsstates1_.lsthing_id
inner join ls_thing_value lsvalues2_ on lsstates1_.id=lsvalues2_.lsthing_state_id
inner join ls_thing_state lsstates3_ on lsthing0_.id=lsstates3_.lsthing_id
inner join ls_thing_value lsvalues4_ on lsstates3_.id=lsvalues4_.lsthing_state_id
inner join ls_thing_label lslabels5_ on lsthing0_.id=lslabels5_.lsthing_id
where lsthing0_.ignored=false
    and (lower(lsthing0_.code_name) like $1
         or lsstates1_.ignored=false
         and lsvalues2_.ignored=false
         and lsstates1_.ls_type=$2
         and lsstates1_.ls_kind=$3
         and lsvalues2_.ls_type=$4
         and lsvalues2_.ls_kind=$5
         and 0=1
         or lsstates3_.ignored=false
         and lsvalues4_.ignored=false
         and lsstates3_.ls_type=$6
         and lsstates3_.ls_kind=$7
         and lsvalues4_.ls_type=$8
         and lsvalues4_.ls_kind=$9
         and (lower(lsvalues4_.clob_value) like $10)
         or lslabels5_.ls_type=$11
         and lslabels5_.ls_kind=$12
         and (lower(lslabels5_.label_text) like $13))
    and lsthing0_.ls_type=$14
    and lsthing0_.ls_kind=$15
```

 