### PR TITLE
ACAS w/BBChem not producing standardized structures

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureService.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureService.java
@@ -24,10 +24,6 @@ public interface BBChemStructureService {
     public HashMap<String, BBChemParentStructure> getProcessedStructures(HashMap<String, String> structures,
             Boolean includeFingerprints) throws CmpdRegMolFormatException;
 
-    // HashMap<OriginalKey, Entry<PreprocessorStatus, PreprocessorStructure>>
-    public HashMap<String, Entry<String, String>> getPreprocessedStructures(HashMap<String, String> structures)
-            throws CmpdRegMolFormatException, IOException;
-
     public String getSDF(BBChemParentStructure structure) throws IOException;
 
     public List<BBChemParentStructure> parseSDF(String molfile) throws CmpdRegMolFormatException;


### PR DESCRIPTION
## Description
Processor does its own standardization of the molecule and if you don't pass standardization configs, it will apply a default standardization before doing hashing.  In this PR, I removed the call to preprocessor as the output was being thrown out anyway and instead just call the process route and include the configured standardization rules.

## Related Issue
ACAS-339

## How Has This Been Tested?
Ran dry run standardization on a test server and verified the dry run structure looks like structure returned from calling the preprocessor via command line using the same mol and processor configs.