### PR TITLE
Docker build roo throws unable to convert uid/gid chown string to host mapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD 	lib/jchem-16.4.25.0.jar /lib/jchem-16.4.25.0.jar
 RUN     mvn install:install-file -Dfile=/lib/jchem-16.4.25.0.jar -DartifactId=jchem -DgroupId=com.chemaxon -Dversion=16.4.25.0 -Dpackaging=jar -DgeneratePom=true -DcreateChecksum=true
 
 FROM 	${CHEMISTRY_PACKAGE} as compile
-ADD 	--chown=runner:runner pom.xml /src/pom.xml
+ADD 	pom.xml /src/pom.xml
 WORKDIR /src
 RUN 	mvn dependency:resolve -P ${CHEMISTRY_PACKAGE}
 ADD 	. /src
@@ -41,7 +41,7 @@ RUN chgrp runner /usr/local/openjdk-8/lib/security/cacerts && \
 
 # Get acas-roo-server compiled code
 COPY 	--chown=runner:runner --from=compile /src/target/acas*.war /usr/local/tomcat/webapps/acas.war
-COPY 	--chown=runner:runner --from=compile /src/target/acas* /usr/local/tomcat/webapps/acas
+COPY 	--chown=runner:runner --from=compile /src/target/acas* /usr/local/tomcat/webapps/acas/
 
 # Wait for it startup script
 COPY 	--chown=runner:runner wait-for-it.sh ./wait-for-it.sh

--- a/Dockerfile-bbchem
+++ b/Dockerfile-bbchem
@@ -9,7 +9,7 @@ ENV     CHEMISTRY_PACKAGE=${CHEMISTRY_PACKAGE}
 FROM 	dependencies as bbchem
 
 FROM 	${CHEMISTRY_PACKAGE} as compile
-ADD 	--chown=runner:runner pom.xml /src/pom.xml
+ADD 	pom.xml /src/pom.xml
 WORKDIR /src
 RUN 	mvn dependency:resolve -P ${CHEMISTRY_PACKAGE}
 ADD 	. /src
@@ -40,7 +40,7 @@ RUN chgrp runner /usr/local/openjdk-8/lib/security/cacerts && \
 
 # Get acas-roo-server compiled code
 COPY 	--chown=runner:runner --from=compile /src/target/acas*.war /usr/local/tomcat/webapps/acas.war
-COPY 	--chown=runner:runner --from=compile /src/target/acas* /usr/local/tomcat/webapps/acas
+COPY 	--chown=runner:runner --from=compile /src/target/acas* /usr/local/tomcat/webapps/acas/
 
 # Wait for it startup script
 COPY 	--chown=runner:runner wait-for-it.sh ./wait-for-it.sh

--- a/Dockerfile-indigo
+++ b/Dockerfile-indigo
@@ -9,7 +9,7 @@ ENV     CHEMISTRY_PACKAGE=${CHEMISTRY_PACKAGE}
 FROM 	dependencies as indigo
 
 FROM 	${CHEMISTRY_PACKAGE} as compile
-ADD 	--chown=runner:runner pom.xml /src/pom.xml
+ADD 	pom.xml /src/pom.xml
 WORKDIR /src
 RUN 	mvn dependency:resolve -P ${CHEMISTRY_PACKAGE}
 ADD 	. /src
@@ -40,7 +40,7 @@ RUN chgrp runner /usr/local/openjdk-8/lib/security/cacerts && \
 
 # Get acas-roo-server compiled code
 COPY 	--chown=runner:runner --from=compile /src/target/acas*.war /usr/local/tomcat/webapps/acas.war
-COPY 	--chown=runner:runner --from=compile /src/target/acas* /usr/local/tomcat/webapps/acas
+COPY 	--chown=runner:runner --from=compile /src/target/acas* /usr/local/tomcat/webapps/acas/
 
 # Wait for it startup script
 COPY 	--chown=runner:runner wait-for-it.sh ./wait-for-it.sh

--- a/Dockerfile-jchem
+++ b/Dockerfile-jchem
@@ -10,7 +10,7 @@ ADD 	lib/jchem-16.4.25.0.jar /lib/jchem-16.4.25.0.jar
 RUN     mvn install:install-file -Dfile=/lib/jchem-16.4.25.0.jar -DartifactId=jchem -DgroupId=com.chemaxon -Dversion=16.4.25.0 -Dpackaging=jar -DgeneratePom=true -DcreateChecksum=true
 
 FROM 	${CHEMISTRY_PACKAGE} as compile
-ADD 	--chown=runner:runner pom.xml /src/pom.xml
+ADD 	pom.xml /src/pom.xml
 WORKDIR /src
 RUN 	mvn dependency:resolve -P ${CHEMISTRY_PACKAGE}
 ADD 	. /src
@@ -41,7 +41,7 @@ RUN chgrp runner /usr/local/openjdk-8/lib/security/cacerts && \
 
 # Get acas-roo-server compiled code
 COPY 	--chown=runner:runner --from=compile /src/target/acas*.war /usr/local/tomcat/webapps/acas.war
-COPY 	--chown=runner:runner --from=compile /src/target/acas* /usr/local/tomcat/webapps/acas
+COPY 	--chown=runner:runner --from=compile /src/target/acas* /usr/local/tomcat/webapps/acas/
 
 # Wait for it startup script
 COPY 	--chown=runner:runner wait-for-it.sh ./wait-for-it.sh

--- a/Dockerfile-multistage
+++ b/Dockerfile-multistage
@@ -14,7 +14,7 @@ FROM 	dependencies as bbchem
 FROM 	dependencies as indigo
 
 FROM 	${CHEMISTRY_PACKAGE} as compile
-ADD 	--chown=runner:runner pom.xml /src/pom.xml
+ADD 	pom.xml /src/pom.xml
 WORKDIR /src
 RUN 	mvn dependency:resolve -P ${CHEMISTRY_PACKAGE}
 ADD 	. /src
@@ -45,7 +45,7 @@ RUN chgrp runner /usr/local/openjdk-8/lib/security/cacerts && \
 
 # Get acas-roo-server compiled code
 COPY 	--chown=runner:runner --from=compile /src/target/acas*.war /usr/local/tomcat/webapps/acas.war
-COPY 	--chown=runner:runner --from=compile /src/target/acas* /usr/local/tomcat/webapps/acas
+COPY 	--chown=runner:runner --from=compile /src/target/acas* /usr/local/tomcat/webapps/acas/
 
 # Wait for it startup script
 COPY 	--chown=runner:runner wait-for-it.sh ./wait-for-it.sh


### PR DESCRIPTION

## Description
Removed chown statement as it was unnecessary and caused issues when using docker build without docker build kit
Added "/" to the end of copy step of acas to fix and issue when building without docker build kit

## Related Issue
Fixes #293

## How Has This Been Tested?
I tested a non docker build kit build of the Jchem version and verified the server came up and ran
I tested a docker build kit build of the bbchem version and verified the server came up and ran