### PR TITLE
ACAS-98: Make SDF bulk loader case insensitive

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiPhysicalStateController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiPhysicalStateController.java
@@ -1,8 +1,15 @@
 package com.labsynch.labseer.api;
 
+import java.util.ArrayList;
+import java.util.List;
+
+
 import com.labsynch.labseer.domain.PhysicalState;
+import com.labsynch.labseer.service.ErrorMessage;
 import com.labsynch.labseer.utils.PropertiesUtilService;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -20,13 +27,12 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @Controller
 public class ApiPhysicalStateController {
 
+    Logger logger = LoggerFactory.getLogger(ApiPhysicalStateController.class);
+
     @Autowired
     private PropertiesUtilService propertiesUtilService;
 
-    @RequestMapping(value = "/{id}", method = RequestMethod.GET, headers = "Accept=application/json")
-    @ResponseBody
-    public ResponseEntity<String> showJson(@PathVariable("id") Long id) {
-        PhysicalState physicalstate = PhysicalState.findPhysicalState(id);
+    private static HttpHeaders getTextHeaders() {
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-Type", "application/text; charset=utf-8");
         headers.add("Access-Control-Allow-Origin", "*");
@@ -34,6 +40,25 @@ public class ApiPhysicalStateController {
         headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
         headers.add("Pragma", "no-cache"); // HTTP 1.0
         headers.setExpires(0); // Expire the cache
+        return headers;
+    }
+
+    private static HttpHeaders getJsonHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+		headers.add("Content-Type", "application/json; charset=utf-8");
+		headers.add("Access-Control-Allow-Headers", "Content-Type");
+		headers.add("Access-Control-Allow-Origin", "*");
+		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
+		headers.add("Pragma", "no-cache"); // HTTP 1.0
+		headers.setExpires(0); // Expire the cache
+        return headers;
+    }
+
+    @RequestMapping(value = "/{id}", method = RequestMethod.GET, headers = "Accept=application/json")
+    @ResponseBody
+    public ResponseEntity<String> showJson(@PathVariable("id") Long id) {
+        PhysicalState physicalstate = PhysicalState.findPhysicalState(id);
+        HttpHeaders headers = getTextHeaders();
         if (physicalstate == null) {
             return new ResponseEntity<String>(headers, HttpStatus.NOT_FOUND);
         }
@@ -43,13 +68,7 @@ public class ApiPhysicalStateController {
     @RequestMapping(headers = "Accept=application/json")
     @ResponseBody
     public ResponseEntity<String> listJson() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", "application/text; charset=utf-8");
-        headers.add("Access-Control-Allow-Origin", "*");
-        headers.add("Access-Control-Allow-Headers", "Content-Type");
-        headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-        headers.add("Pragma", "no-cache"); // HTTP 1.0
-        headers.setExpires(0); // Expire the cache
+        HttpHeaders headers = getTextHeaders();
 
         if (propertiesUtilService.getOrderSelectLists()) {
             return new ResponseEntity<String>(
@@ -65,10 +84,6 @@ public class ApiPhysicalStateController {
     public ResponseEntity<String> createFromJson(@RequestBody String json) {
         PhysicalState ps = PhysicalState.fromJsonToPhysicalState(json);
         ps.persist();
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", "application/text");
-        headers.add("Access-Control-Allow-Origin", "*");
-        headers.add("Access-Control-Allow-Headers", "Content-Type");
         return showJson(ps.getId());
     }
 
@@ -77,19 +92,13 @@ public class ApiPhysicalStateController {
         for (PhysicalState physicalState : PhysicalState.fromJsonArrayToPhysicalStates(json)) {
             physicalState.persist();
         }
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", "application/text");
-        headers.add("Access-Control-Allow-Origin", "*");
-        headers.add("Access-Control-Allow-Headers", "Content-Type");
+        HttpHeaders headers = getTextHeaders();
         return new ResponseEntity<String>(headers, HttpStatus.CREATED);
     }
 
     @RequestMapping(method = RequestMethod.PUT, headers = "Accept=application/json")
     public ResponseEntity<String> updateFromJson(@RequestBody String json) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", "application/text");
-        headers.add("Access-Control-Allow-Origin", "*");
-        headers.add("Access-Control-Allow-Headers", "Content-Type");
+        HttpHeaders headers = getTextHeaders();
         if (PhysicalState.fromJsonToPhysicalState(json).merge() == null) {
             return new ResponseEntity<String>(headers, HttpStatus.NOT_FOUND);
         }
@@ -98,10 +107,7 @@ public class ApiPhysicalStateController {
 
     @RequestMapping(value = "/jsonArray", method = RequestMethod.PUT, headers = "Accept=application/json")
     public ResponseEntity<String> updateFromJsonArray(@RequestBody String json) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", "application/text");
-        headers.add("Access-Control-Allow-Origin", "*");
-        headers.add("Access-Control-Allow-Headers", "Content-Type");
+        HttpHeaders headers = getTextHeaders();
         for (PhysicalState physicalState : PhysicalState.fromJsonArrayToPhysicalStates(json)) {
             if (physicalState.merge() == null) {
                 return new ResponseEntity<String>(headers, HttpStatus.NOT_FOUND);
@@ -113,10 +119,7 @@ public class ApiPhysicalStateController {
     @RequestMapping(value = "/{id}", method = RequestMethod.DELETE, headers = "Accept=application/json")
     public ResponseEntity<String> deleteFromJson(@PathVariable("id") Long id) {
         PhysicalState physicalstate = PhysicalState.findPhysicalState(id);
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", "application/text");
-        headers.add("Access-Control-Allow-Origin", "*");
-        headers.add("Access-Control-Allow-Headers", "Content-Type");
+        HttpHeaders headers = getTextHeaders();
         if (physicalstate == null) {
             return new ResponseEntity<String>(headers, HttpStatus.NOT_FOUND);
         }
@@ -126,14 +129,50 @@ public class ApiPhysicalStateController {
 
     @RequestMapping(method = RequestMethod.OPTIONS)
     public ResponseEntity<String> getPhysicalStateOptions() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", "application/text");
-        headers.add("Access-Control-Allow-Headers", "Content-Type");
-        headers.add("Access-Control-Allow-Origin", "*");
-        headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-        headers.add("Pragma", "no-cache"); // HTTP 1.0
-        headers.setExpires(0); // Expire the cache
+        HttpHeaders headers = getTextHeaders();
         return new ResponseEntity<String>(headers, HttpStatus.OK);
     }
+
+    // validate physicalState before saving
+	// is physicalState code still unique?
+	// is physicalState name unique? (optional)
+	@RequestMapping(value = "/validateBeforeSave", method = RequestMethod.POST, headers = "Accept=application/json")
+	@ResponseBody
+	public ResponseEntity<String> validateNewPhysicalState(@RequestBody String json) {
+		logger.info("validateNewPhysicalState -- incoming json: " + json);
+		PhysicalState queryPhysicalState = PhysicalState.fromJsonToPhysicalState(json);
+		if (queryPhysicalState.getCode() == null || queryPhysicalState.getCode().equalsIgnoreCase("")) {
+			logger.info("creating the missing code name");
+			queryPhysicalState.setCode(queryPhysicalState.getName().toLowerCase());
+		}
+		logger.info("validateNewPhysicalState -- query physicalState: " + queryPhysicalState.toJson());
+
+		ArrayList<ErrorMessage> errors = new ArrayList<ErrorMessage>();
+		// boolean errorsFound = false;
+
+		HttpHeaders headers = getJsonHeaders(); // Expire the cache
+
+		Long physicalStateByCodeCount = 0L;
+		List<PhysicalState> queryPhysicalStates = PhysicalState.findPhysicalStatesByCodeEquals(queryPhysicalState.getCode()).getResultList();
+		for (PhysicalState physicalState : queryPhysicalStates) {
+			if (queryPhysicalState.getId() == null || physicalState.getId().longValue() != queryPhysicalState.getId().longValue()) {
+				++physicalStateByCodeCount;
+				logger.debug("current physicalState: " + physicalState.toJson());
+				logger.debug("physicalState id: " + physicalState.getId());
+				logger.debug("query physicalState ID: " + queryPhysicalState.getId());
+				logger.debug("incrementing the physicalState count " + physicalStateByCodeCount);
+			}
+		}
+
+		if (physicalStateByCodeCount > 0) {
+			ErrorMessage error = new ErrorMessage();
+			error.setLevel("ERROR");
+			error.setMessage("Found another physicalState with the same code name");
+			errors.add(error);
+			return new ResponseEntity<String>(ErrorMessage.toJsonArray(errors), headers, HttpStatus.CONFLICT);
+		} else {
+			return new ResponseEntity<String>(queryPhysicalState.toJson(), headers, HttpStatus.OK);
+		}
+	}
 
 }

--- a/src/main/java/com/labsynch/labseer/api/ApiPhysicalStateController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiPhysicalStateController.java
@@ -133,7 +133,7 @@ public class ApiPhysicalStateController {
         return new ResponseEntity<String>(headers, HttpStatus.OK);
     }
 
-    // validate physicalState before saving
+	// validate physicalState before saving
 	// is physicalState code still unique?
 	// is physicalState name unique? (optional)
 	@RequestMapping(value = "/validateBeforeSave", method = RequestMethod.POST, headers = "Accept=application/json")
@@ -148,8 +148,7 @@ public class ApiPhysicalStateController {
 		logger.info("validateNewPhysicalState -- query physicalState: " + queryPhysicalState.toJson());
 
 		ArrayList<ErrorMessage> errors = new ArrayList<ErrorMessage>();
-		// boolean errorsFound = false;
-
+        
 		HttpHeaders headers = getJsonHeaders(); // Expire the cache
 
 		Long physicalStateByCodeCount = 0L;

--- a/src/main/java/com/labsynch/labseer/api/ApiPhysicalStateController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiPhysicalStateController.java
@@ -153,7 +153,7 @@ public class ApiPhysicalStateController {
 		HttpHeaders headers = getJsonHeaders(); // Expire the cache
 
 		Long physicalStateByCodeCount = 0L;
-		List<PhysicalState> queryPhysicalStates = PhysicalState.findPhysicalStatesByCodeEquals(queryPhysicalState.getCode()).getResultList();
+		List<PhysicalState> queryPhysicalStates = PhysicalState.findPhysicalStatesByCodeEqualsIgnoreCase(queryPhysicalState.getCode()).getResultList();
 		for (PhysicalState physicalState : queryPhysicalStates) {
 			if (queryPhysicalState.getId() == null || physicalState.getId().longValue() != queryPhysicalState.getId().longValue()) {
 				++physicalStateByCodeCount;

--- a/src/main/java/com/labsynch/labseer/api/ApiStereoCategoryController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiStereoCategoryController.java
@@ -31,16 +31,32 @@ public class ApiStereoCategoryController {
 	@Autowired
 	private PropertiesUtilService propertiesUtilService;
 
-	@RequestMapping(value = "/validate", method = RequestMethod.GET, headers = "Accept=application/json")
-	@ResponseBody
-	public ResponseEntity<Boolean> validate(@RequestParam(value = "code", required = true) String code) {
-		HttpHeaders headers = new HttpHeaders();
+	private static HttpHeaders getTextHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/text; charset=utf-8");
+        headers.add("Access-Control-Allow-Origin", "*");
+        headers.add("Access-Control-Allow-Headers", "Content-Type");
+        headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
+        headers.add("Pragma", "no-cache"); // HTTP 1.0
+        headers.setExpires(0); // Expire the cache
+        return headers;
+    }
+
+    private static HttpHeaders getJsonHeaders() {
+        HttpHeaders headers = new HttpHeaders();
 		headers.add("Content-Type", "application/json; charset=utf-8");
 		headers.add("Access-Control-Allow-Headers", "Content-Type");
 		headers.add("Access-Control-Allow-Origin", "*");
 		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
 		headers.add("Pragma", "no-cache"); // HTTP 1.0
 		headers.setExpires(0); // Expire the cache
+        return headers;
+    }
+
+	@RequestMapping(value = "/validate", method = RequestMethod.GET, headers = "Accept=application/json")
+	@ResponseBody
+	public ResponseEntity<Boolean> validate(@RequestParam(value = "code", required = true) String code) {
+		HttpHeaders headers = getJsonHeaders();
 
 		if (StereoCategory.countFindStereoCategorysByCodeEquals(code) > 0) {
 			return new ResponseEntity<Boolean>(false, headers, HttpStatus.CONFLICT);
@@ -63,17 +79,11 @@ public class ApiStereoCategoryController {
 		ArrayList<ErrorMessage> errors = new ArrayList<ErrorMessage>();
 		// boolean errorsFound = false;
 
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/json; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getJsonHeaders();
 
 		Long stereoCategoryByCodeCount = 0L;
 		List<StereoCategory> queryStereoCategorys = StereoCategory
-				.findStereoCategorysByCodeEquals(queryStereoCategory.getCode()).getResultList();
+				.findStereoCategorysByCodeEqualsIgnoreCase(queryStereoCategory.getCode()).getResultList();
 		for (StereoCategory stereoCategory : queryStereoCategorys) {
 			if (queryStereoCategory.getId() == null
 					|| stereoCategory.getId().longValue() != queryStereoCategory.getId().longValue()) {
@@ -99,14 +109,8 @@ public class ApiStereoCategoryController {
 	@RequestMapping(value = "/findByCodeEquals", method = RequestMethod.GET, headers = "Accept=application/json")
 	@ResponseBody
 	public ResponseEntity<String> findByCodeEquals(@RequestParam(value = "code", required = true) String code) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/json; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
-		List<StereoCategory> stereoCategorys = StereoCategory.findStereoCategorysByCodeEquals(code).getResultList();
+		HttpHeaders headers = getJsonHeaders();
+		List<StereoCategory> stereoCategorys = StereoCategory.findStereoCategorysByCodeEqualsIgnoreCase(code).getResultList();
 		logger.debug("number of stereoCategorys found: " + stereoCategorys.size());
 		if (stereoCategorys.size() != 1) {
 			return new ResponseEntity<String>("[]", headers, HttpStatus.CONFLICT);
@@ -119,13 +123,7 @@ public class ApiStereoCategoryController {
 	@RequestMapping(value = "/findByCodeLike", method = RequestMethod.GET, headers = "Accept=application/json")
 	@ResponseBody
 	public ResponseEntity<String> findByCodeLike(@RequestParam(value = "code", required = true) String code) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/json; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getJsonHeaders();
 		return new ResponseEntity<String>(
 				StereoCategory.toJsonArray(StereoCategory.findStereoCategorysByCodeLike(code).getResultList()), headers,
 				HttpStatus.OK);
@@ -135,13 +133,7 @@ public class ApiStereoCategoryController {
 	@ResponseBody
 	public ResponseEntity<String> showJson(@PathVariable("id") Long id) {
 		StereoCategory stereoCategory = StereoCategory.findStereoCategory(id);
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/text; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getTextHeaders();
 		if (stereoCategory == null) {
 			return new ResponseEntity<String>(headers, HttpStatus.NOT_FOUND);
 		}
@@ -151,13 +143,7 @@ public class ApiStereoCategoryController {
 	@RequestMapping(headers = "Accept=application/json")
 	@ResponseBody
 	public ResponseEntity<String> listJson() {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/text; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getTextHeaders();
 
 		if (propertiesUtilService.getOrderSelectLists()) {
 			return new ResponseEntity<String>(
@@ -177,13 +163,7 @@ public class ApiStereoCategoryController {
 			newStereoCategory.setCode(newStereoCategory.getName().toLowerCase());
 		}
 		newStereoCategory.persist();
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/text; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getTextHeaders();
 		return new ResponseEntity<String>(newStereoCategory.toJson(), headers, HttpStatus.CREATED);
 	}
 
@@ -196,25 +176,13 @@ public class ApiStereoCategoryController {
 			}
 			stereoCategory.persist();
 		}
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/text; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getTextHeaders();
 		return new ResponseEntity<String>(headers, HttpStatus.CREATED);
 	}
 
 	@RequestMapping(method = RequestMethod.PUT, headers = "Accept=application/json")
 	public ResponseEntity<String> updateFromJson(@RequestBody String json) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/text; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getTextHeaders();
 		if (StereoCategory.fromJsonToStereoCategory(json).merge() == null) {
 			return new ResponseEntity<String>(headers, HttpStatus.NOT_FOUND);
 		}
@@ -223,13 +191,7 @@ public class ApiStereoCategoryController {
 
 	@RequestMapping(value = "/jsonArray", method = RequestMethod.PUT, headers = "Accept=application/json")
 	public ResponseEntity<String> updateFromJsonArray(@RequestBody String json) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/text; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getTextHeaders();
 		for (StereoCategory stereoCategory : StereoCategory.fromJsonArrayToStereoCategorys(json)) {
 			if (stereoCategory.merge() == null) {
 				return new ResponseEntity<String>(headers, HttpStatus.NOT_FOUND);
@@ -241,13 +203,7 @@ public class ApiStereoCategoryController {
 	@RequestMapping(value = "/{id}", method = RequestMethod.DELETE, headers = "Accept=application/json")
 	public ResponseEntity<String> deleteFromJson(@PathVariable("id") Long id) {
 		StereoCategory stereoCategory = StereoCategory.findStereoCategory(id);
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/text; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getTextHeaders();
 		if (stereoCategory == null) {
 			return new ResponseEntity<String>(headers, HttpStatus.NOT_FOUND);
 		}
@@ -275,13 +231,7 @@ public class ApiStereoCategoryController {
 	@ResponseBody
 	public ResponseEntity<String> searchBySearchTerms(
 			@RequestParam(value = "searchTerm", required = true) String searchTerm) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/json; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getJsonHeaders();
 		return new ResponseEntity<String>(
 				StereoCategory.toJsonArray(StereoCategory.findStereoCategoriesBySearchTerm(searchTerm).getResultList()),
 				headers, HttpStatus.OK);

--- a/src/main/java/com/labsynch/labseer/api/ApiVendorController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiVendorController.java
@@ -31,19 +31,34 @@ public class ApiVendorController {
 	@Autowired
 	private PropertiesUtilService propertiesUtilService;
 
-	// check if vendor already exists by code
-	// if exists -- return false else true
-	@RequestMapping(value = "/validate", method = RequestMethod.GET, headers = "Accept=application/json")
-	@ResponseBody
-	public ResponseEntity<Boolean> validate(@RequestParam(value = "code", required = true) String code) {
-		HttpHeaders headers = new HttpHeaders();
+	private static HttpHeaders getTextHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/text; charset=utf-8");
+        headers.add("Access-Control-Allow-Origin", "*");
+        headers.add("Access-Control-Allow-Headers", "Content-Type");
+        headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
+        headers.add("Pragma", "no-cache"); // HTTP 1.0
+        headers.setExpires(0); // Expire the cache
+        return headers;
+    }
+
+    private static HttpHeaders getJsonHeaders() {
+        HttpHeaders headers = new HttpHeaders();
 		headers.add("Content-Type", "application/json; charset=utf-8");
 		headers.add("Access-Control-Allow-Headers", "Content-Type");
 		headers.add("Access-Control-Allow-Origin", "*");
 		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
 		headers.add("Pragma", "no-cache"); // HTTP 1.0
 		headers.setExpires(0); // Expire the cache
+        return headers;
+    }
 
+	// check if vendor already exists by code
+	// if exists -- return false else true
+	@RequestMapping(value = "/validate", method = RequestMethod.GET, headers = "Accept=application/json")
+	@ResponseBody
+	public ResponseEntity<Boolean> validate(@RequestParam(value = "code", required = true) String code) {
+		HttpHeaders headers = getJsonHeaders();
 		if (Vendor.countFindVendorsByCodeEquals(code) > 0) {
 			return new ResponseEntity<Boolean>(false, headers, HttpStatus.CONFLICT);
 		} else {
@@ -68,16 +83,10 @@ public class ApiVendorController {
 		ArrayList<ErrorMessage> errors = new ArrayList<ErrorMessage>();
 		// boolean errorsFound = false;
 
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/json; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getJsonHeaders();
 
 		Long vendorByCodeCount = 0L;
-		List<Vendor> queryVendors = Vendor.findVendorsByCodeEquals(queryVendor.getCode()).getResultList();
+		List<Vendor> queryVendors = Vendor.findVendorsByCodeEqualsIgnoreCase(queryVendor.getCode()).getResultList();
 		for (Vendor vendor : queryVendors) {
 			if (queryVendor.getId() == null || vendor.getId().longValue() != queryVendor.getId().longValue()) {
 				++vendorByCodeCount;
@@ -102,14 +111,8 @@ public class ApiVendorController {
 	@RequestMapping(value = "/findByCodeEquals", method = RequestMethod.GET, headers = "Accept=application/json")
 	@ResponseBody
 	public ResponseEntity<String> findByCodeEquals(@RequestParam(value = "code", required = true) String code) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/json; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
-		List<Vendor> vendors = Vendor.findVendorsByCodeEquals(code).getResultList();
+		HttpHeaders headers = getJsonHeaders();
+		List<Vendor> vendors = Vendor.findVendorsByCodeEqualsIgnoreCase(code).getResultList();
 		logger.debug("number of vendors found: " + vendors.size());
 		if (vendors.size() != 1) {
 			return new ResponseEntity<String>("[]", headers, HttpStatus.CONFLICT);
@@ -122,13 +125,7 @@ public class ApiVendorController {
 	@RequestMapping(value = "/findByCodeLike", method = RequestMethod.GET, headers = "Accept=application/json")
 	@ResponseBody
 	public ResponseEntity<String> findByCodeLike(@RequestParam(value = "code", required = true) String code) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/json; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getJsonHeaders();
 		return new ResponseEntity<String>(Vendor.toJsonArray(Vendor.findVendorsByCodeLike(code).getResultList()),
 				headers, HttpStatus.OK);
 	}
@@ -137,13 +134,7 @@ public class ApiVendorController {
 	@ResponseBody
 	public ResponseEntity<String> showJson(@PathVariable("id") Long id) {
 		Vendor vendor = Vendor.findVendor(id);
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/text; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getTextHeaders();
 		if (vendor == null) {
 			return new ResponseEntity<String>(headers, HttpStatus.NOT_FOUND);
 		}
@@ -153,13 +144,7 @@ public class ApiVendorController {
 	@RequestMapping(headers = "Accept=application/json")
 	@ResponseBody
 	public ResponseEntity<String> listJson() {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/text; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getTextHeaders();
 
 		if (propertiesUtilService.getOrderSelectLists()) {
 			return new ResponseEntity<String>(Vendor.toJsonArray(Vendor.findAllVendors("name", "ASC")), headers,
@@ -177,13 +162,7 @@ public class ApiVendorController {
 			newVendor.setCode(newVendor.getName().toLowerCase());
 		}
 		newVendor.persist();
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/text; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getTextHeaders();
 		return new ResponseEntity<String>(newVendor.toJson(), headers, HttpStatus.CREATED);
 	}
 
@@ -196,25 +175,13 @@ public class ApiVendorController {
 			}
 			vendor.persist();
 		}
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/text; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getTextHeaders();
 		return new ResponseEntity<String>(headers, HttpStatus.CREATED);
 	}
 
 	@RequestMapping(method = RequestMethod.PUT, headers = "Accept=application/json")
 	public ResponseEntity<String> updateFromJson(@RequestBody String json) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/text; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getTextHeaders();
 		if (Vendor.fromJsonToVendor(json).merge() == null) {
 			return new ResponseEntity<String>(headers, HttpStatus.NOT_FOUND);
 		}
@@ -223,13 +190,7 @@ public class ApiVendorController {
 
 	@RequestMapping(value = "/jsonArray", method = RequestMethod.PUT, headers = "Accept=application/json")
 	public ResponseEntity<String> updateFromJsonArray(@RequestBody String json) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/text; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getTextHeaders();
 		for (Vendor vendor : Vendor.fromJsonArrayToVendors(json)) {
 			if (vendor.merge() == null) {
 				return new ResponseEntity<String>(headers, HttpStatus.NOT_FOUND);
@@ -241,13 +202,7 @@ public class ApiVendorController {
 	@RequestMapping(value = "/{id}", method = RequestMethod.DELETE, headers = "Accept=application/json")
 	public ResponseEntity<String> deleteFromJson(@PathVariable("id") Long id) {
 		Vendor vendor = Vendor.findVendor(id);
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/text; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getTextHeaders();
 		if (vendor == null) {
 			return new ResponseEntity<String>(headers, HttpStatus.NOT_FOUND);
 		}
@@ -274,13 +229,7 @@ public class ApiVendorController {
 	@ResponseBody
 	public ResponseEntity<String> searchBySearchTerms(
 			@RequestParam(value = "searchTerm", required = true) String searchTerm) {
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Content-Type", "application/json; charset=utf-8");
-		headers.add("Access-Control-Allow-Headers", "Content-Type");
-		headers.add("Access-Control-Allow-Origin", "*");
-		headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
-		headers.add("Pragma", "no-cache"); // HTTP 1.0
-		headers.setExpires(0); // Expire the cache
+		HttpHeaders headers = getJsonHeaders();
 		return new ResponseEntity<String>(
 				Vendor.toJsonArray(Vendor.findVendorsBySearchTerm(searchTerm).getResultList()), headers, HttpStatus.OK);
 	}

--- a/src/main/java/com/labsynch/labseer/domain/PhysicalState.java
+++ b/src/main/java/com/labsynch/labseer/domain/PhysicalState.java
@@ -193,11 +193,31 @@ public class PhysicalState {
         return q;
     }
 
+    public static TypedQuery<PhysicalState> findPhysicalStatesByCodeEqualsIgnoreCase(String code) {
+        if (code == null || code.length() == 0)
+            throw new IllegalArgumentException("The code argument is required");
+        EntityManager em = PhysicalState.entityManager();
+        TypedQuery<PhysicalState> q = em.createQuery("SELECT o FROM PhysicalState AS o WHERE LOWER(o.code) = LOWER(:code)",
+                PhysicalState.class);
+        q.setParameter("code", code);
+        return q;
+    }
+
     public static TypedQuery<PhysicalState> findPhysicalStatesByNameEquals(String name) {
         if (name == null || name.length() == 0)
             throw new IllegalArgumentException("The name argument is required");
         EntityManager em = PhysicalState.entityManager();
         TypedQuery<PhysicalState> q = em.createQuery("SELECT o FROM PhysicalState AS o WHERE o.name = :name",
+                PhysicalState.class);
+        q.setParameter("name", name);
+        return q;
+    }
+
+    public static TypedQuery<PhysicalState> findPhysicalStatesByNameEqualsIgnoreCase(String name) {
+        if (name == null || name.length() == 0)
+            throw new IllegalArgumentException("The name argument is required");
+        EntityManager em = PhysicalState.entityManager();
+        TypedQuery<PhysicalState> q = em.createQuery("SELECT o FROM PhysicalState AS o WHERE LOWER(o.name) = LOWER(:name)",
                 PhysicalState.class);
         q.setParameter("name", name);
         return q;

--- a/src/main/java/com/labsynch/labseer/domain/StereoCategory.java
+++ b/src/main/java/com/labsynch/labseer/domain/StereoCategory.java
@@ -185,6 +185,16 @@ public class StereoCategory {
         return q;
     }
 
+    public static TypedQuery<StereoCategory> findStereoCategorysByCodeEqualsIgnoreCase(String code){
+        if (code == null || code.length() == 0)
+            throw new IllegalArgumentException("The code argument is required");
+        EntityManager em = StereoCategory.entityManager();
+        TypedQuery<StereoCategory> q = em.createQuery("SELECT o FROM StereoCategory AS o WHERE LOWER(o.code) = LOWER(:code)",
+                StereoCategory.class);
+        q.setParameter("code", code);
+        return q;
+    }
+
     public static TypedQuery<StereoCategory> findStereoCategorysByCodeEquals(String code, String sortFieldName,
             String sortOrder) {
         if (code == null || code.length() == 0)

--- a/src/main/java/com/labsynch/labseer/domain/Vendor.java
+++ b/src/main/java/com/labsynch/labseer/domain/Vendor.java
@@ -301,6 +301,16 @@ public class Vendor {
         return q;
     }
 
+    public static TypedQuery<Vendor> findVendorsByCodeEqualsIgnoreCase(String code) {
+        if (code == null || code.length() == 0)
+            throw new IllegalArgumentException("The code argument is required");
+        EntityManager em = Vendor.entityManager();
+        TypedQuery<Vendor> q = em.createQuery("SELECT o FROM Vendor AS o WHERE LOWER(o.code) = LOWER(:code)",
+                Vendor.class);
+        q.setParameter("code", code);
+        return q;
+    }
+
     public static TypedQuery<Vendor> findVendorsByCodeLike(String code) {
         if (code == null || code.length() == 0)
             throw new IllegalArgumentException("The code argument is required");
@@ -363,6 +373,16 @@ public class Vendor {
             }
         }
         TypedQuery<Vendor> q = em.createQuery(queryBuilder.toString(), Vendor.class);
+        q.setParameter("name", name);
+        return q;
+    }
+
+    public static TypedQuery<Vendor> findVendorsByNameEqualsIgnoreCase(String name) {
+        if (name == null || name.length() == 0)
+            throw new IllegalArgumentException("The name argument is required");
+        EntityManager em = Vendor.entityManager();
+        TypedQuery<Vendor> q = em.createQuery("SELECT o FROM Vendor AS o WHERE LOWER(o.name) = LOWER(:name)",
+                Vendor.class);
         q.setParameter("name", name);
         return q;
     }

--- a/src/main/java/com/labsynch/labseer/dto/BulkLoadPropertiesDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/BulkLoadPropertiesDTO.java
@@ -81,7 +81,7 @@ public class BulkLoadPropertiesDTO {
 				// if there was a new match, add the mapping
 				if (dbPropMatch != null && (dbPropMatch.getIgnored() == null || !dbPropMatch.getIgnored())) {
 					BulkLoadPropertyMappingDTO newMapping = new BulkLoadPropertyMappingDTO(dbPropMatch.getName(),
-							sdfProp.getName(), dbPropMatch.getRequired(), null, null, false);
+							sdfProp.getName(), dbPropMatch.getRequired(), null, null, null, false);
 					this.bulkLoadProperties.add(newMapping);
 				}
 			}

--- a/src/main/java/com/labsynch/labseer/dto/BulkLoadPropertyMappingDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/BulkLoadPropertyMappingDTO.java
@@ -26,6 +26,8 @@ public class BulkLoadPropertyMappingDTO {
 
     private Collection<String> invalidValues;
 
+    private Collection<String> validValues;
+
     private String defaultVal;
 
     private boolean ignored;
@@ -35,12 +37,13 @@ public class BulkLoadPropertyMappingDTO {
     }
 
     public BulkLoadPropertyMappingDTO(String dbProperty, String sdfProperty, boolean required, String defaultVal,
-            Collection<String> invalidValues, boolean ignored) {
+            Collection<String> invalidValues, Collection<String> validValues, boolean ignored) {
         this.dbProperty = dbProperty;
         this.sdfProperty = sdfProperty;
         this.required = required;
         this.defaultVal = defaultVal;
         this.invalidValues = invalidValues;
+        this.validValues = validValues;
         this.ignored = ignored;
     }
 
@@ -134,6 +137,14 @@ public class BulkLoadPropertyMappingDTO {
 
     public void setInvalidValues(Collection<String> invalidValues) {
         this.invalidValues = invalidValues;
+    }
+
+    public Collection<String> getValidValues() {
+        return this.validValues;
+    }
+
+    public void setValidValues(Collection<String> validValues) {
+        this.validValues = validValues;
     }
 
     public String getDefaultVal() {

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -1323,18 +1323,18 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 			lookUpString = getStringValueFromMappings(mol, lookUpProperty, mappings, results, recordNumber);
 			if (lookUpString != null && lookUpString.length() > 0) {
 				try {
-					lot.setPhysicalState(PhysicalState.findPhysicalStatesByNameEquals(lookUpString).getSingleResult());
+					lot.setPhysicalState(PhysicalState.findPhysicalStatesByNameEqualsIgnoreCase(lookUpString).getSingleResult());
 				} catch (Exception e) {
-					lot.setPhysicalState(PhysicalState.findPhysicalStatesByCodeEquals(lookUpString).getSingleResult());
+					lot.setPhysicalState(PhysicalState.findPhysicalStatesByCodeEqualsIgnoreCase(lookUpString).getSingleResult());
 				}
 			}
 			lookUpProperty = "Lot Vendor";
 			lookUpString = getStringValueFromMappings(mol, lookUpProperty, mappings, results, recordNumber);
 			if (lookUpString != null && lookUpString.length() > 0) {
 				try {
-					lot.setVendor(Vendor.findVendorsByNameEquals(lookUpString).getSingleResult());
+					lot.setVendor(Vendor.findVendorsByNameEqualsIgnoreCase(lookUpString).getSingleResult());
 				} catch (Exception e) {
-					lot.setVendor(Vendor.findVendorsByCodeEquals(lookUpString).getSingleResult());
+					lot.setVendor(Vendor.findVendorsByCodeEqualsIgnoreCase(lookUpString).getSingleResult());
 				}
 			}
 			lookUpProperty = "Lot Purity Operator";
@@ -1593,7 +1593,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 			lookUpString = getStringValueFromMappings(mol, lookUpProperty, mappings, results, recordNumber);
 			if (lookUpString != null && lookUpString.length() > 0)
 				parent.setStereoCategory(
-						StereoCategory.findStereoCategorysByCodeEquals(lookUpString).getSingleResult());
+						StereoCategory.findStereoCategorysByCodeEqualsIgnoreCase(lookUpString).getSingleResult());
 			lookUpProperty = "Parent Annotation";
 			lookUpString = getStringValueFromMappings(mol, lookUpProperty, mappings, results, recordNumber);
 			if (lookUpString != null && lookUpString.length() > 0)

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -1693,6 +1693,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 			value = value.replaceAll(regexMatch, "");
 		if (value == null)
 			value = mapping.getDefaultVal();
+		String origValue = value;
 		Boolean coerced = false;
 		if (value != null) {
 			String trimmedString = value.trim();
@@ -1700,10 +1701,22 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 				value = trimmedString;
 				coerced = true;
 			}
+			// Check if value is part of 'invalidValues' and a coerced change in case will yield one of the 'validValues'
+			if (mapping.getInvalidValues() != null && mapping.getValidValues() != null){
+				if (mapping.getInvalidValues().contains(value)){
+					for (String validValue : mapping.getValidValues()) {
+						if (validValue.toLowerCase().equals(value.toLowerCase())) {
+							// Make the substitution
+							value = validValue;
+							coerced = true;
+						}
+					}
+				}
+			}
 		}
 		if (recordNumber != -1 && coerced)
 			logWarning("TrimmedStringValue", "Trimmed string value for property " + sdfProperty,
-					sdfProperty + " '" + mol.getProperty(sdfProperty) + "' trimmed to '" + value + "'", recordNumber,
+					sdfProperty + " '" + origValue + "' trimmed to '" + value + "'", recordNumber,
 					results);
 		if (value != null)
 			if (logger.isDebugEnabled())
@@ -2330,7 +2343,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 				if (BulkLoadPropertyMappingDTO.findMappingByDbPropertyEquals(mappings, dbProperty) == null) {
 					// no mapping found - add a new one with dbProperty = sdfProperty
 					BulkLoadPropertyMappingDTO newMapping = new BulkLoadPropertyMappingDTO(dbProperty, sdfProperty,
-							false, null, null, false);
+							false, null, null, null, false);
 					mappings.add(newMapping);
 				} else {
 					sdfProperty = BulkLoadPropertyMappingDTO.findMappingByDbPropertyEquals(mappings, dbProperty)
@@ -2343,7 +2356,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 				if (BulkLoadPropertyMappingDTO.findMappingByDbPropertyEquals(mappings, dbProperty) == null) {
 					// no mapping found - add a new one with dbProperty = sdfProperty
 					BulkLoadPropertyMappingDTO newMapping = new BulkLoadPropertyMappingDTO(dbProperty, sdfProperty,
-							false, null, null, false);
+							false, null, null, null, false);
 					mappings.add(newMapping);
 				} else {
 					sdfProperty = BulkLoadPropertyMappingDTO.findMappingByDbPropertyEquals(mappings, dbProperty)


### PR DESCRIPTION
## Description
- Add ignoreCase lookups for vendor, physical state, stereo category
- I wasn't totally sure how far to take this. There are some lesser-used categorical lookups that this could be extended to, like Parent Annotation

## Related Issue

## How Has This Been Tested?
Ran acasclient tests including new one for wrong-case inputs: https://github.com/mcneilco/acasclient/pull/55