### PR TITLE
Dale minor fixes sprint9

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -389,8 +389,6 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 				Lot lot;
 				// attempt to strip salts
 				try {
-					// Check mol mappings for salt present
-					StrippedSaltDTO strippedSaltDTO = chemStructureService.stripSalts(mol);
 					mol = processForSaltStripping(mol, mappings, results, numRecordsRead);
 				} catch (CmpdRegMolFormatException e) {
 					String emptyMolfile = "\n" +
@@ -2344,7 +2342,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 						recordNumber);
 				if (saltAbbrevMapping != null && saltAbbrevMapping.length() > 0) {
 					// Salt(s) has been found in structure and property mapping => not allowed 
-					CmpdRegMolFormatException saltException = new CmpdRegMolFormatException("Salts found in both structure and sdf prop");
+					CmpdRegMolFormatException saltException = new CmpdRegMolFormatException("Salts found in both structure and SDF Property");
 					throw saltException;
 				} 
 				if (saltAbbrevMapping != null) {

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -840,6 +840,11 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 						logWarning("MatchingStructureSameStereoDifferentComment", categoryDescription,
 								categoryDescription + ": " + foundParent.getCorpName(), numRecordsRead,
 								validationResponse);
+						categoryDescription = "New parent will be assigned due to different stereo comment";
+						// logWarning will add to validationResponse and pass information to user 
+						logWarning("AssigningNewParent", categoryDescription,
+								categoryDescription + ": " + foundParent.getCorpName(), numRecordsRead,
+								validationResponse);
 						continue;
 					} else if (!sameStereoCategory & sameCorpName & !noCorpName) {
 						logger.error("Mismatched stereo categories for same parent structure and corp name! Corp name: "
@@ -855,6 +860,11 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 						logWarning("MatchingStructureDifferentStereoCategory", categoryDescription,
 								categoryDescription + ": " + foundParent.getCorpName(), numRecordsRead,
 								validationResponse);
+						categoryDescription = "New parent will be assigned due to different stereo category";
+						// logWarning will add to validationResponse and pass information to user 
+						logWarning("AssigningNewParent", categoryDescription,
+							categoryDescription + ": " + foundParent.getCorpName(), numRecordsRead,
+							validationResponse);
 						continue;
 					}
 				}
@@ -1008,6 +1018,11 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 								categoryDescription + ": " + foundDryRunCompound.getCorpName() + "(record number "
 										+ foundParentCdId + ")",
 								numRecordsRead, validationResponse);
+						categoryDescription = "New parent will be assigned due to different stereo comment";
+						// logWarning will add to validationResponse and pass information to user 
+						logWarning("WithinFileMatchingStructureSameStereoDifferentComment", categoryDescription,
+								categoryDescription + ": " + foundDryRunCompound.getCorpName() + "(record number "
+								+ foundParentCdId + ")", numRecordsRead, validationResponse);
 						continue;
 					} else if (!sameStereoCategory & sameCorpName & !noCorpName) {
 						logger.error(
@@ -1027,6 +1042,11 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 								categoryDescription + ": " + foundDryRunCompound.getCorpName() + "(record number "
 										+ foundParentCdId + ")",
 								numRecordsRead, validationResponse);
+						categoryDescription = "New parent will be assigned due to different stereo category";
+						// logWarning will add to validationResponse and pass information to user 
+						logWarning("WithinFileMatchingStructureDifferentStereoCategory", categoryDescription,
+								categoryDescription + ": " + foundDryRunCompound.getCorpName() + "(record number "
+								+ foundParentCdId + ")", numRecordsRead, validationResponse);
 						continue;
 					}
 				}

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -386,10 +386,12 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 				// Parent
 				Parent parent;
 				SaltForm saltForm;
+				boolean saltStripped = false;
 				Lot lot;
 				// attempt to strip salts
 				try {
 					mol = processForSaltStripping(mol, mappings, results, numRecordsRead);
+					saltStripped = true;
 				} catch (CmpdRegMolFormatException e) {
 					String emptyMolfile = "\n" +
 							"  Ketcher 09111712282D 1   1.00000     0.00000     0\n" +
@@ -425,6 +427,13 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 					isNewParent = false;
 				try {
 					saltForm = createSaltForm(mol, mappings, results, numRecordsRead);
+					if(saltStripped) 
+					{
+						// Salt(s) has been found in structure and property mapping => not allowed 
+						Exception saltException = new Exception("Salts found in both structure and sdf prop");
+						logError(saltException, numRecordsRead, mol, mappings, errorMolExporter, results, errorCSVOutStream);
+						continue;
+					}
 				} catch (Exception e) {
 					logError(e, numRecordsRead, mol, mappings, errorMolExporter, results, errorCSVOutStream);
 					continue;


### PR DESCRIPTION
Minor code changes...

[ACAS-99](https://jira.schrodinger.com/browse/ACAS-99): CReg combines salts from structure and sdf prop; should fail and warn user instead

[ACAS-40](https://jira.schrodinger.com/browse/ACAS-40): CReg bulk loader should warn when assigning existing compound structure a new ID