### PR TITLE
Delete lot ACAS-49

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiAnalysisGroupValueController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiAnalysisGroupValueController.java
@@ -151,30 +151,7 @@ public class ApiAnalysisGroupValueController {
 			return new ResponseEntity<String>("[]", headers, HttpStatus.EXPECTATION_FAILED);
 		}
 		if (format != null && format.equalsIgnoreCase("csv")) {
-			StringWriter outFile = new StringWriter();
-			ICsvBeanWriter beanWriter = null;
-			try {
-				beanWriter = new CsvBeanWriter(outFile, CsvPreference.STANDARD_PREFERENCE);
-				final String[] header = AnalysisGroupValueDTO.getColumns();
-				final CellProcessor[] processors = AnalysisGroupValueDTO.getProcessors();
-				beanWriter.writeHeader(header);
-				for (final AnalysisGroupValueDTO agValue : agValues) {
-					beanWriter.write(agValue, header, processors);
-				}
-			} catch (IOException e) {
-				e.printStackTrace();
-			} finally {
-				if (beanWriter != null) {
-					try {
-						beanWriter.close();
-						outFile.flush();
-						outFile.close();
-					} catch (IOException e) {
-						e.printStackTrace();
-					}
-				}
-			}
-			return new ResponseEntity<String>(outFile.toString(), headers, HttpStatus.OK);
+			return new ResponseEntity<String>(AnalysisGroupValueDTO.toCsv(agValues), headers, HttpStatus.OK);
 		} else {
 			return new ResponseEntity<String>(AnalysisGroupValueDTO.toJsonArray(agValues), headers, HttpStatus.OK);
 		}

--- a/src/main/java/com/labsynch/labseer/api/ApiExportController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiExportController.java
@@ -4,9 +4,15 @@ import com.labsynch.labseer.dto.ExportResultDTO;
 import com.labsynch.labseer.dto.SearchResultExportRequestDTO;
 import com.labsynch.labseer.service.ExportService;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -45,4 +51,20 @@ public class ApiExportController {
 		return new ResponseEntity<String>(resultDTO.toJson(), headers, HttpStatus.OK);
 	}
 
