### PR TITLE
Acas 320 bb

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/indigo/ChemStructureServiceIndigoImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/indigo/ChemStructureServiceIndigoImpl.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceException;
 import javax.persistence.Query;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -276,7 +277,7 @@ public class ChemStructureServiceIndigoImpl implements ChemStructureService {
 
 			return hitList;
 
-		} catch (JpaSystemException sqlException) {
+		} catch (JpaSystemException | PersistenceException sqlException) {
 			logger.error("Caught search error", sqlException);
 			Exception rootCause = new Exception(ExceptionUtils.getRootCause(sqlException).getMessage(),
 					ExceptionUtils.getRootCause(sqlException));

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -522,11 +522,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 					numNewLotsOldParentsLoaded++;
 				writeRegisteredMol(numRecordsRead, mol, metalotReturn, mappings, registeredMolExporter,
 						registeredCSVOutStream, isNewParent, results);
-				if (numRecordsRead % 100 == 0) {
-					logger.info("flushing bulk loader session");
-					session.flush();
-					session.clear();
-				}
+
 				currentTime = new Date().getTime();
 				if (currentTime > startTime) {
 					logger.info("SPEED REPORT:");

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -35,7 +35,6 @@ import com.labsynch.labseer.utils.PropertiesUtilService;
 import com.labsynch.labseer.utils.SimpleUtil;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hibernate.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +43,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.annotation.Propagation;
 
 @Service
 public class StandardizationServiceImpl implements StandardizationService, ApplicationListener<ContextRefreshedEvent> {
@@ -196,23 +196,18 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 	}
 
 	@Override
+	@Transactional
 	public int populateStandardizationDryRunTable()
 			throws CmpdRegMolFormatException, IOException, StandardizerException {
 		List<Long> parentIds = Parent.getParentIds();
 
-		Session session = StandardizationDryRunCompound.entityManager().unwrap(Session.class);
 		Long startTime = new Date().getTime();
-		Long currentTime = new Date().getTime();
 
 		int batchSize = propertiesUtilService.getStandardizationBatchSize();
-		Parent parent;
-		StandardizationDryRunCompound stndznCompound;
 		int nonMatchingCmpds = 0;
 		int totalCount = parentIds.size();
 		logger.info("number of parents to check: " + totalCount);
-		Date qcDate = new Date();
-		Integer cdId = 0;
-		List<Lot> queryLots;
+
 		Integer runNumber = StandardizationDryRunCompound.findMaxRunNumber().getSingleResult();
 		if (runNumber == null) {
 			runNumber = 1;
@@ -229,128 +224,13 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 
 		// Do a bulk standardization
 		for (List<Long> pIdGroup : parentIdGroups) {
-			logger.info("Starting batch of " + pIdGroup.size() + " parents");
-
-			// Create standardization hashmap
-			HashMap<String, String> parentIdsToStructures = new HashMap<String, String>();
-			HashMap<String, String> parentIdsToAsDrawnStructs = new HashMap<String, String>();
-			HashMap<Long, Parent> parents = new HashMap<Long, Parent>();
-			for (Long parentId : pIdGroup) {
-				parent = Parent.findParent(parentId);
-				parents.put(parentId, parent);
-
-				// Get the as drawn structure
-				String asDrawnStruct = Lot.getOriginallyDrawnAsStructure(parent);
-				if (asDrawnStruct == null) {
-					logger.warn("Parent " + parentId + " has no as drawn structure");
-					parentIdsToStructures.put(parentId.toString(parentId), parent.getMolStructure());
-				} else {
-					parentIdsToStructures.put(parentId.toString(parentId), asDrawnStruct);
-					parentIdsToAsDrawnStructs.put(parentId.toString(parentId), asDrawnStruct);
-				}
-
-			}
-
-			// Do standardization
-			logger.info("Starting standardization of " + parentIdsToStructures.size() + " compounds");
-			// Start timer
-			long standardizationStart = new Date().getTime();
-			HashMap<String, CmpdRegMolecule> standardizationResults = chemStructureService
-					.standardizeStructures(parentIdsToStructures);
-			long standardizationEnd = new Date().getTime();
-			// Convert the ms time to seconds
-			long standardizationTime = (standardizationEnd - standardizationStart) / 1000;
-			logger.info("Standardization took " + standardizationTime + " seconds");
-
-			logger.info("Starting saving of " + pIdGroup.size() + " dry run structures");
-			long structureSaveStart = new Date().getTime();
-
-			// Save the standardized dry run structures and return the hashmap of String
-			// (parent id) and Integer (cd id). We use the cdIds below
-			// when saving the dry run compounds to the database which links the structures
-			// and compounds together.
-			HashMap<String, Integer> parentIdToStructureId = saveDryRunStructures(standardizationResults);
-			long structureSaveEnd = new Date().getTime();
-			// Convert the ms time to seconds
-			long saveTime = (structureSaveEnd - structureSaveStart) / 1000;
-			logger.info("Saving took " + saveTime + " seconds");
-
-			logger.info("Starting saving of " + pIdGroup.size() + " standardization dry run compounds");
-			long dryRunCompoundSaveStart = new Date().getTime();
-			for (Long parentId : pIdGroup) {
-				parent = parents.get(parentId);
-				stndznCompound = new StandardizationDryRunCompound();
-				stndznCompound.setRunNumber(runNumber);
-				stndznCompound.setQcDate(qcDate);
-				stndznCompound.setParentId(parent.getId());
-				stndznCompound.setCorpName(parent.getCorpName());
-				stndznCompound.setAlias(getParentAlias(parent));
-				stndznCompound.setStereoCategory(parent.getStereoCategory().getName());
-				stndznCompound.setStereoComment(parent.getStereoComment());
-				stndznCompound.setOldMolWeight(parent.getMolWeight());
-
-				CmpdRegMolecule cmpdRegMolecule = standardizationResults.get(parentId.toString());
-				stndznCompound.setMolStructure(cmpdRegMolecule.getMolStructure());
-				stndznCompound.setStandardizationStatus(cmpdRegMolecule.getStandardizationStatus());
-				stndznCompound.setStandardizationComment(cmpdRegMolecule.getStandardizationComment());
-				stndznCompound.setRegistrationStatus(cmpdRegMolecule.getRegistrationStatus());
-				stndznCompound.setRegistrationComment(cmpdRegMolecule.getRegistrationComment());
-
-				Double newMolWeight = cmpdRegMolecule.getMass();
-				if (newMolWeight != null) {
-					DecimalFormat dMolWeight = new DecimalFormat("#.###");
-					stndznCompound.setNewMolWeight(Double.valueOf(dMolWeight.format(newMolWeight)));
-				} else {
-					stndznCompound.setNewMolWeight(null);
-				}
-
-				if (newMolWeight == null || stndznCompound.getOldMolWeight() == null) {
-					stndznCompound.setDeltaMolWeight(null);
-				} else {
-					DecimalFormat deltaMolFormat = new DecimalFormat("#.###");
-					Double deltaMolWeight = stndznCompound.getOldMolWeight() - stndznCompound.getNewMolWeight();
-					stndznCompound.setDeltaMolWeight(Double.valueOf(deltaMolFormat.format(deltaMolWeight)));
-				}
-
-				boolean displayTheSame = chemStructureService.isIdenticalDisplay(parent.getMolStructure(),
-						stndznCompound.getMolStructure());
-
-				if (!displayTheSame) {
-					stndznCompound.setDisplayChange(true);
-					logger.debug("the compounds are NOT matching: " + parent.getCorpName());
-					nonMatchingCmpds++;
-				}
-				String asDrawnStruct = parentIdsToAsDrawnStructs.get(parentId.toString(parentId));
-				boolean asDrawnDisplaySame = chemStructureService.isIdenticalDisplay(asDrawnStruct,
-						stndznCompound.getMolStructure());
-
-				if (!asDrawnDisplaySame) {
-					stndznCompound.setAsDrawnDisplayChange(true);
-					logger.debug("the compounds are NOT matching: " + parent.getCorpName());
-					nonMatchingCmpds++;
-				}
-
-				cdId = parentIdToStructureId.get(parentId.toString());
-
-				if (cdId == -1) {
-					logger.error("Bad molformat. Please fix the molfile for Corp Name " + stndznCompound.getCorpName()
-							+ ", Parent ID " + stndznCompound.getParentId() + ": " + stndznCompound.getMolStructure());
-				} else {
-					stndznCompound.setCdId(cdId);
-					stndznCompound.persist();
-				}
-				p++;
-			}
-			// End timer
-			long dryRunCompoundSaveEnd = new Date().getTime();
-			// Convert the ms time to seconds
-			long dryRunCompoundSaveTime = (dryRunCompoundSaveEnd - dryRunCompoundSaveStart) / 1000;
-			logger.info("Saving took " + dryRunCompoundSaveTime + " seconds");
+			dryrunStandardizeBatch(pIdGroup, nonMatchingCmpds, runNumber);
+			p = p + pIdGroup.size();
 
 			// Compute your percentage.
 			percent = (float) Math.floor(p * 100f / totalCount);
 			if (percent != previousPercent) {
-				currentTime = new Date().getTime();
+				Long currentTime = new Date().getTime();
 				// Output if different from the last time.
 				logger.info("populating standardization dry run table " + percent + "% complete (" + p + " of "
 						+ totalCount + ") average speed (rows/min):"
@@ -361,12 +241,135 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			// Update the percentage.
 			previousPercent = percent;
 		}
-
-		logger.info(
-				"total number of non matching; structure, display or as drawn display changes: " + nonMatchingCmpds);
+		logger.info("total number of non matching; structure, display or as drawn display changes: " + nonMatchingCmpds);
 		return (nonMatchingCmpds);
 	}
 
+	
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	private void dryrunStandardizeBatch(List<Long> pIdGroup, int nonMatchingCmpds, int runNumber) throws StandardizerException, CmpdRegMolFormatException {
+		Parent parent;
+		StandardizationDryRunCompound stndznCompound;
+		Date qcDate = new Date();
+		Integer cdId = 0;
+
+		logger.info("Starting batch of " + pIdGroup.size() + " parents");
+		// Create standardization hashmap
+		HashMap<String, String> parentIdsToStructures = new HashMap<String, String>();
+		HashMap<String, String> parentIdsToAsDrawnStructs = new HashMap<String, String>();
+		HashMap<Long, Parent> parents = new HashMap<Long, Parent>();
+		for (Long parentId : pIdGroup) {
+			parent = Parent.findParent(parentId);
+			parents.put(parentId, parent);
+
+			// Get the as drawn structure
+			String asDrawnStruct = Lot.getOriginallyDrawnAsStructure(parent);
+			if (asDrawnStruct == null) {
+				logger.warn("Parent " + parentId + " has no as drawn structure");
+				parentIdsToStructures.put(parentId.toString(parentId), parent.getMolStructure());
+			} else {
+				parentIdsToStructures.put(parentId.toString(parentId), asDrawnStruct);
+				parentIdsToAsDrawnStructs.put(parentId.toString(parentId), asDrawnStruct);
+			}
+
+		}
+
+		// Do standardization
+		logger.info("Starting standardization of " + parentIdsToStructures.size() + " compounds");
+		// Start timer
+		long standardizationStart = new Date().getTime();
+		HashMap<String, CmpdRegMolecule> standardizationResults = chemStructureService
+				.standardizeStructures(parentIdsToStructures);
+		long standardizationEnd = new Date().getTime();
+		// Convert the ms time to seconds
+		long standardizationTime = (standardizationEnd - standardizationStart) / 1000;
+		logger.info("Standardization took " + standardizationTime + " seconds");
+
+		logger.info("Starting saving of " + pIdGroup.size() + " dry run structures");
+		long structureSaveStart = new Date().getTime();
+
+		// Save the standardized dry run structures and return the hashmap of String
+		// (parent id) and Integer (cd id). We use the cdIds below
+		// when saving the dry run compounds to the database which links the structures
+		// and compounds together.
+		HashMap<String, Integer> parentIdToStructureId = saveDryRunStructures(standardizationResults);
+		long structureSaveEnd = new Date().getTime();
+		// Convert the ms time to seconds
+		long saveTime = (structureSaveEnd - structureSaveStart) / 1000;
+		logger.info("Saving took " + saveTime + " seconds");
+
+		logger.info("Starting saving of " + pIdGroup.size() + " standardization dry run compounds");
+		long dryRunCompoundSaveStart = new Date().getTime();
+		for (Long parentId : pIdGroup) {
+			parent = parents.get(parentId);
+			stndznCompound = new StandardizationDryRunCompound();
+			stndznCompound.setRunNumber(runNumber);
+			stndznCompound.setQcDate(qcDate);
+			stndznCompound.setParentId(parent.getId());
+			stndznCompound.setCorpName(parent.getCorpName());
+			stndznCompound.setAlias(getParentAlias(parent));
+			stndznCompound.setStereoCategory(parent.getStereoCategory().getName());
+			stndznCompound.setStereoComment(parent.getStereoComment());
+			stndznCompound.setOldMolWeight(parent.getMolWeight());
+
+			CmpdRegMolecule cmpdRegMolecule = standardizationResults.get(parentId.toString());
+			stndznCompound.setMolStructure(cmpdRegMolecule.getMolStructure());
+			stndznCompound.setStandardizationStatus(cmpdRegMolecule.getStandardizationStatus());
+			stndznCompound.setStandardizationComment(cmpdRegMolecule.getStandardizationComment());
+			stndznCompound.setRegistrationStatus(cmpdRegMolecule.getRegistrationStatus());
+			stndznCompound.setRegistrationComment(cmpdRegMolecule.getRegistrationComment());
+
+			Double newMolWeight = cmpdRegMolecule.getMass();
+			if (newMolWeight != null) {
+				DecimalFormat dMolWeight = new DecimalFormat("#.###");
+				stndznCompound.setNewMolWeight(Double.valueOf(dMolWeight.format(newMolWeight)));
+			} else {
+				stndznCompound.setNewMolWeight(null);
+			}
+
+			if (newMolWeight == null || stndznCompound.getOldMolWeight() == null) {
+				stndznCompound.setDeltaMolWeight(null);
+			} else {
+				DecimalFormat deltaMolFormat = new DecimalFormat("#.###");
+				Double deltaMolWeight = stndznCompound.getOldMolWeight() - stndznCompound.getNewMolWeight();
+				stndznCompound.setDeltaMolWeight(Double.valueOf(deltaMolFormat.format(deltaMolWeight)));
+			}
+
+			boolean displayTheSame = chemStructureService.isIdenticalDisplay(parent.getMolStructure(),
+					stndznCompound.getMolStructure());
+
+			if (!displayTheSame) {
+				stndznCompound.setDisplayChange(true);
+				logger.debug("the compounds are NOT matching: " + parent.getCorpName());
+				nonMatchingCmpds++;
+			}
+			String asDrawnStruct = parentIdsToAsDrawnStructs.get(parentId.toString(parentId));
+			boolean asDrawnDisplaySame = chemStructureService.isIdenticalDisplay(asDrawnStruct,
+					stndznCompound.getMolStructure());
+
+			if (!asDrawnDisplaySame) {
+				stndznCompound.setAsDrawnDisplayChange(true);
+				logger.debug("the compounds are NOT matching: " + parent.getCorpName());
+				nonMatchingCmpds++;
+			}
+
+			cdId = parentIdToStructureId.get(parentId.toString());
+
+			if (cdId == -1) {
+				logger.error("Bad molformat. Please fix the molfile for Corp Name " + stndznCompound.getCorpName()
+						+ ", Parent ID " + stndznCompound.getParentId() + ": " + stndznCompound.getMolStructure());
+			} else {
+				stndznCompound.setCdId(cdId);
+				stndznCompound.persist();
+			}
+		}
+		// End timer
+		long dryRunCompoundSaveEnd = new Date().getTime();
+		// Convert the ms time to seconds
+		long dryRunCompoundSaveTime = (dryRunCompoundSaveEnd - dryRunCompoundSaveStart) / 1000;
+		logger.info("Saving took " + dryRunCompoundSaveTime + " seconds");
+	}
+	
 	private String getParentAlias(Parent parent) {
 		StringBuilder aliasSB = new StringBuilder();
 		Set<ParentAlias> parentAliases = parent.getParentAliases();
@@ -383,143 +386,160 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 	}
 
 	@Override
+	@Transactional
 	public int dupeCheckStandardizationStructures() throws CmpdRegMolFormatException {
 		List<Long> dryRunIds = StandardizationDryRunCompound.findAllIds().getResultList();
 
-		Session session = StandardizationDryRunCompound.entityManager().unwrap(Session.class);
 		Long startTime = new Date().getTime();
-		Long currentTime = new Date().getTime();
 
 		int totalCount = dryRunIds.size();
 		logger.debug("number of compounds found in dry run table: " + totalCount);
 		int totalNewDuplicateCount = 0;
-		int totalExistingDuplicateCount = 0;
-		if (dryRunIds.size() > 0) {
-			int[] hits;
-			StandardizationDryRunCompound dryRunCompound;
-			String newDuplicateCorpNames = "";
-			String oldDuplicateCorpNames = "";
-			int newDupeCount = 0;
-			int oldDuplicateCount = 0;
 
-			float percent = 0;
-			int p = 1;
-			float previousPercent = percent;
+		// Split parent ids into groups of batchSize of 1
+		// We tested this with large batch sizes and it was faster doing 1 per transaction
+		int batchSize = propertiesUtilService.getStandardizationBatchSize();
+		List<List<Long>> dryRunIdGroups = SimpleUtil.splitArrayIntoGroups(dryRunIds, batchSize);
+
+		float percent = 0;
+		float previousPercent = percent;
+		previousPercent = percent;
+
+		int p = 1;
+		// Do a bulk standardization
+		for (List<Long> dIdGroup : dryRunIdGroups) {
+			totalNewDuplicateCount = totalNewDuplicateCount + dupeCheckStandardizationStructuresBatch(dIdGroup);
+			p = p+dIdGroup.size();
+
+			// Compute your percentage.
+			percent = (float) Math.floor(p * 100f / totalCount);
+			if (percent != previousPercent) {
+				Long currentTime = new Date().getTime();
+				// Output if different from the last time.
+				logger.info("checking for standardization duplicates " + percent + "% complete (" + p + "/"
+						+ totalCount + ") average speed (rows/min):"
+						+ (p / ((currentTime - startTime) / 60.0 / 1000.0)));
+				logger.debug("Time Elapsed:" + (currentTime - startTime));
+			}
+			// Update the percentage.
 			previousPercent = percent;
-			for (Long dryRunId : dryRunIds) {
-				boolean firstNewDuplicateHit = true;
-				boolean firstOldDuplicateHit = true;
-				dryRunCompound = StandardizationDryRunCompound.findStandardizationDryRunCompound(dryRunId);
+		}
+		return(totalNewDuplicateCount);
+	}
 
-				if (dryRunCompound.getRegistrationStatus() == RegistrationStatus.ERROR) {
-					logger.info("skipping dupe check for compound with registration status "
-							+ dryRunCompound.getRegistrationStatus() + ": " + dryRunCompound.getCorpName());
-				} else {
-					logger.debug("query compound: " + dryRunCompound.getCorpName());
+	private int dupeCheckStandardizationStructuresBatch(List<Long> dryRunIds)  throws CmpdRegMolFormatException {
+		int totalNewDuplicateCount = 0;
+		for (Long dryRunId : dryRunIds) {
+			int newDuplicates = dupeCheckStandardizationStructure(dryRunId);
+			totalNewDuplicateCount = totalNewDuplicateCount + newDuplicates;
+		}
+		return totalNewDuplicateCount;
+	}
 
-					HashMap<String, Integer> chemStructureHashMap = new HashMap<String, Integer>();
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	private int dupeCheckStandardizationStructure(Long dryRunId) throws CmpdRegMolFormatException {
 
-					// Arbitrary key to call service and fetch cmpdreg molecule
-					String tmpStructureKey = "TmpStructureKey01";
-					chemStructureHashMap.put(tmpStructureKey, dryRunCompound.getCdId());
-					HashMap<String, CmpdRegMolecule> cmpdRegMolecules = chemStructureService.getCmpdRegMolecules(
-							chemStructureHashMap,
-							StructureType.STANDARDIZATION_DRY_RUN);
+		int[] hits;
+		StandardizationDryRunCompound dryRunCompound;
+		String newDuplicateCorpNames = "";
+		String oldDuplicateCorpNames = "";
+		int newDupeCount = 0;
+		int oldDuplicateCount = 0;
 
-					// Pass -1F for simlarityPercent (non nullable int required in function
-					// signature not used in DUPLICATE_TAUTOMER searches)
-					// Pass -1 for maxResults (non nullable int required in function signature we
-					// don't want to limit the hit counts here)
-					hits = chemStructureService.searchMolStructures(cmpdRegMolecules.get(tmpStructureKey),
-							StructureType.STANDARDIZATION_DRY_RUN, SearchType.DUPLICATE_TAUTOMER, -1F, -1);
-					newDupeCount = hits.length;
-					for (int hit : hits) {
-						List<StandardizationDryRunCompound> searchResults = StandardizationDryRunCompound
-								.findStandardizationDryRunCompoundsByCdId(hit).getResultList();
-						for (StandardizationDryRunCompound searchResult : searchResults) {
-							if (searchResult.getCorpName().equalsIgnoreCase(dryRunCompound.getCorpName())) {
-								newDupeCount = newDupeCount - 1;
-							} else {
-								if (StringUtils.equals(searchResult.getStereoCategory(),
-										dryRunCompound.getStereoCategory())
-										&& StringUtils.equalsIgnoreCase(searchResult.getStereoComment(),
-												dryRunCompound.getStereoComment())) {
-									if (!firstNewDuplicateHit)
-										newDuplicateCorpNames = newDuplicateCorpNames.concat(";");
-									newDuplicateCorpNames = newDuplicateCorpNames.concat(searchResult.getCorpName());
-									firstNewDuplicateHit = false;
-									logger.info("found new dupe parents");
-									logger.info("query: " + dryRunCompound.getCorpName() + "     dupe: "
-											+ searchResult.getCorpName());
-									totalNewDuplicateCount++;
-								} else {
-									newDupeCount = newDupeCount - 1;
-									logger.debug("found different stereo codes and comments");
-								}
-							}
+		int totalNewDuplicateCount = 0;
+
+		boolean firstNewDuplicateHit = true;
+		boolean firstOldDuplicateHit = true;
+		dryRunCompound = StandardizationDryRunCompound.findStandardizationDryRunCompound(dryRunId);
+
+		if (dryRunCompound.getRegistrationStatus() == RegistrationStatus.ERROR) {
+			logger.info("skipping dupe check for compound with registration status "
+					+ dryRunCompound.getRegistrationStatus() + ": " + dryRunCompound.getCorpName());
+		} else {
+			logger.debug("query compound: " + dryRunCompound.getCorpName());
+
+			HashMap<String, Integer> chemStructureHashMap = new HashMap<String, Integer>();
+
+			// Arbitrary key to call service and fetch cmpdreg molecule
+			String tmpStructureKey = "TmpStructureKey01";
+			chemStructureHashMap.put(tmpStructureKey, dryRunCompound.getCdId());
+			HashMap<String, CmpdRegMolecule> cmpdRegMolecules = chemStructureService.getCmpdRegMolecules(
+					chemStructureHashMap,
+					StructureType.STANDARDIZATION_DRY_RUN);
+
+			// Pass -1F for simlarityPercent (non nullable int required in function
+			// signature not used in DUPLICATE_TAUTOMER searches)
+			// Pass -1 for maxResults (non nullable int required in function signature we
+			// don't want to limit the hit counts here)
+			hits = chemStructureService.searchMolStructures(cmpdRegMolecules.get(tmpStructureKey),
+					StructureType.STANDARDIZATION_DRY_RUN, SearchType.DUPLICATE_TAUTOMER, -1F, -1);
+			newDupeCount = hits.length;
+			for (int hit : hits) {
+				List<StandardizationDryRunCompound> searchResults = StandardizationDryRunCompound
+						.findStandardizationDryRunCompoundsByCdId(hit).getResultList();
+				for (StandardizationDryRunCompound searchResult : searchResults) {
+					if (searchResult.getCorpName().equalsIgnoreCase(dryRunCompound.getCorpName())) {
+						newDupeCount = newDupeCount - 1;
+					} else {
+						if (StringUtils.equals(searchResult.getStereoCategory(),
+								dryRunCompound.getStereoCategory())
+								&& StringUtils.equalsIgnoreCase(searchResult.getStereoComment(),
+										dryRunCompound.getStereoComment())) {
+							if (!firstNewDuplicateHit)
+								newDuplicateCorpNames = newDuplicateCorpNames.concat(";");
+							newDuplicateCorpNames = newDuplicateCorpNames.concat(searchResult.getCorpName());
+							firstNewDuplicateHit = false;
+							logger.info("found new dupe parents - query: '" + dryRunCompound.getCorpName() + "' dupe: '"
+									+ searchResult.getCorpName() + "'");
+							totalNewDuplicateCount++;
+						} else {
+							newDupeCount = newDupeCount - 1;
+							logger.debug("found different stereo codes and comments");
 						}
 					}
-					hits = chemStructureService.searchMolStructures(cmpdRegMolecules.get(tmpStructureKey),
-							StructureType.PARENT, SearchType.DUPLICATE_TAUTOMER, -1F, -1);
-					oldDuplicateCount = hits.length;
-					dryRunCompound.setChangedStructure(true);
-					for (int hit : hits) {
-						List<Parent> searchResults = Parent.findParentsByCdId(hit).getResultList();
-						for (Parent searchResult : searchResults) {
-							if (searchResult.getCorpName().equalsIgnoreCase(dryRunCompound.getCorpName())) {
-								oldDuplicateCount = oldDuplicateCount - 1;
-								dryRunCompound.setChangedStructure(false);
-							} else {
-								if (StringUtils.equals(searchResult.getStereoCategory().getName(),
-										dryRunCompound.getStereoCategory())
-										&& StringUtils.equalsIgnoreCase(searchResult.getStereoComment(),
-												dryRunCompound.getStereoComment())) {
-									if (!firstOldDuplicateHit)
-										oldDuplicateCorpNames = oldDuplicateCorpNames.concat(";");
-									oldDuplicateCorpNames = oldDuplicateCorpNames.concat(searchResult.getCorpName());
-									firstOldDuplicateHit = false;
-									logger.info("found old dupe parents");
-									logger.info("query: " + dryRunCompound.getCorpName() + "     dupe: "
-											+ searchResult.getCorpName());
-									totalExistingDuplicateCount++;
-								} else {
-									oldDuplicateCount = oldDuplicateCount - 1;
-									logger.debug("found different stereo codes and comments");
-								}
-							}
+				}
+			}
+			hits = chemStructureService.searchMolStructures(cmpdRegMolecules.get(tmpStructureKey),
+					StructureType.PARENT, SearchType.DUPLICATE_TAUTOMER, -1F, -1);
+			oldDuplicateCount = hits.length;
+			dryRunCompound.setChangedStructure(true);
+			for (int hit : hits) {
+				List<Parent> searchResults = Parent.findParentsByCdId(hit).getResultList();
+				for (Parent searchResult : searchResults) {
+					if (searchResult.getCorpName().equalsIgnoreCase(dryRunCompound.getCorpName())) {
+						oldDuplicateCount = oldDuplicateCount - 1;
+						dryRunCompound.setChangedStructure(false);
+					} else {
+						if (StringUtils.equals(searchResult.getStereoCategory().getName(),
+								dryRunCompound.getStereoCategory())
+								&& StringUtils.equalsIgnoreCase(searchResult.getStereoComment(),
+										dryRunCompound.getStereoComment())) {
+							if (!firstOldDuplicateHit)
+								oldDuplicateCorpNames = oldDuplicateCorpNames.concat(";");
+							oldDuplicateCorpNames = oldDuplicateCorpNames.concat(searchResult.getCorpName());
+							firstOldDuplicateHit = false;
+							logger.info("found old dupe parents - query: '" + dryRunCompound.getCorpName() + "' dupe: "
+									+ searchResult.getCorpName() + "'");
+							// totalExistingDuplicateCount++;
+						} else {
+							oldDuplicateCount = oldDuplicateCount - 1;
+							logger.debug("found different stereo codes and comments");
 						}
 					}
-					dryRunCompound.setNewDuplicateCount(newDupeCount);
-					if (!newDuplicateCorpNames.equals("")) {
-						dryRunCompound.setNewDuplicates(newDuplicateCorpNames);
-					}
-					dryRunCompound.setExistingDuplicateCount(oldDuplicateCount);
-					if (!oldDuplicateCorpNames.equals("")) {
-						dryRunCompound.setExistingDuplicates(oldDuplicateCorpNames);
-					}
-
-					dryRunCompound.merge();
-					newDuplicateCorpNames = "";
-					oldDuplicateCorpNames = "";
 				}
-
-				// Compute your percentage.
-				percent = (float) Math.floor(p * 100f / totalCount);
-				if (percent != previousPercent) {
-					currentTime = new Date().getTime();
-					// Output if different from the last time.
-					logger.info("checking for standardization duplicates " + percent + "% complete (" + p + "/"
-							+ totalCount + ") average speed (rows/min):"
-							+ (p / ((currentTime - startTime) / 60.0 / 1000.0)));
-					logger.debug("Time Elapsed:" + (currentTime - startTime));
-				}
-				// Update the percentage.
-				previousPercent = percent;
-				p++;
-
+			}
+			dryRunCompound.setNewDuplicateCount(newDupeCount);
+			if (!newDuplicateCorpNames.equals("")) {
+				dryRunCompound.setNewDuplicates(newDuplicateCorpNames);
+			}
+			dryRunCompound.setExistingDuplicateCount(oldDuplicateCount);
+			if (!oldDuplicateCorpNames.equals("")) {
+				dryRunCompound.setExistingDuplicates(oldDuplicateCorpNames);
 			}
 
+			dryRunCompound.merge();
 		}
+	
 		return (totalNewDuplicateCount);
 	}
 
@@ -636,14 +656,12 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 	}
 
 	@Override
+	@Transactional
 	public int restandardizeParentStructures(List<Long> parentIds)
 			throws CmpdRegMolFormatException, StandardizerException, IOException {
 
 		int batchSize = propertiesUtilService.getStandardizationBatchSize();
-		Parent parent;
-		List<Lot> lots;
-		Lot lot;
-		String standardizedMol;
+
 		int totalCount = parentIds.size();
 		logger.info("number of parents to restandardize: " + totalCount);
 		float percent = 0;
@@ -651,7 +669,6 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		float previousPercent = percent;
 		previousPercent = percent;
 
-		Session session = Parent.entityManager().unwrap(Session.class);
 		Long startTime = new Date().getTime();
 		Long currentTime = new Date().getTime();
 
@@ -660,94 +677,8 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		// Do a bulk standardization
 		for (List<Long> pIdGroup : parentIdGroups) {
 			logger.info("Starting batch of " + pIdGroup.size() + " parents");
-
-			// Create standardization hashmap
-			HashMap<String, String> parentIdsToStructures = new HashMap<String, String>();
-			HashMap<Long, Parent> parents = new HashMap<Long, Parent>();
-			for (Long parentId : pIdGroup) {
-				parent = Parent.findParent(parentId);
-				parents.put(parentId, parent);
-
-				// Get the as drawn structure
-				String asDrawnStruct = Lot.getOriginallyDrawnAsStructure(parent);
-				if (asDrawnStruct == null) {
-					logger.warn("Parent " + parentId + " has no as drawn structure");
-					parentIdsToStructures.put(parentId.toString(parentId), parent.getMolStructure());
-				} else {
-					parentIdsToStructures.put(parentId.toString(parentId), asDrawnStruct);
-				}
-
-			}
-
-			// Do standardization
-			logger.info("Starting standardization of " + parentIdsToStructures.size() + " compounds");
-			// Start timer
-			long standardizationStart = new Date().getTime();
-			HashMap<String, CmpdRegMolecule> standardizationResults = chemStructureService
-					.standardizeStructures(parentIdsToStructures);
-			long standardizationEnd = new Date().getTime();
-			// Convert the ms time to seconds
-			long standardizationTime = (standardizationEnd - standardizationStart) / 1000;
-			logger.info("Standardization took " + standardizationTime + " seconds");
-
-			logger.info("Starting save of " + pIdGroup.size() + " parents");
-			long savingStart = new Date().getTime();
-			for (Long parentId : pIdGroup) {
-
-				parent = parents.get(parentId);
-
-				// We standardize the structure first
-				CmpdRegMolecule cmpdRegMolecule = standardizationResults.get(parentId.toString());
-				standardizedMol = cmpdRegMolecule.getMolStructure();
-
-				// Now we update the parent structure
-				Boolean success = updateStructure(cmpdRegMolecule, parent.getCdId());
-
-				// In the case where we are switching chemistry engines the structure might not
-				// exist,
-				// so we need to check for that and if it does not exist we need to create it
-				if (!success) {
-					logger.warn("Could not update structure for parent: " + parentId + "  " + parent.getCorpName());
-					logger.info("Assuming the structure did not exist in the first place and saving a new one");
-					int newCdId = chemStructureService.saveStructure(cmpdRegMolecule, StructureType.PARENT, false);
-					parent.setCdId(newCdId);
-					logger.info("Updated parent with new cdId: " + newCdId);
-				}
-
-				// Update the mol structure
-				parent.setMolStructure(standardizedMol);
-
-				// Update other properties
-				if (cmpdRegMolecule.getExactMass() != null) {
-					DecimalFormat dExactMass = new DecimalFormat("#.######");
-					parent.setExactMass(Double.valueOf(dExactMass.format(cmpdRegMolecule.getExactMass())));
-				} else {
-					parent.setExactMass(null);
-				}
-
-				if (cmpdRegMolecule.getMass() != null) {
-					DecimalFormat dMolWeight = new DecimalFormat("#.###");
-					parent.setMolWeight(Double.valueOf(dMolWeight.format(cmpdRegMolecule.getMass())));
-				} else {
-					parent.setMolWeight(null);
-				}
-
-				parent.setMolFormula(cmpdRegMolecule.getFormula());
-
-				parent.merge();
-
-				p++;
-
-			}
-			// Update lot information, this is much faster than looping through the
-			// salt_forms and lots using hibernate
-			int countLotsUpdated = restandardizeLots(pIdGroup);
-			logger.info("Updated " + countLotsUpdated + " lots");
-
-			long savingEnd = new Date().getTime();
-			// Convert the ms time to seconds
-			long savingTime = (savingEnd - savingStart) / 1000;
-			logger.info("Saving took " + savingTime + " seconds");
+			restandardizeParentStructuresBatch(pIdGroup);
+			p =  p + pIdGroup.size();
 
 			// Compute your percentage.
 			percent = (float) Math.floor(p * 100f / totalCount);
@@ -763,7 +694,101 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			// Update the percentage.
 			previousPercent = percent;
 		}
-		return parentIds.size();
+		return(p);
+	}
+	
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public int restandardizeParentStructuresBatch(List<Long> pIdGroup) throws CmpdRegMolFormatException, StandardizerException, IOException {
+		// Create standardization hashmap
+		HashMap<String, String> parentIdsToStructures = new HashMap<String, String>();
+		HashMap<Long, Parent> parents = new HashMap<Long, Parent>();
+		Parent parent;
+		String standardizedMol;
+
+		for (Long parentId : pIdGroup) {
+			parent = Parent.findParent(parentId);
+			parents.put(parentId, parent);
+
+			// Get the as drawn structure
+			String asDrawnStruct = Lot.getOriginallyDrawnAsStructure(parent);
+			if (asDrawnStruct == null) {
+				logger.warn("Parent " + parentId + " has no as drawn structure");
+				parentIdsToStructures.put(parentId.toString(parentId), parent.getMolStructure());
+			} else {
+				parentIdsToStructures.put(parentId.toString(parentId), asDrawnStruct);
+			}
+
+		}
+
+		// Do standardization
+		logger.info("Starting standardization of " + parentIdsToStructures.size() + " compounds");
+		// Start timer
+		long standardizationStart = new Date().getTime();
+		HashMap<String, CmpdRegMolecule> standardizationResults = chemStructureService
+				.standardizeStructures(parentIdsToStructures);
+		long standardizationEnd = new Date().getTime();
+		// Convert the ms time to seconds
+		long standardizationTime = (standardizationEnd - standardizationStart) / 1000;
+		logger.info("Standardization took " + standardizationTime + " seconds");
+
+		logger.info("Starting save of " + pIdGroup.size() + " parents");
+		long savingStart = new Date().getTime();
+		for (Long parentId : pIdGroup) {
+
+			parent = parents.get(parentId);
+
+			// We standardize the structure first
+			CmpdRegMolecule cmpdRegMolecule = standardizationResults.get(parentId.toString());
+			standardizedMol = cmpdRegMolecule.getMolStructure();
+
+			// Now we update the parent structure
+			Boolean success = updateStructure(cmpdRegMolecule, parent.getCdId());
+
+			// In the case where we are switching chemistry engines the structure might not
+			// exist,
+			// so we need to check for that and if it does not exist we need to create it
+			if (!success) {
+				logger.warn("Could not update structure for parent: " + parentId + "  " + parent.getCorpName());
+				logger.info("Assuming the structure did not exist in the first place and saving a new one");
+				int newCdId = chemStructureService.saveStructure(cmpdRegMolecule, StructureType.PARENT, false);
+				parent.setCdId(newCdId);
+				logger.info("Updated parent with new cdId: " + newCdId);
+			}
+
+			// Update the mol structure
+			parent.setMolStructure(standardizedMol);
+
+			// Update other properties
+			if (cmpdRegMolecule.getExactMass() != null) {
+				DecimalFormat dExactMass = new DecimalFormat("#.######");
+				parent.setExactMass(Double.valueOf(dExactMass.format(cmpdRegMolecule.getExactMass())));
+			} else {
+				parent.setExactMass(null);
+			}
+
+			if (cmpdRegMolecule.getMass() != null) {
+				DecimalFormat dMolWeight = new DecimalFormat("#.###");
+				parent.setMolWeight(Double.valueOf(dMolWeight.format(cmpdRegMolecule.getMass())));
+			} else {
+				parent.setMolWeight(null);
+			}
+
+			parent.setMolFormula(cmpdRegMolecule.getFormula());
+
+			parent.merge();
+
+		}
+		// Update lot information, this is much faster than looping through the
+		// salt_forms and lots using hibernate
+		int countLotsUpdated = restandardizeLots(pIdGroup);
+		logger.info("Updated " + countLotsUpdated + " lots");
+
+		long savingEnd = new Date().getTime();
+		// Convert the ms time to seconds
+		long savingTime = (savingEnd - savingStart) / 1000;
+		logger.info("Saving took " + savingTime + " seconds");
+
+		return pIdGroup.size();
 	}
 
 	@Override

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -347,11 +347,6 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			long dryRunCompoundSaveTime = (dryRunCompoundSaveEnd - dryRunCompoundSaveStart) / 1000;
 			logger.info("Saving took " + dryRunCompoundSaveTime + " seconds");
 
-			// End loop through parent id group
-			logger.debug("flushing loader session");
-			session.flush();
-			session.clear();
-
 			// Compute your percentage.
 			percent = (float) Math.floor(p * 100f / totalCount);
 			if (percent != previousPercent) {
@@ -506,11 +501,6 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 					dryRunCompound.merge();
 					newDuplicateCorpNames = "";
 					oldDuplicateCorpNames = "";
-				}
-				if (p % 100 == 0) {
-					logger.debug("flushing loader session");
-					session.flush();
-					session.clear();
 				}
 
 				// Compute your percentage.
@@ -758,10 +748,6 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			// Convert the ms time to seconds
 			long savingTime = (savingEnd - savingStart) / 1000;
 			logger.info("Saving took " + savingTime + " seconds");
-
-			logger.debug("flushing loader session");
-			session.flush();
-			session.clear();
 
 			// Compute your percentage.
 			percent = (float) Math.floor(p * 100f / totalCount);

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -7,12 +7,18 @@
   </Appenders>
   <Loggers>
     <Logger name="com.labsynch.labseer" level="info"/>
+    <Logger name="com.mangofactory.swagger" level="error"/>
     <Logger name="org.springframework" level="info"/>
     <Logger name="org.springframework.orm" level="info"/>
     <Logger name="org.springframework.security" level="info"/>
     <Logger name="org.springframework.web" level="info"/>
     <Logger name="org.apache.catalina.core" level="info"/>
     <Logger name="org.apache.catalina.core.ContainerBase.[Catalina].[localhost]" level="info"/>
+
+    <!-- Leaving debug transactions here but commented as it can be helpful for knowing when begin/commit of transaction is-->
+    <!-- <Logger name="org.hibernate.engine.transaction.internal.TransactionImpl" level="debug"/>
+    <Logger name="org.springframework.transaction" level="debug"/>
+    <Logger name="org.springframework.orm.jpa" level="debug"/> -->
     <Root level="info">
       <AppenderRef ref="STDOUT"/>
     </Root>


### PR DESCRIPTION
## Description

 - Refactored registerSDF main loop into `@Transactional(propagation = Propagation.REQUIRES_NEW)` so that any  single compound is atomic but the main loop continues on sql error.
  - For standardization implementation `@Transactional(propagation = Propagation.REQUIRES_NEW)` to reduce batch size of main transactions.
   - https://docs.spring.io/spring-framework/docs/current/reference/html/data-access.html#tx-propagation
 
## Related Issue
ACAS-320

## How Has This Been Tested?
Added acasclient test for large (1K) compound load including a compound which errors
Due to Indigo chemistry (open source) not currently implementing standardization I couldn't add acasclient tests for standardization. Instead I used a bbchem server to run dry run standardization. Additionally, I truncated the bbchem_parent_structure table and ran dry/run and full parent restandardization to verify speeds.
Verified that duplicate compounds within the same file are detected via `test_047_load_sdf_with_salts` acasclient tests
Ran all acas client tests