### PR TITLE
CmpdReg bulkloader should require amount amount units and barcode when any one of them is provided

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -918,6 +918,16 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 		if (lot.getNotebookPage() == null && requiredDbProperties.contains("Lot Notebook Page")) missingProperties.add("Lot Notebook Page");
 		if (lot.getChemist() == null && requiredDbProperties.contains("Lot Chemist")) missingProperties.add("Lot Chemist");
 		if (lot.getPurityMeasuredBy() == null && requiredDbProperties.contains("Lot Purity Measured By"))  missingProperties.add("Lot Purity Measured By");
+
+		// If lot inventory is one then we do extra validation to make sure
+		// that lot barcode, amount and amount untis are filled in if the user
+		// is trying to add lot inventory
+		if (propertiesUtilService.getCompoundInventory()) {
+			if ((lot.getAmount() != null || lot.getAmountUnits() != null) && lot.getBarcode() == null) missingProperties.add("Lot Barcode");
+			if ((lot.getBarcode() != null || lot.getAmountUnits() != null) && lot.getAmount() == null) missingProperties.add("Lot Amount");
+			if ((lot.getBarcode() != null || lot.getAmount() != null) && lot.getAmountUnits() == null) missingProperties.add("Lot Amount Units");
+		}
+		
 		if (!missingProperties.isEmpty()){
 			String errorMessage = "";
 			for (String missingProperty : missingProperties){


### PR DESCRIPTION

Fixes #291

## Description
When compound inventory is turned on, if amount, or amount units or barcode are provided and any of the other 2 are not, then throw an error that the other 2 are required.

## Related Issue
Fixes #291


## How Has This Been Tested?
Bulk loaded a file, mapped barcode and amount but not amount units.  Got an error that said "Lot Amount Units required".

I tested with the two other combinations as well as not providing any inventory information.