### PR TITLE
Acas 320

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -489,8 +489,8 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 								newDuplicateCorpNames = newDuplicateCorpNames.concat(";");
 							newDuplicateCorpNames = newDuplicateCorpNames.concat(searchResult.getCorpName());
 							firstNewDuplicateHit = false;
-							logger.info("found new dupe parents - query: " + dryRunCompound.getCorpName() + "     dupe: "
-									+ searchResult.getCorpName());
+							logger.info("found new dupe parents - query: '" + dryRunCompound.getCorpName() + "' dupe: '"
+									+ searchResult.getCorpName() + "'");
 							totalNewDuplicateCount++;
 						} else {
 							newDupeCount = newDupeCount - 1;
@@ -518,8 +518,8 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 								oldDuplicateCorpNames = oldDuplicateCorpNames.concat(";");
 							oldDuplicateCorpNames = oldDuplicateCorpNames.concat(searchResult.getCorpName());
 							firstOldDuplicateHit = false;
-							logger.info("found old dupe parents - query: " + dryRunCompound.getCorpName() + "     dupe: "
-									+ searchResult.getCorpName());
+							logger.info("found old dupe parents - query: '" + dryRunCompound.getCorpName() + "' dupe: "
+									+ searchResult.getCorpName() + "'");
 							// totalExistingDuplicateCount++;
 						} else {
 							oldDuplicateCount = oldDuplicateCount - 1;

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -408,7 +408,7 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		int p = 1;
 		// Do a bulk standardization
 		for (List<Long> dIdGroup : dryRunIdGroups) {
-			totalNewDuplicateCount = totalNewDuplicateCount + dupeCheckStandardizationStructuresBatch(dIdGroup, totalNewDuplicateCount);
+			totalNewDuplicateCount = totalNewDuplicateCount + dupeCheckStandardizationStructuresBatch(dIdGroup);
 			p = p+dIdGroup.size();
 
 			// Compute your percentage.
@@ -428,7 +428,16 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 	}
 
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	private int dupeCheckStandardizationStructuresBatch(List<Long> dryRunIds, int totalNewDuplicateCount)  throws CmpdRegMolFormatException {
+	private int dupeCheckStandardizationStructuresBatch(List<Long> dryRunIds)  throws CmpdRegMolFormatException {
+		int totalNewDuplicateCount = 0;
+		for (Long dryRunId : dryRunIds) {
+			int newDuplicates = dupeCheckStandardizationStructure(dryRunId);
+			totalNewDuplicateCount = totalNewDuplicateCount + newDuplicates;
+		}
+		return totalNewDuplicateCount;
+	}
+
+	private int dupeCheckStandardizationStructure(Long dryRunId) throws CmpdRegMolFormatException {
 
 		int[] hits;
 		StandardizationDryRunCompound dryRunCompound;
@@ -437,105 +446,99 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		int newDupeCount = 0;
 		int oldDuplicateCount = 0;
 
-		for (Long dryRunId : dryRunIds) {
-			boolean firstNewDuplicateHit = true;
-			boolean firstOldDuplicateHit = true;
-			dryRunCompound = StandardizationDryRunCompound.findStandardizationDryRunCompound(dryRunId);
+		int totalNewDuplicateCount = 0;
 
-			if (dryRunCompound.getRegistrationStatus() == RegistrationStatus.ERROR) {
-				logger.info("skipping dupe check for compound with registration status "
-						+ dryRunCompound.getRegistrationStatus() + ": " + dryRunCompound.getCorpName());
-			} else {
-				logger.debug("query compound: " + dryRunCompound.getCorpName());
+		boolean firstNewDuplicateHit = true;
+		boolean firstOldDuplicateHit = true;
+		dryRunCompound = StandardizationDryRunCompound.findStandardizationDryRunCompound(dryRunId);
 
-				HashMap<String, Integer> chemStructureHashMap = new HashMap<String, Integer>();
+		if (dryRunCompound.getRegistrationStatus() == RegistrationStatus.ERROR) {
+			logger.info("skipping dupe check for compound with registration status "
+					+ dryRunCompound.getRegistrationStatus() + ": " + dryRunCompound.getCorpName());
+		} else {
+			logger.debug("query compound: " + dryRunCompound.getCorpName());
 
-				// Arbitrary key to call service and fetch cmpdreg molecule
-				String tmpStructureKey = "TmpStructureKey01";
-				chemStructureHashMap.put(tmpStructureKey, dryRunCompound.getCdId());
-				HashMap<String, CmpdRegMolecule> cmpdRegMolecules = chemStructureService.getCmpdRegMolecules(
-						chemStructureHashMap,
-						StructureType.STANDARDIZATION_DRY_RUN);
+			HashMap<String, Integer> chemStructureHashMap = new HashMap<String, Integer>();
 
-				// Pass -1F for simlarityPercent (non nullable int required in function
-				// signature not used in DUPLICATE_TAUTOMER searches)
-				// Pass -1 for maxResults (non nullable int required in function signature we
-				// don't want to limit the hit counts here)
-				hits = chemStructureService.searchMolStructures(cmpdRegMolecules.get(tmpStructureKey),
-						StructureType.STANDARDIZATION_DRY_RUN, SearchType.DUPLICATE_TAUTOMER, -1F, -1);
-				newDupeCount = hits.length;
-				for (int hit : hits) {
-					List<StandardizationDryRunCompound> searchResults = StandardizationDryRunCompound
-							.findStandardizationDryRunCompoundsByCdId(hit).getResultList();
-					for (StandardizationDryRunCompound searchResult : searchResults) {
-						if (searchResult.getCorpName().equalsIgnoreCase(dryRunCompound.getCorpName())) {
+			// Arbitrary key to call service and fetch cmpdreg molecule
+			String tmpStructureKey = "TmpStructureKey01";
+			chemStructureHashMap.put(tmpStructureKey, dryRunCompound.getCdId());
+			HashMap<String, CmpdRegMolecule> cmpdRegMolecules = chemStructureService.getCmpdRegMolecules(
+					chemStructureHashMap,
+					StructureType.STANDARDIZATION_DRY_RUN);
+
+			// Pass -1F for simlarityPercent (non nullable int required in function
+			// signature not used in DUPLICATE_TAUTOMER searches)
+			// Pass -1 for maxResults (non nullable int required in function signature we
+			// don't want to limit the hit counts here)
+			hits = chemStructureService.searchMolStructures(cmpdRegMolecules.get(tmpStructureKey),
+					StructureType.STANDARDIZATION_DRY_RUN, SearchType.DUPLICATE_TAUTOMER, -1F, -1);
+			newDupeCount = hits.length;
+			for (int hit : hits) {
+				List<StandardizationDryRunCompound> searchResults = StandardizationDryRunCompound
+						.findStandardizationDryRunCompoundsByCdId(hit).getResultList();
+				for (StandardizationDryRunCompound searchResult : searchResults) {
+					if (searchResult.getCorpName().equalsIgnoreCase(dryRunCompound.getCorpName())) {
+						newDupeCount = newDupeCount - 1;
+					} else {
+						if (StringUtils.equals(searchResult.getStereoCategory(),
+								dryRunCompound.getStereoCategory())
+								&& StringUtils.equalsIgnoreCase(searchResult.getStereoComment(),
+										dryRunCompound.getStereoComment())) {
+							if (!firstNewDuplicateHit)
+								newDuplicateCorpNames = newDuplicateCorpNames.concat(";");
+							newDuplicateCorpNames = newDuplicateCorpNames.concat(searchResult.getCorpName());
+							firstNewDuplicateHit = false;
+							logger.info("found new dupe parents - query: " + dryRunCompound.getCorpName() + "     dupe: "
+									+ searchResult.getCorpName());
+							totalNewDuplicateCount++;
+						} else {
 							newDupeCount = newDupeCount - 1;
-						} else {
-							if (StringUtils.equals(searchResult.getStereoCategory(),
-									dryRunCompound.getStereoCategory())
-									&& StringUtils.equalsIgnoreCase(searchResult.getStereoComment(),
-											dryRunCompound.getStereoComment())) {
-								if (!firstNewDuplicateHit)
-									newDuplicateCorpNames = newDuplicateCorpNames.concat(";");
-								newDuplicateCorpNames = newDuplicateCorpNames.concat(searchResult.getCorpName());
-								firstNewDuplicateHit = false;
-								logger.info("found new dupe parents");
-								logger.info("query: " + dryRunCompound.getCorpName() + "     dupe: "
-										+ searchResult.getCorpName());
-								totalNewDuplicateCount++;
-							} else {
-								newDupeCount = newDupeCount - 1;
-								logger.debug("found different stereo codes and comments");
-							}
+							logger.debug("found different stereo codes and comments");
 						}
 					}
 				}
-				hits = chemStructureService.searchMolStructures(cmpdRegMolecules.get(tmpStructureKey),
-						StructureType.PARENT, SearchType.DUPLICATE_TAUTOMER, -1F, -1);
-				oldDuplicateCount = hits.length;
-				dryRunCompound.setChangedStructure(true);
-				for (int hit : hits) {
-					List<Parent> searchResults = Parent.findParentsByCdId(hit).getResultList();
-					for (Parent searchResult : searchResults) {
-						if (searchResult.getCorpName().equalsIgnoreCase(dryRunCompound.getCorpName())) {
+			}
+			hits = chemStructureService.searchMolStructures(cmpdRegMolecules.get(tmpStructureKey),
+					StructureType.PARENT, SearchType.DUPLICATE_TAUTOMER, -1F, -1);
+			oldDuplicateCount = hits.length;
+			dryRunCompound.setChangedStructure(true);
+			for (int hit : hits) {
+				List<Parent> searchResults = Parent.findParentsByCdId(hit).getResultList();
+				for (Parent searchResult : searchResults) {
+					if (searchResult.getCorpName().equalsIgnoreCase(dryRunCompound.getCorpName())) {
+						oldDuplicateCount = oldDuplicateCount - 1;
+						dryRunCompound.setChangedStructure(false);
+					} else {
+						if (StringUtils.equals(searchResult.getStereoCategory().getName(),
+								dryRunCompound.getStereoCategory())
+								&& StringUtils.equalsIgnoreCase(searchResult.getStereoComment(),
+										dryRunCompound.getStereoComment())) {
+							if (!firstOldDuplicateHit)
+								oldDuplicateCorpNames = oldDuplicateCorpNames.concat(";");
+							oldDuplicateCorpNames = oldDuplicateCorpNames.concat(searchResult.getCorpName());
+							firstOldDuplicateHit = false;
+							logger.info("found old dupe parents - query: " + dryRunCompound.getCorpName() + "     dupe: "
+									+ searchResult.getCorpName());
+							// totalExistingDuplicateCount++;
+						} else {
 							oldDuplicateCount = oldDuplicateCount - 1;
-							dryRunCompound.setChangedStructure(false);
-						} else {
-							if (StringUtils.equals(searchResult.getStereoCategory().getName(),
-									dryRunCompound.getStereoCategory())
-									&& StringUtils.equalsIgnoreCase(searchResult.getStereoComment(),
-											dryRunCompound.getStereoComment())) {
-								if (!firstOldDuplicateHit)
-									oldDuplicateCorpNames = oldDuplicateCorpNames.concat(";");
-								oldDuplicateCorpNames = oldDuplicateCorpNames.concat(searchResult.getCorpName());
-								firstOldDuplicateHit = false;
-								logger.info("found old dupe parents");
-								logger.info("query: " + dryRunCompound.getCorpName() + "     dupe: "
-										+ searchResult.getCorpName());
-								// totalExistingDuplicateCount++;
-							} else {
-								oldDuplicateCount = oldDuplicateCount - 1;
-								logger.debug("found different stereo codes and comments");
-							}
+							logger.debug("found different stereo codes and comments");
 						}
 					}
 				}
-				dryRunCompound.setNewDuplicateCount(newDupeCount);
-				if (!newDuplicateCorpNames.equals("")) {
-					dryRunCompound.setNewDuplicates(newDuplicateCorpNames);
-				}
-				dryRunCompound.setExistingDuplicateCount(oldDuplicateCount);
-				if (!oldDuplicateCorpNames.equals("")) {
-					dryRunCompound.setExistingDuplicates(oldDuplicateCorpNames);
-				}
-
-				dryRunCompound.merge();
-				newDuplicateCorpNames = "";
-				oldDuplicateCorpNames = "";
+			}
+			dryRunCompound.setNewDuplicateCount(newDupeCount);
+			if (!newDuplicateCorpNames.equals("")) {
+				dryRunCompound.setNewDuplicates(newDuplicateCorpNames);
+			}
+			dryRunCompound.setExistingDuplicateCount(oldDuplicateCount);
+			if (!oldDuplicateCorpNames.equals("")) {
+				dryRunCompound.setExistingDuplicates(oldDuplicateCorpNames);
 			}
 
+			dryRunCompound.merge();
 		}
-
 	
 		return (totalNewDuplicateCount);
 	}

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -13,6 +13,9 @@
     <Logger name="org.springframework.web" level="info"/>
     <Logger name="org.apache.catalina.core" level="info"/>
     <Logger name="org.apache.catalina.core.ContainerBase.[Catalina].[localhost]" level="info"/>
+
+    <!-- Leaving debug transactions here but commented as it can be helpful for knowing when begin/commit of transaction is-->
+    <!-- <Logger name="org.hibernate.engine.transaction.internal.TransactionImpl" level="debug"/> -->
     <Root level="info">
       <AppenderRef ref="STDOUT"/>
     </Root>


### PR DESCRIPTION
## Description
 - Use `@Transactional` for cmpd reg bulk loader and standardization steps (including parent restandardization)
 - Use `@Transactional(propagation = Propagation.REQUIRES_NEW)` to reduce batch size of main transactions
   - https://docs.spring.io/spring-framework/docs/current/reference/html/data-access.html#tx-propagation

## Related Issue
ACAS-320

## How Has This Been Tested?
Added acasclient test for large (1K) compound load including a compound which errors
Due to Indigo chemistry (open source) not currently implementing standardization I couldn't add acasclient tests for standardization.  Instead I used a bbchem server to run dry run standardization.  Additionally, I truncated the bbchem_parent_structure table and ran dry/run and full parent restandardization to verify speeds.