### PR TITLE
Add back $listen.address attribute to acas-roo-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ FROM tomcat:9.0.58-jre8-openjdk-slim-buster
 RUN apt-get update && \
     apt-get install -y openssl libfontconfig libfreetype6 curl
 
+RUN  sed -i 's/<Connector port="8080"/<Connector address="${listen.address}" port="8080"/' conf/server.xml
+
 # Add nodejs for prepare config files
 ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_VERSION 14.x


### PR DESCRIPTION
## Description
Added back sed command to make listen address configurable by environment variable

## Related Issue
Fixes #295

## How Has This Been Tested?

Ran netstat:
```

docker-compose exec --user root roo /bin/bash
apt-get install -y net-tools
netstat -tulpn | grep LISTEN
```

0.0.0.0 settings:
```
tcp        0      0 0.0.0.0:8000            0.0.0.0:*               LISTEN      -                   
tcp        0      0 127.0.0.1:8005          0.0.0.0:*               LISTEN      -                   
tcp        0      0 127.0.0.11:40743        0.0.0.0:*               LISTEN      -                   
tcp        0      0 0.0.0.0:8080            0.0.0.0:*               LISTEN      -     
```

127.0.0.1 settings:
``
tcp        0      0 127.0.0.1:8080          0.0.0.0:*               LISTEN      -                   
tcp        0      0 127.0.0.1:8000          0.0.0.0:*               LISTEN      -                   
tcp        0      0 127.0.0.11:44001        0.0.0.0:*               LISTEN      -                   
tcp        0      0 127.0.0.1:8005          0.0.0.0:*               LISTEN      -     
```

From rservices I tried to curl

0.0.0.0 settings:
````
runner@31c79ad914b0 build]$ curl http://roo:8080/acas/api/v1
<!doctype html><html lang="en"><head><title>HTTP Status 405 – Method Not Allowed</title><style type="text/css">body {font-family:Tahoma,Arial,sans-serif;} h1, h2, h3, b {color:white;background-color:#525D76;} h1 {font-size:22px;} h2 {font-size:16px;} h3 {font-size:14px;} p {font-size:12px;} a {color:black;} .line {height:1px;background-color:#525D76;border:none;}</style></head><body><h1>HTTP Status 405 – Method Not Allowed</h1><hr class="line" /><p><b>Type</b> Status Report</p><p><b>Message</b> Request method &#39;GET&#39; not supported</p><p><b>Description</b> The method received in the request-line is known by the origin server but not supported by the target resource.</p><hr class="line" /><h3>Apache Tomcat/9.0.58</h3></body></html>[runner@31c79ad914b0 build]$ 
```

127.0.0.1 settings:
```
[runner@31c79ad914b0 build]$ curl http://roo:8080/acas/api/v1
curl: (7) Failed to connect to roo port 8080: Connection refused
```