### PR TITLE
ACAS-327: Add catch for null property value

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/CmpdRegMoleculeBBChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/CmpdRegMoleculeBBChemImpl.java
@@ -39,7 +39,7 @@ public class CmpdRegMoleculeBBChemImpl implements CmpdRegMolecule {
 	@Override
 	public String getProperty(String key) {
 		String prop = this.molecule.getProperties().get(key);
-		if (prop.equals("")) {
+		if (prop == null || prop.equals("")) {
 			return null;
 		} else {
 			return prop;


### PR DESCRIPTION
## Description
We hit a NullPointerException in the BBChem ACAS code when it encounters an empty SDF property. This should fix it.

## Related Issue

## How Has This Been Tested?
Not tested