+	@RequestMapping(value = "/lotCorpNames", method = RequestMethod.POST, headers = "Accept=application/json")
+	@ResponseBody
+	public ResponseEntity<InputStreamResource> exportLotsByCorpName(@RequestBody List<String> codeNames) {
+		HttpHeaders headers = new HttpHeaders();
+		try{
+			File outputFile = exportService.exportLots(codeNames);
+			InputStream inputStream = new FileInputStream(outputFile);
+			headers.add("Content-Type", "application/octet-stream");
+			headers.add("Content-Disposition", "attachment; filename=" + outputFile.getName());
+			headers.add("Content-Length", String.valueOf(outputFile.length()));
+			return new ResponseEntity<InputStreamResource>(new InputStreamResource(inputStream), headers, HttpStatus.OK);
+		} catch (Exception e) {
+			logger.error("Caught error trying to export lots", e);
+			return new ResponseEntity<InputStreamResource>(headers, HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
 }

--- a/src/main/java/com/labsynch/labseer/api/ApiMetalotController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiMetalotController.java
@@ -236,7 +236,7 @@ public class ApiMetalotController {
 			batchCodeSet.add(lot.getCorpName());
 			CmpdRegBatchCodeDTO batchDTO = lotService.checkForDependentData(batchCodeSet);
 
-			//
+			// Return json
 			String json = batchDTO.toJson();
 			return new ResponseEntity<String>(json, headers, HttpStatus.OK);
 		}

--- a/src/main/java/com/labsynch/labseer/api/ApiMetalotController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiMetalotController.java
@@ -179,7 +179,11 @@ public class ApiMetalotController {
 		return new ResponseEntity<String>(metaLot.toJson(), headers, HttpStatus.OK);
 	}
 
-	// Method to delete a metalot by corp name
+	/**
+	 * Deletes a lot from the database by corp name.  This includes all depedencies such as file lists, experiment data, aliases, orphan iso salts, orphan salt forms and orphan parents.
+	 * @param corpName
+	 * @return
+	 */
 	@Transactional
 	@RequestMapping(value = "/corpName/{corpName}", method = RequestMethod.DELETE)
 	public ResponseEntity<String> deleteMetalotByCorpName(@PathVariable("corpName") String corpName) {
@@ -211,6 +215,11 @@ public class ApiMetalotController {
 		}
 	}
 
+	/**  
+	 * Gets dependencies for the lot with the given lot corp name. This includes experimental data (analysis, subject or treatment), containers, protocol values...etc.
+	 * @param corpName
+	 * @return
+	 */
 	@RequestMapping(value = "checkDependencies/corpName/{corpName}", method = RequestMethod.GET)
 	public ResponseEntity<String> getDependenciesByLotCorpName(@PathVariable("corpName") String corpName) {
 		HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/labsynch/labseer/api/ApiMetalotController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiMetalotController.java
@@ -199,14 +199,14 @@ public class ApiMetalotController {
 		// Get the lot and check for depdencies
 		List<Lot> lots = Lot.findLotsByCorpNameEquals(corpName).getResultList();
 
-		System.out.println("Number of lots found = " + lots.size());		
+		logger.debug("Number of lots found = " + lots.size());		
 
 		if(lots.size() == 0) {
 			logger.info("Did not find a lot with corpName '" + corpName + "'");
 			// Return a 404 error
 			return new ResponseEntity<String>(headers, HttpStatus.NOT_FOUND);
 		} else {
-			logger.info("Found " + lots.size() + " lots with corpName '" + corpName + "'");
+			logger.debug("Found " + lots.size() + " lots with corpName '" + corpName + "'");
 
 			Lot lot = lots.get(0);
 			parentLotService.deleteLot(lot);

--- a/src/main/java/com/labsynch/labseer/domain/AnalysisGroupValue.java
+++ b/src/main/java/com/labsynch/labseer/domain/AnalysisGroupValue.java
@@ -352,7 +352,7 @@ public class AnalysisGroupValue extends AbstractValue {
 		logger.debug("size for batchCodeList: " + batchCodeList.size());
 		logger.debug("size for experimentCodeList: " + experimentCodeList.size());
 		String sqlQuery = "select new com.labsynch.labseer.dto.AnalysisGroupValueDTO(agv.id, prot.id as protocolId, protLabel.labelText as protocolName, "
-				+ "expt.id as experimentId, expt.codeName, el.labelText as prefName, agv.lsType as lsType, agv.lsKind as lsKind, "
+				+ "expt.id as experimentId, expt.codeName, el.labelText as prefName, ag.id as agId, ags.id as agStateId, agv.lsType as lsType, agv.lsKind as lsKind, "
 				+ "agv.stringValue as stringValue, agv.numericValue as numericValue, agv.codeValue as codeValue, agv.dateValue as dateValue, agv.fileValue as fileValue, "
 				+ "agv2.codeValue AS testedLot "
 				+ ", agv2.codeValue as geneId  "

--- a/src/main/java/com/labsynch/labseer/dto/AnalysisGroupValueDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/AnalysisGroupValueDTO.java
@@ -1,5 +1,7 @@
 package com.labsynch.labseer.dto;
 
+import java.io.IOException;
+import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.text.Format;
 import java.text.SimpleDateFormat;
@@ -14,6 +16,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.supercsv.cellprocessor.Optional;
 import org.supercsv.cellprocessor.ift.CellProcessor;
+import org.supercsv.io.CsvBeanWriter;
+import org.supercsv.io.ICsvBeanWriter;
+import org.supercsv.prefs.CsvPreference;
 
 import flexjson.JSONDeserializer;
 import flexjson.JSONSerializer;
@@ -279,6 +284,33 @@ public class AnalysisGroupValueDTO {
 
 	public String toPrettyJson() {
 		return new JSONSerializer().exclude("*.class").prettyPrint(true).serialize(this);
+	}
+
+	public static String toCsv(Collection<AnalysisGroupValueDTO> collection) {
+		StringWriter outFile = new StringWriter();
+		ICsvBeanWriter beanWriter = null;
+		try {
+			beanWriter = new CsvBeanWriter(outFile, CsvPreference.STANDARD_PREFERENCE);
+			final String[] header = AnalysisGroupValueDTO.getColumns();
+			final CellProcessor[] processors = AnalysisGroupValueDTO.getProcessors();
+			beanWriter.writeHeader(header);
+			for (final AnalysisGroupValueDTO agValue : collection) {
+				beanWriter.write(agValue, header, processors);
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+		} finally {
+			if (beanWriter != null) {
+				try {
+					beanWriter.close();
+					outFile.flush();
+					outFile.close();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+			}
+		}
+		return beanWriter.toString();
 	}
 
 	public static AnalysisGroupValueDTO fromJsonToAnalysisGroupValueDTO(String json) {

--- a/src/main/java/com/labsynch/labseer/dto/CmpdRegBatchCodeDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/CmpdRegBatchCodeDTO.java
@@ -37,7 +37,7 @@ public class CmpdRegBatchCodeDTO {
 		this.setBatchCodes(Collections.singletonList(corpName));
     }
 
-    private static final Logger logger = LoggerFactory.getLogger(CmpdRegBatchCodeDTO.class);
+	private static final Logger logger = LoggerFactory.getLogger(CmpdRegBatchCodeDTO.class);
 
 	private Collection<String> batchCodes;
 

--- a/src/main/java/com/labsynch/labseer/dto/CmpdRegBatchCodeDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/CmpdRegBatchCodeDTO.java
@@ -116,7 +116,8 @@ public class CmpdRegBatchCodeDTO {
 				+ "AND es.ignored = false "
 				+ "AND e.ignored = false "
 				+ "AND el.ignored = false "
-				+ "AND ev.codeValue IN :batchCodes";
+				+ "AND ev.codeValue IN :batchCodes "
+				+ "GROUP BY e.codeName, el.labelText, ev.codeValue";
 
 		TypedQuery<Map> q = em.createQuery(sql, Map.class);
 		q.setParameter("batchCodes", this.batchCodes);
@@ -222,7 +223,8 @@ public class CmpdRegBatchCodeDTO {
 				+ "AND ag.ignored = false "
 				+ "AND e.ignored = false "
 				+ "AND el.ignored = false "
-				+ "AND tgv.codeValue IN :batchCodes";
+				+ "AND tgv.codeValue IN :batchCodes "
+				+ "GROUP BY e.codeName, el.labelText, tgv.codeValue";
 
 		TypedQuery<Map> q = em.createQuery(sql, Map.class);
 		q.setParameter("batchCodes", this.batchCodes);

--- a/src/main/java/com/labsynch/labseer/service/ContainerService.java
+++ b/src/main/java/com/labsynch/labseer/service/ContainerService.java
@@ -158,6 +158,8 @@ public interface ContainerService {
 
 	void logicalDeleteContainerArray(Collection<Container> foundContainers);
 
+	void logicalDeleteContainerCodesArray(List<String> containerCodes);
+
 	List<ContainerLocationTreeDTO> getLocationTreeByRootLabel(String rootLabel, Boolean withContainers)
 			throws SQLException;
 

--- a/src/main/java/com/labsynch/labseer/service/ContainerServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ContainerServiceImpl.java
@@ -3511,6 +3511,15 @@ public class ContainerServiceImpl implements ContainerService {
 	}
 
 	@Override
+	@Transactional
+	public void logicalDeleteContainerCodesArray(List<String> containerCodes) {
+		for(String containerCode : containerCodes) {
+			Container container = Container.findContainerByCodeNameEquals(containerCode);
+			container.logicalDelete();
+		}
+	}
+
+	@Override
 	public List<ContainerLocationTreeDTO> getLocationTreeByRootLabel(String rootLabel, Boolean withContainers)
 			throws SQLException {
 		return getLocationTreeDTO(rootLabel, null, null, withContainers);

--- a/src/main/java/com/labsynch/labseer/service/ExperimentService.java
+++ b/src/main/java/com/labsynch/labseer/service/ExperimentService.java
@@ -69,6 +69,8 @@ public interface ExperimentService {
 
 	public boolean deleteAnalysisGroupsByExperiment(Experiment experiment);
 
+	public String deleteExperimentDataByBatchCode(String experimentCode, String batchCode);
+
 	public Collection<ExperimentErrorMessageDTO> findExperimentsByCodeNames(List<String> codeNames);
 
 	public Collection<Experiment> saveLsExperiments(

--- a/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
@@ -1600,14 +1600,15 @@ public class ExperimentServiceImpl implements ExperimentService {
 			experimentCodes.add(experimentCode);
 			
 			// Logical delete analysis groups
+			//First find the analysis groups that have this experiment code and batch code
 			List<AnalysisGroupValueDTO> analysisGroupValueDTOs = AnalysisGroupValue.findAnalysisGroupValueDTO(batchCodes, experimentCodes).getResultList();
 
-			// Get unique set of analsyis group ids
+			// Second, get unique set of analsyis group ids
 			Set<Long> analysisGroupIds = new HashSet<Long>();
 			for (AnalysisGroupValueDTO analysisGroupValueDTO : analysisGroupValueDTOs) {
 				analysisGroupIds.add(analysisGroupValueDTO.getAgId());
 			}
-			// Delete analysis group values
+			// Finally, delete analysis group values
 			for (Long analysisGroupId : analysisGroupIds) {
 				logger.info("Logically deleting analysis group: " + analysisGroupId);
 				AnalysisGroup.findAnalysisGroup(analysisGroupId).logicalDelete();

--- a/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
@@ -1596,7 +1596,6 @@ public class ExperimentServiceImpl implements ExperimentService {
 			
 			// Logical delete analysis groups
 			List<AnalysisGroupValueDTO> analysisGroupValueDTOs = AnalysisGroupValue.findAnalysisGroupValueDTO(batchCodes, experimentCodes).getResultList();
-			csvString = AnalysisGroupValueDTO.toCsv(analysisGroupValueDTOs);
 
 			// Get unique set of analsyis group ids
 			Set<Long> analysisGroupIds = new HashSet<Long>();

--- a/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
@@ -1579,6 +1579,11 @@ public class ExperimentServiceImpl implements ExperimentService {
 		// return isSoftDeleted;
 	}
 
+	/** 
+	 * Given an experiment code and batch code, deletes the experimental data associated with the experiment and batch and returns a string representation of the data that was deleted.
+	 * @param experimentCode
+	 * @param batchCode
+	**/
 	@Override
 	@Transactional
 	public String deleteExperimentDataByBatchCode(String experimentCode, String batchCode) {

--- a/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
@@ -1597,10 +1597,16 @@ public class ExperimentServiceImpl implements ExperimentService {
 			// Logical delete analysis groups
 			List<AnalysisGroupValueDTO> analysisGroupValueDTOs = AnalysisGroupValue.findAnalysisGroupValueDTO(batchCodes, experimentCodes).getResultList();
 			csvString = AnalysisGroupValueDTO.toCsv(analysisGroupValueDTOs);
-			// Delete analysis group values
+
+			// Get unique set of analsyis group ids
+			Set<Long> analysisGroupIds = new HashSet<Long>();
 			for (AnalysisGroupValueDTO analysisGroupValueDTO : analysisGroupValueDTOs) {
-				logger.info("Logically deleting analysis group: " + analysisGroupValueDTO.getAgId());
-				AnalysisGroup.findAnalysisGroup(analysisGroupValueDTO.getAgId()).logicalDelete();
+				analysisGroupIds.add(analysisGroupValueDTO.getAgId());
+			}
+			// Delete analysis group values
+			for (Long analysisGroupId : analysisGroupIds) {
+				logger.info("Logically deleting analysis group: " + analysisGroupId);
+				AnalysisGroup.findAnalysisGroup(analysisGroupId).logicalDelete();
 			}
 		}
 		return csvString;

--- a/src/main/java/com/labsynch/labseer/service/ExportService.java
+++ b/src/main/java/com/labsynch/labseer/service/ExportService.java
@@ -1,10 +1,14 @@
 package com.labsynch.labseer.service;
 
+import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 
 import com.labsynch.labseer.dto.ExportResultDTO;
 import com.labsynch.labseer.dto.SearchResultExportRequestDTO;
+import com.labsynch.labseer.exceptions.CmpdRegMolFormatException;
 
 public interface ExportService {
 
@@ -12,5 +16,7 @@ public interface ExportService {
 			throws FileNotFoundException;
 
 	ExportResultDTO exportLots(String filePath, Collection<String> lotCorpNames) throws FileNotFoundException;
+
+	File exportLots(List<String> lotCorpNames) throws IllegalArgumentException, IOException, CmpdRegMolFormatException;
 
 }

--- a/src/main/java/com/labsynch/labseer/service/ExportServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ExportServiceImpl.java
@@ -1,5 +1,6 @@
 package com.labsynch.labseer.service;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -52,6 +53,20 @@ public class ExportServiceImpl implements ExportService {
 		}
 		ExportResultDTO exportResult = exportLots(searchResultExportRequestDTO.getFilePath(), lotCorpNames);
 		return exportResult;
+	}
+	
+	@Override
+	public File exportLots(List<String> lotCorpNames) throws IllegalArgumentException, IOException, CmpdRegMolFormatException {
+		Collection<Lot> foundLots = getLotsByCorpNames(lotCorpNames);
+		Collection<LotDTO> lotDTOs = new HashSet<LotDTO>();
+		for (Lot foundLot : foundLots) {
+			LotDTO lotDTO = new LotDTO(foundLot);
+			lotDTOs.add(lotDTO);
+		}
+		logger.debug("Attempting to export " + lotDTOs.size() + " lots");
+		File tempFile = File.createTempFile("export-lots-", ".sdf");
+		writeLotsToSDF(tempFile.getAbsolutePath().toString(), lotDTOs);
+		return tempFile;
 	}
 
 	@Override

--- a/src/main/java/com/labsynch/labseer/service/ExportServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ExportServiceImpl.java
@@ -55,6 +55,11 @@ public class ExportServiceImpl implements ExportService {
 		return exportResult;
 	}
 	
+	/** 
+	 * Exports an SDF file of the lot corp names provided. The SDF file is written to a file.
+	 * @param lotCorpNames
+	 * @return File of the SDF data representing the lots
+	**/
 	@Override
 	public File exportLots(List<String> lotCorpNames) throws IllegalArgumentException, IOException, CmpdRegMolFormatException {
 		Collection<Lot> foundLots = getLotsByCorpNames(lotCorpNames);

--- a/src/main/java/com/labsynch/labseer/service/LotService.java
+++ b/src/main/java/com/labsynch/labseer/service/LotService.java
@@ -44,9 +44,8 @@ public interface LotService {
 
 	public CmpdRegBatchCodeDTO checkForDependentData(Set<String> lotCorpNames);
 
-	public void deleteLots(Collection<Lot> lots );
+	public void deleteLots(Collection<Lot> lots);
 
-	public void deleteLot(Lot lot );
-	
+	public void deleteLot(Lot lot);
 
 }

--- a/src/main/java/com/labsynch/labseer/service/LotService.java
+++ b/src/main/java/com/labsynch/labseer/service/LotService.java
@@ -44,4 +44,9 @@ public interface LotService {
 
 	public CmpdRegBatchCodeDTO checkForDependentData(Set<String> lotCorpNames);
 
+	public void deleteLots(Collection<Lot> lots );
+
+	public void deleteLot(Lot lot );
+	
+
 }

--- a/src/main/java/com/labsynch/labseer/service/LotService.java
+++ b/src/main/java/com/labsynch/labseer/service/LotService.java
@@ -1,11 +1,11 @@
 package com.labsynch.labseer.service;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
 import com.labsynch.labseer.domain.Lot;
+import com.labsynch.labseer.dto.CmpdRegBatchCodeDTO;
 import com.labsynch.labseer.dto.LotDTO;
 import com.labsynch.labseer.dto.LotsByProjectDTO;
 import com.labsynch.labseer.dto.PreferredNameDTO;
@@ -41,5 +41,7 @@ public interface LotService {
 	int generateParentLotNumber(Lot lot);
 
 	public Collection<PreferredNameDTO> getPreferredNames(Collection<PreferredNameDTO> preferredNameDTOs);
+
+	public CmpdRegBatchCodeDTO checkForDependentData(Set<String> lotCorpNames);
 
 }

--- a/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
@@ -555,9 +555,15 @@ public class LotServiceImpl implements LotService {
 		
 	}
 
+	/**
+	 * Delete the lot and all of its children. This method is specific for the lot and does not clean up the orphaned salt forms , iso salts or parents. See ParentLotServiceImpl.deleteLot for the recursive delete of the parent lot.
+	 * 
+	 * @param lot
+	 */
 	@Override
 	@Transactional
 	public void deleteLot(Lot lot) {
+
 
 		// Check for dependent data
 		Set<String> batchCodeSet = new HashSet<String>();

--- a/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
@@ -1,8 +1,9 @@
 package com.labsynch.labseer.service;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -22,6 +23,7 @@ import com.labsynch.labseer.domain.SaltForm;
 import com.labsynch.labseer.domain.SolutionUnit;
 import com.labsynch.labseer.domain.Unit;
 import com.labsynch.labseer.domain.Vendor;
+import com.labsynch.labseer.dto.CmpdRegBatchCodeDTO;
 import com.labsynch.labseer.dto.LotDTO;
 import com.labsynch.labseer.dto.LotsByProjectDTO;
 import com.labsynch.labseer.dto.PreferredNameDTO;
@@ -37,9 +39,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class LotServiceImpl implements LotService {
 
 	@Autowired
-	private ChemStructureService chemService;
-
-	@Autowired
 	private CorpNameService corpNameService;
 
 	@Autowired
@@ -50,6 +49,9 @@ public class LotServiceImpl implements LotService {
 
 	@Autowired
 	private PropertiesUtilService propertiesUtilService;
+
+	@Autowired
+	private ContainerService containerService;
 
 	private static final Logger logger = LoggerFactory.getLogger(LotServiceImpl.class);
 
@@ -511,6 +513,20 @@ public class LotServiceImpl implements LotService {
 			preferredNameDTO.setPreferredName(preferredName);
 		}
 		return preferredNameDTOs;
+	}
+
+	@Override
+	public CmpdRegBatchCodeDTO checkForDependentData(Set<String> lotCorpNames) {
+		CmpdRegBatchCodeDTO cmpdRegBatchCodeDTO = new CmpdRegBatchCodeDTO(lotCorpNames);
+
+		cmpdRegBatchCodeDTO.checkForDependentData();
+
+		if(cmpdRegBatchCodeDTO.getLinkedDataExists()) {
+			List<String> batchCodeList = new ArrayList<String>();
+			batchCodeList.addAll(lotCorpNames);
+			cmpdRegBatchCodeDTO.setLinkedContainers(containerService.getContainerDTOsByBatchCodes(batchCodeList));
+		}
+		return cmpdRegBatchCodeDTO;
 	}
 
 }

--- a/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -17,7 +16,6 @@ import java.util.regex.Pattern;
 
 import javax.persistence.NoResultException;
 import javax.persistence.NonUniqueResultException;
-import javax.persistence.TypedQuery;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.labsynch.labseer.domain.CorpName;
 import com.labsynch.labseer.domain.FileList;
 import com.labsynch.labseer.domain.IsoSalt;
 import com.labsynch.labseer.domain.Lot;

--- a/src/main/java/com/labsynch/labseer/service/ParentLotService.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentLotService.java
@@ -14,4 +14,6 @@ public interface ParentLotService {
 
 	public Collection<Lot> getLotsByParentCorpName(String parentCorpName);
 
+	public void deleteLot(Lot lot);
+
 }

--- a/src/main/java/com/labsynch/labseer/service/ParentLotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentLotServiceImpl.java
@@ -115,9 +115,14 @@ public class ParentLotServiceImpl implements ParentLotService {
 
 	}
 
+	/**
+	 * Deletes a lot from the database including it's children and any orphaned iso salts, saltforms and parents.
+	 * @param lot The lot to delete
+	 * @return
+	 */
 	@Override
 	public void deleteLot(Lot lot) {
-		// Deletes lot and orphan salt forms and orphan parents of the lot
+
 		Parent parent = Parent.findParent(lot.getParent().getId());
 		Boolean canDeleteSaltForm = true;
 		Boolean canDeleteParent = true;

--- a/src/main/java/com/labsynch/labseer/service/ParentService.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentService.java
@@ -21,4 +21,6 @@ public interface ParentService {
 
 	String updateParentMetaArray(String jsonInput);
 
+	public void deleteParent(Parent parent );
+
 }

--- a/src/main/java/com/labsynch/labseer/service/ParentServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentServiceImpl.java
@@ -12,9 +12,11 @@ import com.labsynch.labseer.chemclasses.CmpdRegMoleculeFactory;
 import com.labsynch.labseer.chemclasses.CmpdRegSDFWriterFactory;
 import com.labsynch.labseer.domain.Author;
 import com.labsynch.labseer.domain.CompoundType;
+import com.labsynch.labseer.domain.Lot;
 import com.labsynch.labseer.domain.Parent;
 import com.labsynch.labseer.domain.ParentAlias;
 import com.labsynch.labseer.domain.ParentAnnotation;
+import com.labsynch.labseer.domain.SaltForm;
 import com.labsynch.labseer.domain.StereoCategory;
 import com.labsynch.labseer.dto.CodeTableDTO;
 import com.labsynch.labseer.dto.ParentAliasDTO;
@@ -57,6 +59,12 @@ public class ParentServiceImpl implements ParentService {
 
 	@Autowired
 	public CmpdRegMoleculeFactory cmpdRegMoleculeFactory;
+
+	@Autowired
+	public LotService lotService;
+
+	@Autowired
+	public SaltFormService saltFormService;
 
 	@Override
 	@Transactional
@@ -319,6 +327,20 @@ public class ParentServiceImpl implements ParentService {
 		parent.setParentAliases(newParentAliases);
 
 		return parent;
+	}
+
+	@Override
+	@Transactional
+	public void deleteParent(Parent parent) {
+		for(SaltForm s : parent.getSaltForms()) {
+			saltFormService.deleteSaltForm(s);
+		}
+
+		chemStructureService.deleteStructure(StructureType.PARENT, parent.getCdId());
+		for (ParentAlias alias : parent.getParentAliases()) {
+			alias.remove();
+		}
+		parent.remove();
 	}
 
 }

--- a/src/main/java/com/labsynch/labseer/service/SaltFormService.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltFormService.java
@@ -19,4 +19,6 @@ public interface SaltFormService {
 			throws SaltFormMolFormatException, DupeSaltFormStructureException;
 
 	public double calculateSaltWeight(SaltForm saltForm);
+
+	public void deleteSaltForm(SaltForm saltForm);
 }


### PR DESCRIPTION
## Description
 - Added service to delete a lot including dependencies:
   - If remaining is orphan salt form/iso salts then delete it
   - If remaining is orphan parent then delete it
   - Experiment analysis groups
   - Containers
 - Added some functionality around dependency checking
 - Route to export to SDF via output stream rather than json with string file

## Related Issue
ACAS-49

## How Has This Been Tested?
Ran acas client tests