### PR TITLE
Return bulk load file id

### DIFF
--- a/src/main/java/com/labsynch/labseer/dto/BulkLoadRegisterSDFResponseDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/BulkLoadRegisterSDFResponseDTO.java
@@ -19,15 +19,18 @@ public class BulkLoadRegisterSDFResponseDTO {
 
     private Collection<String> reportFiles;
 
+    private Long id;
+
     public BulkLoadRegisterSDFResponseDTO() {
 
     }
 
     public BulkLoadRegisterSDFResponseDTO(String summary, Collection<ValidationResponseDTO> results,
-            Collection<String> reportFiles) {
+            Collection<String> reportFiles, Long id) {
         this.summary = summary;
         this.results = results;
         this.reportFiles = reportFiles;
+        this.id = id;
     }
 
     public String toJson() {
@@ -58,6 +61,14 @@ public class BulkLoadRegisterSDFResponseDTO {
 
     public void setReportFiles(Collection<String> reportFiles) {
         this.reportFiles = reportFiles;
+    }
+
+    public Long getId() {
+        return this.id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
     }
 
     public static BulkLoadRegisterSDFResponseDTO fromJsonToBulkLoadRegisterSDFResponseDTO(String json) {

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -581,11 +581,11 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 			} else {
 				logger.info("Finished bulk loading file: " + bulkLoadFile.toJson());
 			}
-			return new BulkLoadRegisterSDFResponseDTO(summaryHtml, results, reportFiles);
+			return new BulkLoadRegisterSDFResponseDTO(summaryHtml, results, reportFiles, bulkLoadFile.getId());
 		} catch (Exception e) {
 			logger.error("Caught an error in the big loop", e);
 			results.add(new ValidationResponseDTO("error", -1, "Unassigned", e.getMessage(), e.getMessage()));
-			return new BulkLoadRegisterSDFResponseDTO(e.getMessage(), results, null);
+			return new BulkLoadRegisterSDFResponseDTO(e.getMessage(), results, null, null);
 		}
 	}
 


### PR DESCRIPTION
## Description
Add bulk load file `id` to the output of bulk load reg responses

## Related Issue
ACAS-311
ACAS-273

## How Has This Been Tested?
Wrote ACAS client tests for ACAS-273 and changed the behavior of the purge bulk load test to use the `id` as a handle when bulk loading and then purging a file.