### PR TITLE
ACAS-316 add maven build caching

### DIFF
--- a/Dockerfile-multistage
+++ b/Dockerfile-multistage
@@ -17,9 +17,9 @@ FROM 	${CHEMISTRY_PACKAGE} as compile
 
 ADD 	pom.xml /src/pom.xml
 WORKDIR /src
-RUN 	mvn dependency:resolve -P ${CHEMISTRY_PACKAGE}
+RUN 	--mount=type=cache,target=/root/.m2 mvn dependency:resolve -P ${CHEMISTRY_PACKAGE}
 ADD 	. /src
-RUN 	mvn clean && \
+RUN 	--mount=type=cache,target=/root/.m2 mvn clean && \
         mvn compile war:war -P ${CHEMISTRY_PACKAGE}
 
 FROM tomcat:9.0.62-jre8-openjdk-slim-buster


### PR DESCRIPTION
## Description
Add maven build caching to multistage builds file. Item #3 from https://www.baeldung.com/ops/docker-cache-maven-dependencies

## Related Issue

## How Has This Been Tested?
Ran builds against indigo, switched branches, reran build and it went super fast.
Switched to building bbchem, reran build and it went super fast too.

Merging this to the release will test the CI builds.