### PR TITLE
HQL fixes

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/ContainerServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ContainerServiceImpl.java
@@ -2130,7 +2130,7 @@ public class ContainerServiceImpl implements ContainerService {
 		EntityManager em = Container.entityManager();
 		String queryString = "SELECT new com.labsynch.labseer.dto.ContainerErrorMessageDTO( " + "container.codeName, "
 				+ "container )" + " FROM Container container ";
-		queryString += "where ( container.ignored <> true ) and ( ";
+		queryString += "where ( container.ignored <> true ) and ";
 		Collection<Query> queries = SimpleUtil.splitHqlInClause(em, queryString, "container.codeName", codeNames);
 		Collection<ContainerErrorMessageDTO> results = new HashSet<ContainerErrorMessageDTO>();
 		for (Query q : queries) {
@@ -2168,7 +2168,7 @@ public class ContainerServiceImpl implements ContainerService {
 		queryString += SimpleUtil.makeInnerJoinHql("container.firstContainers", "itx", "defines",
 				"definition container_container");
 		queryString += SimpleUtil.makeInnerJoinHql("itx.firstContainer", "definition", "definition container");
-		queryString += "where ( container.ignored <> true ) and ( ";
+		queryString += "where ( container.ignored <> true ) and ";
 		Collection<Query> queries = SimpleUtil.splitHqlInClause(em, queryString, "container.codeName", codeNames);
 		Collection<ContainerErrorMessageDTO> results = new HashSet<ContainerErrorMessageDTO>();
 		for (Query q : queries) {
@@ -2205,7 +2205,7 @@ public class ContainerServiceImpl implements ContainerService {
 		String queryString = "SELECT new map(container.codeName as containerCodeName, itx.id as itxId)"
 				+ " FROM Container container ";
 		queryString += SimpleUtil.makeInnerJoinHql("container.secondContainers", "itx", itxType, itxKind);
-		queryString += "where ( container.ignored <> true ) and ( ";
+		queryString += "where ( container.ignored <> true ) and ";
 		Collection<Query> queries = SimpleUtil.splitHqlInClause(em, queryString, "container.codeName", codeNames);
 		Collection<Map<String, Long>> results = new HashSet<Map<String, Long>>();
 		for (Query q : queries) {
@@ -2230,7 +2230,7 @@ public class ContainerServiceImpl implements ContainerService {
 				+ "well.codeName as wellCodeName )" + " FROM Container container ";
 		queryString += SimpleUtil.makeInnerJoinHql("container.secondContainers", "itx", "has member");
 		queryString += SimpleUtil.makeInnerJoinHql("itx.secondContainer", "well", "well");
-		queryString += "where ( container.ignored <> true ) and ( well.ignored <> true) and ( ";
+		queryString += "where ( container.ignored <> true ) and ( well.ignored <> true) and ";
 		Collection<Query> queries = SimpleUtil.splitHqlInClause(em, queryString, "container.codeName", codeNames);
 		Collection<Map<String, String>> results = new HashSet<Map<String, String>>();
 		for (Query q : queries) {

--- a/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
@@ -1684,7 +1684,7 @@ public class ExperimentServiceImpl implements ExperimentService {
 				+ "experiment.codeName, "
 				+ "experiment )"
 				+ " FROM Experiment experiment ";
-		queryString += "where ( experiment.ignored <> true ) and ( ";
+		queryString += "where ( experiment.ignored <> true ) and ";
 		Collection<Query> queries = SimpleUtil.splitHqlInClause(em, queryString, "experiment.codeName", codeNames);
 		Collection<ExperimentErrorMessageDTO> results = new HashSet<ExperimentErrorMessageDTO>();
 		for (Query q : queries) {

--- a/src/main/java/com/labsynch/labseer/service/ProtocolServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ProtocolServiceImpl.java
@@ -632,7 +632,7 @@ public class ProtocolServiceImpl implements ProtocolService {
 				+ "protocol.codeName, "
 				+ "protocol )"
 				+ " FROM Protocol protocol ";
-		queryString += "where ( protocol.ignored <> true ) and ( ";
+		queryString += "where ( protocol.ignored <> true ) and ";
 		Collection<Query> queries = SimpleUtil.splitHqlInClause(em, queryString, "protocol.codeName", codeNames);
 		Collection<ProtocolErrorMessageDTO> results = new HashSet<ProtocolErrorMessageDTO>();
 		for (Query q : queries) {

--- a/src/main/java/com/labsynch/labseer/service/SubjectServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SubjectServiceImpl.java
@@ -674,7 +674,7 @@ public class SubjectServiceImpl implements SubjectService {
 				+ "subject.codeName, "
 				+ "subject )"
 				+ " FROM Subject subject ";
-		queryString += "where ( subject.ignored <> true ) and ( ";
+		queryString += "where ( subject.ignored <> true ) and ";
 		Query q = SimpleUtil.addHqlInClause(em, queryString, "subject.codeName", codeNames);
 
 		// if (logger.isDebugEnabled())

--- a/src/test/java/com/labsynch/labseer/service/ContainerLSServiceTests.java
+++ b/src/test/java/com/labsynch/labseer/service/ContainerLSServiceTests.java
@@ -1401,7 +1401,7 @@ public class ContainerLSServiceTests {
 		String queryString = "SELECT new Map(container.codeName, itx.id )"
 				+ " FROM Container container ";
 		queryString += SimpleUtil.makeInnerJoinHql("container.secondContainers", "itx", itxType, itxKind);
-		queryString += "where ( container.ignored <> true ) and ( ";
+		queryString += "where ( container.ignored <> true ) and ";
 		Collection<Query> queries = SimpleUtil.splitHqlInClause(em, queryString, "container.codeName", codeNames);
 		Collection<Map<String, Long>> results = new HashSet<Map<String, Long>>();
 		for (Query q : queries) {


### PR DESCRIPTION
## Description
Found all references to `splitHqlInClause` and `addHqlInClause` and viewed their usages
Found mixed cases query strings being passed to the function with an opening `(` and others not using an opening `(`
Found routes that tested these and found that all those with an opening `( ` were broken.
Removed opening `( ` in those usages

## Related Issue
Fixes #317 

## How Has This Been Tested?
Ran acasclient tests which caught this behavior when calling `getBatchProjects` via `test_008_cmpd_search`
Ran curl's again the routes which were using these function with an opening `( ` and verified they were fixed.  

http://localhost:8080/acas/api/v1/experiments/codename/jsonArray
http://localhost:8080/acas/api/v1/protocols/codename/jsonArray
http://localhost:8080/acas/api/v1/containers/getContainersByCodeNames
http://localhost:8080/acas/api/v1/containers/getDefinitionContainersByContainerCodeNames
http://localhost:8080/acas/api/v1/containers/getWellCodesByContainerCodes
http://localhost:8080/acas/api/v1/containers/moveToLocation
http://localhost:8080/acas/api/v1/containers/getItxIdsByContainerCodeNamesAndItxTypeAndKind
