### PR TITLE
Add service to swap two parent structures.

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiParentController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiParentController.java
@@ -4,9 +4,13 @@ import java.util.Collection;
 
 import com.labsynch.labseer.domain.Parent;
 import com.labsynch.labseer.dto.CodeTableDTO;
+import com.labsynch.labseer.dto.ParentDTO;
 import com.labsynch.labseer.dto.ParentEditDTO;
+import com.labsynch.labseer.dto.ParentSwapStructuresDTO;
 import com.labsynch.labseer.dto.ParentValidationDTO;
 import com.labsynch.labseer.service.ParentService;
+import com.labsynch.labseer.service.ParentStructureService;
+import com.labsynch.labseer.service.ParentSwapStructuresService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +33,9 @@ public class ApiParentController {
 
 	@Autowired
 	public ParentService parentService;
+
+	@Autowired
+	public ParentSwapStructuresService parentSwapStructuresService;
 
 	@Transactional
 	@RequestMapping(value = "/validateParent", method = RequestMethod.POST, headers = "Accept=application/json")
@@ -63,6 +70,31 @@ public class ApiParentController {
 			return new ResponseEntity<String>(CodeTableDTO.toJsonArray(affectedLots), headers, HttpStatus.OK);
 		} catch (Exception e) {
 			logger.error("Caught error trying to update parent", e);
+			return new ResponseEntity<String>(headers, HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	@Transactional
+	@RequestMapping(value = "/swapParentStructures", method = RequestMethod.POST, headers = "Accept=application/json")
+	@ResponseBody
+	public ResponseEntity<String> swapParentStructures(@RequestBody String json) {
+		HttpHeaders headers = new HttpHeaders();
+		ParentSwapStructuresDTO parentSwapStructuresDTO = ParentSwapStructuresDTO.fromJSONToParentSwapStructuresDTO(json);
+
+		String msg = String.format(
+			"corpName1=%s & corpName2=%s swap: ",
+			parentSwapStructuresDTO.getCorpName1(),
+			parentSwapStructuresDTO.getCorpName2());
+		try {
+			if (parentSwapStructuresService.swapParentStructures(parentSwapStructuresDTO)) {
+				logger.info(msg + "success");
+				return new ResponseEntity<String>(headers, HttpStatus.OK);
+			} else {
+				logger.info(msg + "failure");
+				return new ResponseEntity<String>(headers, HttpStatus.INTERNAL_SERVER_ERROR);
+			}
+		} catch (Exception e) {
+			logger.error("Caught error while trying to swap parent structures", e);
 			return new ResponseEntity<String>(headers, HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 	}

--- a/src/main/java/com/labsynch/labseer/api/ApiParentController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiParentController.java
@@ -4,12 +4,10 @@ import java.util.Collection;
 
 import com.labsynch.labseer.domain.Parent;
 import com.labsynch.labseer.dto.CodeTableDTO;
-import com.labsynch.labseer.dto.ParentDTO;
 import com.labsynch.labseer.dto.ParentEditDTO;
 import com.labsynch.labseer.dto.ParentSwapStructuresDTO;
 import com.labsynch.labseer.dto.ParentValidationDTO;
 import com.labsynch.labseer.service.ParentService;
-import com.labsynch.labseer.service.ParentStructureService;
 import com.labsynch.labseer.service.ParentSwapStructuresService;
 
 import org.slf4j.Logger;

--- a/src/main/java/com/labsynch/labseer/dto/ParentSwapStructuresDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/ParentSwapStructuresDTO.java
@@ -36,7 +36,7 @@ public class ParentSwapStructuresDTO {
     }
 
     public String toJson() {
-        return new JSONSerializer().include("corpName1", "corpName2", "username").serialize(this);
+        return new JSONSerializer().serialize(this);
     }
 
     public static ParentSwapStructuresDTO fromJSONToParentSwapStructuresDTO(String json) {

--- a/src/main/java/com/labsynch/labseer/dto/ParentSwapStructuresDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/ParentSwapStructuresDTO.java
@@ -9,6 +9,8 @@ public class ParentSwapStructuresDTO {
 
     private String corpName2;
 
+    private String username;
+
     public String getCorpName1() {
         return this.corpName1;
     }
@@ -25,8 +27,16 @@ public class ParentSwapStructuresDTO {
         this.corpName2 = corpName2;
     }
 
+    public String getUsername() {
+        return this.username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
     public String toJson() {
-        return new JSONSerializer().include("corpName1", "corpName2").serialize(this);
+        return new JSONSerializer().include("corpName1", "corpName2", "username").serialize(this);
     }
 
     public static ParentSwapStructuresDTO fromJSONToParentSwapStructuresDTO(String json) {

--- a/src/main/java/com/labsynch/labseer/dto/ParentSwapStructuresDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/ParentSwapStructuresDTO.java
@@ -1,0 +1,35 @@
+package com.labsynch.labseer.dto;
+
+import flexjson.JSONDeserializer;
+import flexjson.JSONSerializer;
+
+public class ParentSwapStructuresDTO {
+
+    private String corpName1;
+
+    private String corpName2;
+
+    public String getCorpName1() {
+        return this.corpName1;
+    }
+
+    public void setCorpName1(String corpName1) {
+        this.corpName1 = corpName1;
+    }
+
+    public String getCorpName2() {
+        return this.corpName2;
+    }
+
+    public void setCorpName2(String corpName2) {
+        this.corpName2 = corpName2;
+    }
+
+    public String toJson() {
+        return new JSONSerializer().include("corpName1", "corpName2").serialize(this);
+    }
+
+    public static ParentSwapStructuresDTO fromJSONToParentSwapStructuresDTO(String json) {
+        return new JSONDeserializer<ParentSwapStructuresDTO>().use(null, ParentSwapStructuresDTO.class).deserialize(json);
+    }
+}

--- a/src/main/java/com/labsynch/labseer/dto/ParentValidationDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/ParentValidationDTO.java
@@ -60,6 +60,10 @@ public class ParentValidationDTO {
         this.dupeParents = dupeParents;
     }
 
+    public boolean hasErrors() {
+        return !(this.errors.isEmpty());
+    }
+
     public Collection<ErrorMessage> getErrors() {
         return this.errors;
     }

--- a/src/main/java/com/labsynch/labseer/service/ParentSwapStructuresService.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentSwapStructuresService.java
@@ -4,6 +4,6 @@ import com.labsynch.labseer.dto.ParentSwapStructuresDTO;
 
 public interface ParentSwapStructuresService {
 
-    public boolean swapParentStructures(ParentSwapStructuresDTO parentSwapStructuresDTO);
+    public String swapParentStructures(ParentSwapStructuresDTO parentSwapStructuresDTO);
 
 }

--- a/src/main/java/com/labsynch/labseer/service/ParentSwapStructuresService.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentSwapStructuresService.java
@@ -1,0 +1,9 @@
+package com.labsynch.labseer.service;
+
+import com.labsynch.labseer.dto.ParentSwapStructuresDTO;
+
+public interface ParentSwapStructuresService {
+
+    public boolean swapParentStructures(ParentSwapStructuresDTO parentSwapStructuresDTO);
+
+}

--- a/src/main/java/com/labsynch/labseer/service/ParentSwapStructuresServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentSwapStructuresServiceImpl.java
@@ -27,8 +27,8 @@ public class ParentSwapStructuresServiceImpl implements ParentSwapStructuresServ
 	public ChemStructureService chemStructureService;
 
     @Override
-    public boolean swapParentStructures(ParentSwapStructuresDTO parentSwapStructuresDTO) {
-        String corpName1 = parentSwapStructuresDTO.getCorpName1();
+    public String swapParentStructures(ParentSwapStructuresDTO parentSwapStructuresDTO) {
+		String corpName1 = parentSwapStructuresDTO.getCorpName1();
 		String corpName2 = parentSwapStructuresDTO.getCorpName2();
 
 		Parent parent1;
@@ -37,8 +37,9 @@ public class ParentSwapStructuresServiceImpl implements ParentSwapStructuresServ
 			parent1 = Parent.findParentsByCorpNameEquals(corpName1).getSingleResult();
 			parent2 = Parent.findParentsByCorpNameEquals(corpName2).getSingleResult();
 		} catch (Exception e) {
-			logger.error("Caught error while fetching parent", e);
-            return false;
+			String msg = "Caught error while fetching parent";
+			logger.error(msg, e);
+			return msg;
 		}
 
 		// Check if there are existing errors or duplicates.
@@ -48,18 +49,17 @@ public class ParentSwapStructuresServiceImpl implements ParentSwapStructuresServ
 			validationDTO1 = parentService.validateUniqueParent(parent1);
 			validationDTO2 = parentService.validateUniqueParent(parent2);
 		} catch (Exception e) {
-			logger.error("Caught error while trying to validate parent", e);
-			return false;
+			String msg = "Caught error while trying to validate parent";
+			logger.error(msg, e);
+			return msg;
 		}
+
 		if (validationDTO1.hasErrors()) {
-			logger.error(String.format("%s has existing errors: %s", corpName1, validationDTO1.getErrors()));
-			return false;
+			return String.format("%s has existing errors: %s", corpName1, validationDTO1.getErrors());
 		} else if (validationDTO2.hasErrors()) {
-			logger.error(String.format("%s has existing errors: %s", corpName2, validationDTO2.getErrors()));
-			return false;
+			return String.format("%s has existing errors: %s", corpName2, validationDTO2.getErrors());
 		} else if (!validationDTO1.isParentUnique() || !validationDTO2.isParentUnique()) {
-			logger.error(String.format("%s or %s have existing duplicates.", corpName1, corpName2));
-			return false;
+			return String.format("%s or %s have existing duplicates.", corpName1, corpName2);
 		}
 
 		// Check if duplicates get introduced on swapping the structures.
@@ -70,8 +70,9 @@ public class ParentSwapStructuresServiceImpl implements ParentSwapStructuresServ
 			dupeParents2 = getParents(parent1.getMolStructure(), parent2.getStereoCategory().getCode(), parent2.getStereoComment());
 		} catch (Exception e) {
 			// In case of any exceptions, abort the swapping.
-			logger.error("Error finding parents to check for duplication", e);
-			return false;
+			String msg = "Error finding parents to check for duplication";
+			logger.error(msg, e);
+			return msg;
 		}
 		// Duplicate with the items being swapped is okay.
 		dupeParents1.remove(corpName1);
@@ -87,10 +88,11 @@ public class ParentSwapStructuresServiceImpl implements ParentSwapStructuresServ
 			parent2.setModifiedDate(new Date());
 			parent2.setModifiedBy(parentSwapStructuresDTO.getUsername());
 			logger.info(String.format("Swapping corpName1=%s & corpName2=%s swap successful.", corpName1, corpName2));
-			return true;
+			return "";
 		} else {
-			logger.error(String.format("Swapping corpName1=%s & corpName2=%s creates duplicates.", corpName1, corpName2));
-			return false;
+			String msg = String.format("Swapping corpName1=%s & corpName2=%s creates duplicates.", corpName1, corpName2);
+			logger.error(msg);
+			return msg;
 		}
     }
 

--- a/src/main/java/com/labsynch/labseer/service/ParentSwapStructuresServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentSwapStructuresServiceImpl.java
@@ -1,6 +1,7 @@
 package com.labsynch.labseer.service;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashSet;
 
 import org.slf4j.Logger;
@@ -80,7 +81,9 @@ public class ParentSwapStructuresServiceImpl implements ParentSwapStructuresServ
 		if (dupeParents1.isEmpty() && dupeParents2.isEmpty()) {
 			String mol = parent1.getMolStructure();
 			parent1.setMolStructure(parent2.getMolStructure());
+			parent1.setModifiedDate(new Date());
 			parent2.setMolStructure(mol);
+			parent2.setModifiedDate(new Date());
 			logger.info(String.format("Swapping corpName1=%s & corpName2=%s swap successful.", corpName1, corpName2));
 			return true;
 		} else {

--- a/src/main/java/com/labsynch/labseer/service/ParentSwapStructuresServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentSwapStructuresServiceImpl.java
@@ -77,7 +77,7 @@ public class ParentSwapStructuresServiceImpl implements ParentSwapStructuresServ
 		dupeParents1.remove(corpName2);
 		dupeParents2.remove(corpName1);
 		dupeParents2.remove(corpName2);
-		if (dupeParents1.size() == 0 && dupeParents2.size() == 0) {
+		if (dupeParents1.isEmpty() && dupeParents2.isEmpty()) {
 			String mol = parent1.getMolStructure();
 			parent1.setMolStructure(parent2.getMolStructure());
 			parent2.setMolStructure(mol);
@@ -90,7 +90,7 @@ public class ParentSwapStructuresServiceImpl implements ParentSwapStructuresServ
     }
 
 	private HashSet<String> getParents(String molStructure, String stereoCategory, String stereoComment) throws CmpdRegMolFormatException {
-		ArrayList<Parent> matchingParents = new ArrayList<Parent>();
+		ArrayList<Parent> matchingParents = new ArrayList<>();
 		int[] parentCdIds = chemStructureService.checkDupeMol(molStructure, StructureType.PARENT);
 		for (int parentCdId : parentCdIds) {
 			for (Parent parent : Parent.findParentsByCdId(parentCdId).getResultList()) {
@@ -99,16 +99,15 @@ public class ParentSwapStructuresServiceImpl implements ParentSwapStructuresServ
 					continue;
 				}
 				String parentStereoComment = parent.getStereoComment();
-				if (parentStereoComment == null && stereoComment == null) {
-					matchingParents.add(parent);
-				} else if (parentStereoComment == null || stereoComment == null) {
-					continue;
-				} else if (parentStereoComment.equalsIgnoreCase(stereoComment)) {
+				if (
+					(parentStereoComment == null || parentStereoComment.isEmpty()) &&
+					(stereoComment == null || stereoComment.isEmpty()) ||
+					(parentStereoComment != null && stereoComment != null && parentStereoComment.equalsIgnoreCase(stereoComment))) {
 					matchingParents.add(parent);
 				}
 			}
 		}
-		HashSet<String> matchingParentCorpNames = new HashSet<String>();
+		HashSet<String> matchingParentCorpNames = new HashSet<>();
 		for (Parent parent : matchingParents) {
 			matchingParentCorpNames.add(parent.getCorpName());
 		}

--- a/src/main/java/com/labsynch/labseer/service/ParentSwapStructuresServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentSwapStructuresServiceImpl.java
@@ -82,8 +82,10 @@ public class ParentSwapStructuresServiceImpl implements ParentSwapStructuresServ
 			String mol = parent1.getMolStructure();
 			parent1.setMolStructure(parent2.getMolStructure());
 			parent1.setModifiedDate(new Date());
+			parent1.setModifiedBy(parentSwapStructuresDTO.getUsername());
 			parent2.setMolStructure(mol);
 			parent2.setModifiedDate(new Date());
+			parent2.setModifiedBy(parentSwapStructuresDTO.getUsername());
 			logger.info(String.format("Swapping corpName1=%s & corpName2=%s swap successful.", corpName1, corpName2));
 			return true;
 		} else {

--- a/src/main/java/com/labsynch/labseer/service/ParentSwapStructuresServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentSwapStructuresServiceImpl.java
@@ -1,0 +1,91 @@
+package com.labsynch.labseer.service;
+
+import java.util.Collection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.labsynch.labseer.domain.Parent;
+import com.labsynch.labseer.dto.ParentDTO;
+import com.labsynch.labseer.dto.ParentSwapStructuresDTO;
+import com.labsynch.labseer.dto.ParentValidationDTO;
+
+@Service
+public class ParentSwapStructuresServiceImpl implements ParentSwapStructuresService {
+
+    Logger logger = LoggerFactory.getLogger(ParentSwapStructuresServiceImpl.class);
+
+    @Autowired
+    public ParentService parentService;
+
+    @Override
+    public boolean swapParentStructures(ParentSwapStructuresDTO parentSwapStructuresDTO) {
+        String corpName1 = parentSwapStructuresDTO.getCorpName1();
+		String corpName2 = parentSwapStructuresDTO.getCorpName2();
+
+		Parent parent1;
+		Parent parent2;
+		try {
+			parent1 = Parent.findParentsByCorpNameEquals(corpName1).getSingleResult();
+			parent2 = Parent.findParentsByCorpNameEquals(corpName2).getSingleResult();
+		} catch (Exception e) {
+			logger.error("Caught error while fetching parent", e);
+            return false;
+		}
+
+		ParentValidationDTO validationDTO1;
+		ParentValidationDTO validationDTO2;
+		try {
+			validationDTO1 = parentService.validateUniqueParent(parent1);
+			validationDTO2 = parentService.validateUniqueParent(parent2);
+		} catch (Exception e) {
+			logger.error("Caught error trying to validate parent", e);
+			return false;
+		}
+
+		// In case of any valdation errors, abort.
+		if (validationDTO1.hasErrors()) {
+			logger.error("validationDTO1 has errors", validationDTO1.getErrors());
+			return false;
+		} else if (validationDTO2.hasErrors()) {
+			logger.error("validationDTO2 has errors", validationDTO2.getErrors());
+			return false;
+		}
+
+		// Check if they are duplicates of each other.
+		Collection<ParentDTO> dupeParents1 = validationDTO1.getDupeParents();
+		Collection<ParentDTO> dupeParents2 = validationDTO1.getDupeParents();
+
+		boolean canSwap = false;
+		if (validationDTO1.isParentUnique() && validationDTO2.isParentUnique()) {
+			canSwap = true;
+		} else if (
+			dupeParents1.size() == 1 &&
+			dupeParents2.size() == 1 &&
+			dupeParents1.iterator().next().getCorpName() == dupeParents2.iterator().next().getCorpName()) {
+			canSwap = true;
+		}
+
+		if (canSwap) {
+			String mol = parent1.getMolStructure();
+			parent1.setMolStructure(parent2.getMolStructure());
+			parent2.setMolStructure(mol);
+		} else {
+			logger.error(String.format("corpName1=%s & corpName2=%s have other duplicates.", corpName1, corpName2));
+			return false;
+		}
+
+		if (canSwap) {
+			try {
+				parentService.updateParent(parent1);
+				parentService.updateParent(parent2);
+			} catch (Exception e) {
+				logger.error("Caught error trying to update parents", e);
+				return false;
+			}
+		}
+		return canSwap;
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Create the service to swap two parent structures. Swapping of structures is only allowed if the two parent structures are unique or just duplicates of each other than the swapping.

## Description
<!--- Describe your changes in detail -->
Recommended workflow to check:
1. ParentSwapStructuresDTO > ParentSwapStructures
2.  APIParentController > swapParentStructures
3. ParentSwapStructureServiceImpl > swapParentStructurs.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACAS-286](https://jira.schrodinger.com/browse/ACAS-286).

## How Has This Been Tested?
<!--- Describe how this has been tested -->
See testing section in the acas PR.

## TODO
~I am seeing issues when querying duplicate parents i.e in the cases where duplicate parents do exist(confirmed via the `/validateParent` API). I am not getting the duplicate parents listed in the `swapParentStructures` service.~