### PR TITLE
mcneilco/acas#756 get code name from name performance

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/LsThingService.java
+++ b/src/main/java/com/labsynch/labseer/service/LsThingService.java
@@ -88,9 +88,6 @@ public interface LsThingService {
 	
 	Collection<LsThing> sortBatches(Collection<LsThing> batches);
 
-	PreferredNameResultsDTO getCodeNameFromName(String thingType,
-			String thingKind, String labelType, String labelKind, String json);
-
 	DependencyCheckDTO checkBatchDependencies(LsThing batch);
 
 	DependencyCheckDTO checkParentDependencies(LsThing parent);

--- a/src/main/java/com/labsynch/labseer/service/LsThingServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LsThingServiceImpl.java
@@ -158,6 +158,14 @@ public class LsThingServiceImpl implements LsThingService {
 		// Build the WHERE clause predicates
 		Predicate[] predicates = new Predicate[0];
 		List<Predicate> predicateList = new ArrayList<Predicate>();
+		// Thing not ignored
+		Predicate thingNotIgnored = cb.not(lsThingRoot.<Boolean>get("ignored"));
+		predicateList.add(thingNotIgnored);
+		// Label null or not ignored
+		Predicate labelIgnoredNull = cb.isNull(lsThingLabel.<Boolean>get("ignored"));
+		Predicate labelNotIgnored = cb.not(lsThingLabel.<Boolean>get("ignored"));
+		Predicate labelIgnored = cb.or(labelIgnoredNull, labelNotIgnored);
+		predicateList.add(labelIgnored);
 		// Thing Type and Kind
 		if (thingType != null && thingType.length() > 0){
 			Predicate predicate = cb.equal(lsThingRoot.<String>get("lsType"), thingType);

--- a/src/main/java/com/labsynch/labseer/service/LsThingServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LsThingServiceImpl.java
@@ -195,24 +195,22 @@ public class LsThingServiceImpl implements LsThingService {
 		TypedQuery<LsThing> q = em.createQuery(criteria);
 		logger.debug(q.unwrap(org.hibernate.Query.class).getQueryString());
 		List<LsThing> foundLsThings = q.getResultList();
-		// Construct two PreferredNameDTOs for each found LsThing, one referenced by label and the other by codeName
+		// Construct a PreferredNameDTO for each possible requestName for each found LsThing, both by label and by codeName
 		// The goal is to be able to line up with what was sent in, whether it was by label or by codeName
 		List<PreferredNameDTO> rawResultDTOs = new ArrayList<PreferredNameDTO>();
 		for (LsThing lsThing : foundLsThings){
 			String bestLabel = pickBestLabel(lsThing);
 			String codeName = lsThing.getCodeName();
-			String requestName = ""; 
 			for (LsThingLabel label : lsThing.getLsLabels()){
 				boolean typeMatches = labelType == null || label.getLsType().equals(labelType);
 				boolean kindMatches = labelKind == null || label.getLsKind().equals(labelKind);
 				if (typeMatches && kindMatches){
-					requestName = label.getLabelText();
+					PreferredNameDTO resByLabel = new PreferredNameDTO(label.getLabelText(), bestLabel, codeName);
+					rawResultDTOs.add(resByLabel);
 				}
 			}
-			PreferredNameDTO res = new PreferredNameDTO(requestName, bestLabel, codeName);
-			PreferredNameDTO res2 = new PreferredNameDTO(codeName, bestLabel, codeName);
-			rawResultDTOs.add(res);
-			rawResultDTOs.add(res2);
+			PreferredNameDTO resByCodeName = new PreferredNameDTO(codeName, bestLabel, codeName);
+			rawResultDTOs.add(resByCodeName);
 		}
 		
 

--- a/src/main/java/com/labsynch/labseer/service/LsThingServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LsThingServiceImpl.java
@@ -224,6 +224,8 @@ public class LsThingServiceImpl implements LsThingService {
 
 		// Work up query results into output
 		for (PreferredNameDTO request : requests){
+			request.setPreferredName("");
+			request.setReferenceName("");
 			List<PreferredNameDTO> matches = new ArrayList<PreferredNameDTO>();
 			for (PreferredNameDTO res : rawResultDTOs){
 				if (res.getRequestName().equals(request.getRequestName())){
@@ -238,14 +240,12 @@ public class LsThingServiceImpl implements LsThingService {
 			} else if (matches.size() > 1){
 				responseOutput.setError(true);
 				ErrorMessageDTO error = new ErrorMessageDTO();
-				error.setLevel("MULTIPLE RESULTS");
+				error.setLevel("error");
 				error.setMessage("FOUND MULTIPLE LSTHINGS WITH THE SAME NAME: " + request.getRequestName() );	
 				logger.error("FOUND MULTIPLE LSTHINGS WITH THE SAME NAME: " + request.getRequestName());
 				errors.add(error);
 			} else{
 				logger.info("Did not find a LS_THING WITH THE REQUESTED NAME: " + request.getRequestName());
-				request.setPreferredName("");
-				request.setReferenceName("");
 			}
 		}
 		


### PR DESCRIPTION
Fixes mcneilco/acas#756 
- Remove unused `getCodeNameFromName(String thingType, String thingKind, String labelType, String labelKind, String json)` function.
- Total rewrite of `getCodeNameFromName(String thingType, String thingKind, String labelType, String labelKind, PreferredNameRequestDTO requestDTO)` to use CriteriaQuery and issue a single query instead of using a for loop and issuing a query for every single input.

Tested updated route with:
- thingType + thingKind + labelType + labelKind
- thingType + thingKind only
- Inputs with labelText as requestName
- Inputs with codeName as requestName
- Inputs that request the same entity, but one by label and one by codeName
- No match
- Duplicate matches