### PR TITLE
Brianbolt/issue288

### DIFF
--- a/src/main/java/com/labsynch/labseer/db/migration/postgres/V2_3_0_4__url_encode_cmpdreg_filelist_urls.java
+++ b/src/main/java/com/labsynch/labseer/db/migration/postgres/V2_3_0_4__url_encode_cmpdreg_filelist_urls.java
@@ -1,0 +1,90 @@
+package com.labsynch.labseer.db.migration.postgres;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.net.URLEncoder;
+
+import javax.transaction.Transactional;
+
+import org.flywaydb.core.api.migration.spring.SpringJdbcMigration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+
+
+public class V2_3_0_4__url_encode_cmpdreg_filelist_urls implements SpringJdbcMigration {
+ 
+	Logger logger = LoggerFactory.getLogger(V2_3_0_4__url_encode_cmpdreg_filelist_urls.class);
+
+	@Transactional
+	public void migrate(JdbcTemplate jdbcTemplate) throws Exception {
+		logger.debug("attempting to url encode file_list.urls");
+
+		String selectFileIds = "SELECT id FROM file_list WHERE id IS NOT null";
+		String selectFileByIdSQL = "SELECT * FROM file_list WHERE id = ?";
+		String updateFileURLs = "UPDATE file_list SET url = ? WHERE id = ?";
+
+		List<Integer> ids = jdbcTemplate.queryForList(selectFileIds, Integer.class);
+
+		for (Integer id : ids){
+			FileObject file = (FileObject)jdbcTemplate.queryForObject(selectFileByIdSQL, new Object[] { id }, new FileRowMapper());
+			if (logger.isDebugEnabled()) logger.debug(file.getUrl());
+			String url = getEncodedUrl(file.getUrl());
+			
+			int rs2 = jdbcTemplate.update(updateFileURLs,  new Object[] { url, id });
+		}
+	}
+	
+	private class FileObject{
+		private long id;
+		private String url;
+		
+		public long getId(){
+			return this.id;
+		}
+		
+		public String getUrl(){
+			return this.url;
+		}
+		
+		public void setId(long id){
+			this.id = id;
+		}
+		
+		public void setUrl(String url){
+			this.url = url;
+		}
+	}
+	
+	@SuppressWarnings("rawtypes")
+	public class FileRowMapper implements RowMapper
+	{
+		@Override
+		public Object mapRow(ResultSet rs, int rowNum) throws SQLException {
+			FileObject file = new FileObject();
+			file.setId(rs.getLong("id"));
+			file.setUrl(rs.getString("url"));
+			return file;
+		}
+	}
+	
+	private String getEncodedUrl(String url) {
+		try{
+			// Split url on = and encode the second part (file path) of the url
+			String[] urlParts = url.split("=");
+			String charset = "UTF-8";
+			String encodedUrl = urlParts[0] + "=" + URLEncoder.encode(urlParts[1], charset);
+			return encodedUrl;
+		} catch (Exception e){
+			logger.error("error encoding url: " + url);
+			// log the stacktrace
+			e.printStackTrace();
+			return url;
+		}
+	}
+
+}
+

--- a/src/main/java/com/labsynch/labseer/dto/FileSaveSendDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/FileSaveSendDTO.java
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -82,7 +83,11 @@ public class FileSaveSendDTO{
 						logger.error("unable to create the directory " + savePath);
 					}
 					logger.debug(" Saving file: " + file.getOriginalFilename() + " to  " + saveFileName); 
-					String urlString = "getFile?fileUrl=" + saveFileName;
+
+					// URL encode the file name
+					String charset = "UTF-8";
+					String urlString = "getFile?fileUrl=" + URLEncoder.encode(saveFileName, charset);
+
 					logger.debug("url string " + urlString);
 
 					FileOutputStream f = new FileOutputStream(saveFileName); 


### PR DESCRIPTION
Fixes #288

Testing:

A) Before upgrade, I uploaded this file and verified that the link in ACAS was broken:
[test & ' this : * _ ( % $ # + ).pdf.pdf](https://github.com/mcneilco/acas-roo-server/files/8208938/test.this._.%2B.pdf.pdf)

The file url was stored as:
`getFile?fileUrl=/home/runner/build/privateUploads/cmpdreg/noteBookFiles/noteBook/CMPD-0000001-001/test & ' this : * _ ( % $ # + ).pdf.pdf`

B) After the migration was run this became the following and I verified the link in ACAS now works:
`getFile?fileUrl=%2Fhome%2Frunner%2Fbuild%2FprivateUploads%2Fcmpdreg%2FnoteBookFiles%2FnoteBook%2FCMPD-0000001-001%2Ftest+%26+%27+this+%3A+*+_+%28+%25+%24+%23+%2B+%29.pdf.pdf
`

C) I uploaded the same file again to ACAS and verified the link worked with the new code.
D) I verified a regular file worked as expected.

