### PR TITLE
Fixing jchem and indigo builds

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/indigo/CmpdRegMoleculeIndigoImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/indigo/CmpdRegMoleculeIndigoImpl.java
@@ -136,4 +136,23 @@ public class CmpdRegMoleculeIndigoImpl implements CmpdRegMolecule {
 		this.molecule.dearomatize();
 	}
 
+	@Override
+	public StandardizationStatus getStandardizationStatus() {
+		return StandardizationStatus.SUCCESS;
+	}
+
+	@Override
+	public String getStandardizationComment() {
+		return null;
+	}
+
+	@Override
+	public RegistrationStatus getRegistrationStatus() {
+		return RegistrationStatus.SUCCESS;
+	}
+
+	@Override
+	public String getRegistrationComment() {
+		return null;
+	}
 }

--- a/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegMoleculeJChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegMoleculeJChemImpl.java
@@ -137,4 +137,24 @@ public class CmpdRegMoleculeJChemImpl implements CmpdRegMolecule {
 		this.molecule.dearomatize();	
 	}
 
+	@Override
+	public StandardizationStatus getStandardizationStatus() {
+		return StandardizationStatus.SUCCESS;
+	}
+
+	@Override
+	public String getStandardizationComment() {
+		return null;
+	}
+
+	@Override
+	public RegistrationStatus getRegistrationStatus() {
+		return RegistrationStatus.SUCCESS;
+	}
+
+	@Override
+	public String getRegistrationComment() {
+		return null;
+	}
+
 }


### PR DESCRIPTION
These are additionally changes I missed for the other chemistry packages.  These are required methods on CmpdRegMolecule.