### PR TITLE
Update to new tomcat image which has openssl and cacerts permissions for runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG 	CHEMISTRY_PACKAGE=bbchem
-ARG 	TOMCAT_IMAGE=mcneilco/tomcat-maven:1.4-openjdk8
+ARG 	TOMCAT_IMAGE=mcneilco/tomcat-maven:1.5-openjdk8
 
 FROM 	${TOMCAT_IMAGE} as dependencies
 ARG     CHEMISTRY_PACKAGE


### PR DESCRIPTION
I tested running the OpenSSL and keytool import command on a server which used self signed certs.

fixes #260

See pull request https://github.com/mcneilco/tomcat-maven/pull/1