### PR TITLE
Make CReg enforce globally unique parent aliases

### DIFF
--- a/src/main/java/com/labsynch/labseer/exceptions/NonUniqueAliasException.java
+++ b/src/main/java/com/labsynch/labseer/exceptions/NonUniqueAliasException.java
@@ -1,0 +1,24 @@
+package com.labsynch.labseer.exceptions;
+
+public class NonUniqueAliasException extends Exception {
+
+    public NonUniqueAliasException() {
+        // TODO Auto-generated constructor stub
+    }
+
+    public NonUniqueAliasException(String message) {
+        super(message);
+        // TODO Auto-generated constructor stub
+    }
+
+    public NonUniqueAliasException(Throwable cause) {
+        super(cause);
+        // TODO Auto-generated constructor stub
+    }
+
+    public NonUniqueAliasException(String message, Throwable cause) {
+        super(message, cause);
+        // TODO Auto-generated constructor stub
+    }
+
+}

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -476,7 +476,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 									allAliasMaps.put(alias.getAliasName(), numRecordsRead);
 								} else {
 									throw new NonUniqueAliasException(
-											"Within File, Parent alias " + alias.getAliasName()
+											"Within File, Parent Alias " + alias.getAliasName()
 													+ " is not unique");
 								}
 							}

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -68,6 +68,7 @@ import com.labsynch.labseer.exceptions.CmpdRegMolFormatException;
 import com.labsynch.labseer.exceptions.DupeLotException;
 import com.labsynch.labseer.exceptions.DupeParentException;
 import com.labsynch.labseer.exceptions.MissingPropertyException;
+import com.labsynch.labseer.exceptions.NonUniqueAliasException;
 import com.labsynch.labseer.exceptions.SaltedCompoundException;
 import com.labsynch.labseer.service.ChemStructureService.StructureType;
 import com.labsynch.labseer.utils.PropertiesUtilService;
@@ -108,6 +109,9 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 
 	@Autowired
 	public CmpdRegSDFWriterFactory sdfWriterFactory;
+
+	@Autowired
+	private ParentAliasService parentAliasService;
 
 	@Override
 	public BulkLoadPropertiesDTO readSDFPropertiesFromFile(BulkLoadSDFPropertyRequestDTO requestDTO) {
@@ -368,11 +372,13 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 
 			CmpdRegSDFWriter errorMolExporter = sdfWriterFactory.getCmpdRegSDFWriter(errorSDFName);
 			CmpdRegSDFWriter registeredMolExporter = sdfWriterFactory.getCmpdRegSDFWriter(registeredSDFName);
+			HashMap<String, Integer> allAliasMaps = new HashMap<String, Integer>();
 
 			CmpdRegMolecule mol = null;
 			int numRecordsRead = 0;
 			int numNewParentsLoaded = 0;
 			int numNewLotsOldParentsLoaded = 0;
+
 			while ((mol = molReader.readNextMol()) != null) {
 				numRecordsRead++;
 				boolean isNewParent = true;
@@ -463,6 +469,18 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 				if (validate) {
 					try {
 						parent = validateParentAgainstDryRunCompound(parent, numRecordsRead, results);
+						// Check list of aliases within file being bulkloaded
+						if (!propertiesUtilService.getAllowDuplicateParentAliases()) {
+							for (ParentAlias alias : parent.getParentAliases()) {
+								if (allAliasMaps.get(alias.getAliasName()) == null) {
+									allAliasMaps.put(alias.getAliasName(), numRecordsRead);
+								} else {
+									throw new NonUniqueAliasException(
+											"Within File, Parent alias " + alias.getAliasName()
+													+ " is not unique");
+								}
+							}
+						}
 						saveDryRunCompound(mol, parent, numRecordsRead, dryRunCompound);
 
 					} catch (TransactionSystemException rollbackException) {
@@ -896,6 +914,8 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 						"Duplicate corp names for different parent structure and stereo category! sdf corp name: "
 								+ parent.getCorpName() + " db corp name: " + foundParent.getCorpName());
 		}
+		// Validate lot aliases locally and in the database
+		parentAliasService.validateParentAliases(parent.getParentAliases());
 
 		return parent;
 	}
@@ -1031,6 +1051,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 				}
 			}
 		}
+
 		return parent;
 	}
 

--- a/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
@@ -17,6 +17,7 @@ import java.util.regex.Pattern;
 
 import javax.persistence.NoResultException;
 import javax.persistence.NonUniqueResultException;
+import javax.persistence.TypedQuery;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +49,7 @@ import com.labsynch.labseer.exceptions.DupeParentException;
 import com.labsynch.labseer.exceptions.DupeSaltFormCorpNameException;
 import com.labsynch.labseer.exceptions.DupeSaltFormStructureException;
 import com.labsynch.labseer.exceptions.JsonParseException;
+import com.labsynch.labseer.exceptions.NonUniqueAliasException;
 import com.labsynch.labseer.exceptions.SaltFormMolFormatException;
 import com.labsynch.labseer.exceptions.SaltedCompoundException;
 import com.labsynch.labseer.exceptions.StandardizerException;
@@ -152,6 +154,12 @@ public class MetalotServiceImpl implements MetalotService {
 			standardizerError.setMessage("Standardizer Error: " + e.getMessage());
 			logger.error(standardizerError.getMessage());
 			errors.add(standardizerError);
+		} catch (NonUniqueAliasException e) {
+			ErrorMessage standardizerError = new ErrorMessage();
+			standardizerError.setLevel("error");
+			standardizerError.setMessage("Parent Aliases must be globally unique.");
+			logger.error(standardizerError.getMessage());
+			errors.add(standardizerError);
 		} catch (Exception e) {
 			ErrorMessage genericError = new ErrorMessage();
 			genericError.setLevel("error");
@@ -169,7 +177,8 @@ public class MetalotServiceImpl implements MetalotService {
 	public MetalotReturn processAndSave(Metalot metaLot, MetalotReturn mr, ArrayList<ErrorMessage> errors)
 			throws UniqueNotebookException, DupeParentException, JsonParseException,
 			DupeSaltFormCorpNameException, DupeSaltFormStructureException, SaltFormMolFormatException,
-			SaltedCompoundException, IOException, CmpdRegMolFormatException, StandardizerException {
+			SaltedCompoundException, IOException, CmpdRegMolFormatException, StandardizerException,
+			NonUniqueAliasException {
 
 		logger.info("attempting to save the metaLot. ");
 

--- a/src/main/java/com/labsynch/labseer/service/ParentAliasService.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentAliasService.java
@@ -4,13 +4,14 @@ import java.util.Set;
 
 import com.labsynch.labseer.domain.Parent;
 import com.labsynch.labseer.domain.ParentAlias;
+import com.labsynch.labseer.exceptions.NonUniqueAliasException;
 
 public interface ParentAliasService {
 
-	public Parent updateParentAliases(Parent parent);
+	public Parent updateParentAliases(Parent parent) throws NonUniqueAliasException;
 
 	public Parent updateParentAliases(Parent parent,
-			Set<ParentAlias> parentAliases);
+			Set<ParentAlias> parentAliases) throws NonUniqueAliasException;
 
 	Parent updateParentLiveDesignAlias(Parent parent, String aliasList);
 
@@ -20,4 +21,5 @@ public interface ParentAliasService {
 
 	Parent updateParentAliasByTypeAndKind(Parent parent, String lsType, String lsKind, String aliasList);
 
+	void validateParentAliases(Set<ParentAlias> aliasesToBeSaved) throws NonUniqueAliasException;
 }

--- a/src/main/java/com/labsynch/labseer/service/ParentAliasServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentAliasServiceImpl.java
@@ -28,11 +28,12 @@ public class ParentAliasServiceImpl implements ParentAliasService {
 
 	@Override
 	@Transactional
-	public Parent updateParentAliases(Parent parent) {
+	public Parent updateParentAliases(Parent parent) throws NonUniqueAliasException {
 		Set<ParentAlias> aliasesToBeSaved = parent.getParentAliases();
 		logger.debug(ParentAlias.toJsonArray(aliasesToBeSaved));
 		Set<ParentAlias> savedAliases = new HashSet<ParentAlias>();
 		if (aliasesToBeSaved != null && !aliasesToBeSaved.isEmpty()) {
+			validateParentAliases(aliasesToBeSaved);
 			for (ParentAlias aliasToBeSaved : aliasesToBeSaved) {
 				logger.debug(aliasToBeSaved.toJson());
 				aliasToBeSaved.setParent(parent);

--- a/src/main/java/com/labsynch/labseer/service/ParentService.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentService.java
@@ -7,6 +7,7 @@ import com.labsynch.labseer.dto.CodeTableDTO;
 import com.labsynch.labseer.dto.ParentEditDTO;
 import com.labsynch.labseer.dto.ParentValidationDTO;
 import com.labsynch.labseer.exceptions.CmpdRegMolFormatException;
+import com.labsynch.labseer.exceptions.NonUniqueAliasException;
 import com.labsynch.labseer.exceptions.StandardizerException;
 
 public interface ParentService {
@@ -14,7 +15,7 @@ public interface ParentService {
 	ParentValidationDTO validateUniqueParent(Parent queryParent)
 			throws CmpdRegMolFormatException, StandardizerException;
 
-	Collection<CodeTableDTO> updateParent(Parent parent);
+	Collection<CodeTableDTO> updateParent(Parent parent) throws NonUniqueAliasException;
 
 	Parent updateParentMeta(ParentEditDTO parentDTO);
 

--- a/src/main/java/com/labsynch/labseer/service/ParentServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentServiceImpl.java
@@ -22,6 +22,7 @@ import com.labsynch.labseer.dto.ParentDTO;
 import com.labsynch.labseer.dto.ParentEditDTO;
 import com.labsynch.labseer.dto.ParentValidationDTO;
 import com.labsynch.labseer.exceptions.CmpdRegMolFormatException;
+import com.labsynch.labseer.exceptions.NonUniqueAliasException;
 import com.labsynch.labseer.service.ChemStructureService.StructureType;
 import com.labsynch.labseer.utils.PropertiesUtilService;
 
@@ -156,7 +157,7 @@ public class ParentServiceImpl implements ParentService {
 	}
 
 	@Override
-	public Collection<CodeTableDTO> updateParent(Parent parent) {
+	public Collection<CodeTableDTO> updateParent(Parent parent) throws NonUniqueAliasException {
 		Set<ParentAlias> parentAliases = parent.getParentAliases();
 		parent = parentStructureService.update(parent);
 		// save parent aliases

--- a/src/main/java/com/labsynch/labseer/utils/PropertiesUtilService.java
+++ b/src/main/java/com/labsynch/labseer/utils/PropertiesUtilService.java
@@ -130,4 +130,6 @@ public interface PropertiesUtilService {
 
 	Integer getExternalStructureProcessingBatchSize();
 
+	Boolean getAllowDuplicateParentAliases();
+
 }

--- a/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
@@ -895,7 +895,7 @@ public class PropertiesUtilServiceImpl implements PropertiesUtilService {
 
 	Boolean allowDuplicateParentAliases;
 
-	@Value("${server.service.external.preferred.batchid.allowParentAliasLotNames}")
+	@Value("${client.cmpdreg.metaLot.allowDuplicateParentAliases}")
 	public void setAllowDuplicateParentAliases(String allowDuplicateParentAliases) {
 		if (allowDuplicateParentAliases.startsWith("${")) {
 			this.allowDuplicateParentAliases = true;

--- a/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
@@ -893,4 +893,20 @@ public class PropertiesUtilServiceImpl implements PropertiesUtilService {
 		return this.externalStructureProcessingBatchSize;
 	}
 
+	Boolean allowDuplicateParentAliases;
+
+	@Value("${server.service.external.preferred.batchid.allowParentAliasLotNames}")
+	public void setAllowDuplicateParentAliases(String allowDuplicateParentAliases) {
+		if (allowDuplicateParentAliases.startsWith("${")) {
+			this.allowDuplicateParentAliases = true;
+		} else {
+			this.allowDuplicateParentAliases = Boolean.parseBoolean(allowDuplicateParentAliases);
+		}
+	}
+
+	@Override
+	public Boolean getAllowDuplicateParentAliases() {
+		return this.allowDuplicateParentAliases;
+	}
+
 }


### PR DESCRIPTION
## Description
Add config `server.service.external.preferred.batchid.allowParentAliasLotNames`
Checks uniqueness of parent aliases globally on the system

## Related Issue
Fixes #324

## How Has This Been Tested?
Bulkloader with this setting on and trying to load duplicates:
<img width="1728" alt="Screen Shot 2022-05-06 at 4 46 14 PM" src="https://user-images.githubusercontent.com/868119/167230313-4b30c07b-6ea2-45bb-88c4-f14c85227384.png">
Turned off validation and verified mode and verified its still caught:
<img width="725" alt="Screen Shot 2022-05-06 at 4 23 14 PM" src="https://user-images.githubusercontent.com/868119/167230351-27793efa-5359-443b-8bb3-ab697396b423.png">
Verified that "Within the file" duplicate checking works:
<img width="931" alt="Screen Shot 2022-05-06 at 5 05 45 PM" src="https://user-images.githubusercontent.com/868119/167230374-9712210a-c8be-4098-bb2c-5df2918349e3.png">

Single reg:
<img width="462" alt="Screen Shot 2022-05-06 at 4 11 19 PM" src="https://user-images.githubusercontent.com/868119/167230381-195db2ec-dae2-4b76-a073-8fd3b0f95038.png">

I also verified this properly ignores soft deleted ( "ignored" and "deleted" aliases)