### PR TITLE
Reparent lot route updates ACAS-216-reparent-lot

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiParentLotController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiParentLotController.java
@@ -129,13 +129,14 @@ public class ApiParentLotController {
 
 	@RequestMapping(value = "/reparentLot", method = RequestMethod.POST, headers = "Accept=application/json")
 	@ResponseBody
-	public ResponseEntity<String> reparentLot(@RequestBody String json) {
+	public ResponseEntity<String> reparentLot(@RequestBody String json, @RequestParam(value = "dryRun", required = false, defaultValue = "true") Boolean dryRun) {
 		HttpHeaders headers = new HttpHeaders();
 		headers.add("Content-Type", "application/json; charset=utf-8");
 		try {
 			ReparentLotDTO lotDTO = ReparentLotDTO.fromJsonToReparentLotDTO(json);
 			ReparentLotResponseDTO reparentLotDTO = lotService.reparentLot(lotDTO.getLotCorpName(), lotDTO.getParentCorpName(),
-					lotDTO.getModifiedBy(), true, true);
+				lotDTO.getModifiedBy(), true, true, dryRun);
+
 			return new ResponseEntity<String>(reparentLotDTO.toJson(), headers, HttpStatus.OK);
 		} catch (DupeLotException e) {
 			logger.error("Error saving lot with duplicate name", e);
@@ -149,14 +150,14 @@ public class ApiParentLotController {
 	@Transactional
 	@RequestMapping(value = "/reparentLot/jsonArray", method = RequestMethod.POST, headers = "Accept=application/json")
 	@ResponseBody
-	public ResponseEntity<String> reparentLotArray(@RequestBody String json) {
+	public ResponseEntity<String> reparentLotArray(@RequestBody String json, @RequestParam(value = "dryRun", required = false, defaultValue = "true") Boolean dryRun) {
 		HttpHeaders headers = new HttpHeaders();
 		headers.add("Content-Type", "application/json; charset=utf-8");
 		int lotCount = 0;
 		try {
 			Collection<ReparentLotDTO> lotDTOs = ReparentLotDTO.fromJsonArrayToReparentLoes(json);
 			for (ReparentLotDTO lotDTO : lotDTOs) {
-				lotService.reparentLot(lotDTO.getLotCorpName(), lotDTO.getParentCorpName(), lotDTO.getModifiedBy(), true, true);
+				lotService.reparentLot(lotDTO.getLotCorpName(), lotDTO.getParentCorpName(), lotDTO.getModifiedBy(), true, true, dryRun);
 				lotCount++;
 			}
 			return new ResponseEntity<String>("number of lots reparented: " + lotCount, headers, HttpStatus.OK);

--- a/src/main/java/com/labsynch/labseer/api/ApiParentLotController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiParentLotController.java
@@ -113,6 +113,7 @@ public class ApiParentLotController {
 		}
 	}
 
+	@Transactional
 	@RequestMapping(value = "/updateLot/metadata/jsonArray", method = RequestMethod.POST, headers = "Accept=application/json")
 	@ResponseBody
 	public ResponseEntity<String> updateLotMetaArray(@RequestBody String json) {

--- a/src/main/java/com/labsynch/labseer/api/ApiParentLotController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiParentLotController.java
@@ -9,6 +9,7 @@ import com.labsynch.labseer.dto.LotDTO;
 import com.labsynch.labseer.dto.LotsByProjectDTO;
 import com.labsynch.labseer.dto.ParentLotCodeDTO;
 import com.labsynch.labseer.dto.ReparentLotDTO;
+import com.labsynch.labseer.dto.ReparentLotResponseDTO;
 import com.labsynch.labseer.service.LotService;
 import com.labsynch.labseer.service.ParentLotService;
 
@@ -126,7 +127,6 @@ public class ApiParentLotController {
 		}
 	}
 
-	@Transactional
 	@RequestMapping(value = "/reparentLot", method = RequestMethod.POST, headers = "Accept=application/json")
 	@ResponseBody
 	public ResponseEntity<String> reparentLot(@RequestBody String json) {
@@ -134,9 +134,9 @@ public class ApiParentLotController {
 		headers.add("Content-Type", "application/json; charset=utf-8");
 		try {
 			ReparentLotDTO lotDTO = ReparentLotDTO.fromJsonToReparentLotDTO(json);
-			Lot lot = lotService.reparentLot(lotDTO.getLotCorpName(), lotDTO.getParentCorpName(),
-					lotDTO.getModifiedBy());
-			return new ResponseEntity<String>(lot.toJsonIncludeAliases(), headers, HttpStatus.OK);
+			ReparentLotResponseDTO reparentLotDTO = lotService.reparentLot(lotDTO.getLotCorpName(), lotDTO.getParentCorpName(),
+					lotDTO.getModifiedBy(), true, true);
+			return new ResponseEntity<String>(reparentLotDTO.toJson(), headers, HttpStatus.OK);
 		} catch (Exception e) {
 			logger.error("Caught exception updating lot metadata", e);
 			return new ResponseEntity<String>(headers, HttpStatus.NOT_FOUND);
@@ -153,7 +153,7 @@ public class ApiParentLotController {
 		try {
 			Collection<ReparentLotDTO> lotDTOs = ReparentLotDTO.fromJsonArrayToReparentLoes(json);
 			for (ReparentLotDTO lotDTO : lotDTOs) {
-				lotService.reparentLot(lotDTO.getLotCorpName(), lotDTO.getParentCorpName(), lotDTO.getModifiedBy());
+				lotService.reparentLot(lotDTO.getLotCorpName(), lotDTO.getParentCorpName(), lotDTO.getModifiedBy(), true, true);
 				lotCount++;
 			}
 			return new ResponseEntity<String>("number of lots reparented: " + lotCount, headers, HttpStatus.OK);

--- a/src/main/java/com/labsynch/labseer/api/ApiParentLotController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiParentLotController.java
@@ -10,6 +10,7 @@ import com.labsynch.labseer.dto.LotsByProjectDTO;
 import com.labsynch.labseer.dto.ParentLotCodeDTO;
 import com.labsynch.labseer.dto.ReparentLotDTO;
 import com.labsynch.labseer.dto.ReparentLotResponseDTO;
+import com.labsynch.labseer.exceptions.DupeLotException;
 import com.labsynch.labseer.service.LotService;
 import com.labsynch.labseer.service.ParentLotService;
 
@@ -112,7 +113,6 @@ public class ApiParentLotController {
 		}
 	}
 
-	@Transactional
 	@RequestMapping(value = "/updateLot/metadata/jsonArray", method = RequestMethod.POST, headers = "Accept=application/json")
 	@ResponseBody
 	public ResponseEntity<String> updateLotMetaArray(@RequestBody String json) {
@@ -137,9 +137,12 @@ public class ApiParentLotController {
 			ReparentLotResponseDTO reparentLotDTO = lotService.reparentLot(lotDTO.getLotCorpName(), lotDTO.getParentCorpName(),
 					lotDTO.getModifiedBy(), true, true);
 			return new ResponseEntity<String>(reparentLotDTO.toJson(), headers, HttpStatus.OK);
+		} catch (DupeLotException e) {
+			logger.error("Error saving lot with duplicate name", e);
+			return new ResponseEntity<String>(e.getMessage(), headers, HttpStatus.CONFLICT);
 		} catch (Exception e) {
 			logger.error("Caught exception updating lot metadata", e);
-			return new ResponseEntity<String>(headers, HttpStatus.NOT_FOUND);
+			return new ResponseEntity<String>(headers, HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 	}
 

--- a/src/main/java/com/labsynch/labseer/domain/AnalysisGroupValue.java
+++ b/src/main/java/com/labsynch/labseer/domain/AnalysisGroupValue.java
@@ -1970,4 +1970,33 @@ public class AnalysisGroupValue extends AbstractValue {
 	public AnalysisGroupValue() {
 		super();
 	}
+
+    public static TypedQuery<AnalysisGroupValue> findAnalysisGroupValuesByLsKindEqualsAndCodeValueEquals(
+            String valueKind, String codeValue) {
+
+        if (valueKind == null || valueKind.length() == 0)
+            throw new IllegalArgumentException("The valueKind argument is required");
+        if (codeValue == null || codeValue.length() == 0)
+            throw new IllegalArgumentException("The valueKind argument is required");
+
+	    // Join through protocol to only fetch where top level protocol is not ignored
+        EntityManager em = entityManager();
+        String hsqlQuery = "SELECT agv FROM AnalysisGroupValue AS agv " +
+				"JOIN agv.lsState ags " +
+				"JOIN ags.analysisGroup ag " +
+				"JOIN ag.experiments e " +
+                "JOIN e.protocol p " +
+                "WHERE agv.codeValue = :codeValue AND agv.lsType = :valueType AND agv.lsKind = :valueKind AND agv.ignored IS NOT :ignored " +
+                "AND ags.ignored IS NOT :ignored " +
+                "AND ag.ignored IS NOT :ignored " +
+                "AND e.ignored IS NOT :ignored " +
+				"AND p.ignored IS NOT :ignored ";
+
+        TypedQuery<AnalysisGroupValue> q = em.createQuery(hsqlQuery, AnalysisGroupValue.class);
+        q.setParameter("valueType", "codeValue");
+        q.setParameter("valueKind", valueKind);
+        q.setParameter("codeValue", codeValue);
+        q.setParameter("ignored", true);
+        return q;
+    }
 }

--- a/src/main/java/com/labsynch/labseer/domain/ContainerValue.java
+++ b/src/main/java/com/labsynch/labseer/domain/ContainerValue.java
@@ -472,4 +472,28 @@ public class ContainerValue extends AbstractValue {
         return entityManager().createQuery(jpaQuery, ContainerValue.class).setFirstResult(firstResult)
                 .setMaxResults(maxResults).getResultList();
     }
+
+    public static TypedQuery<ContainerValue> findContainerValuesByLsKindEqualsAndCodeValueEquals(
+        String valueKind, String codeValue) {
+
+        if (valueKind == null || valueKind.length() == 0)
+            throw new IllegalArgumentException("The valueKind argument is required");
+        if (codeValue == null || codeValue.length() == 0)
+            throw new IllegalArgumentException("The valueKind argument is required");
+
+        EntityManager em = entityManager();
+        String hsqlQuery = "SELECT cv FROM ContainerValue AS cv " +
+            "JOIN cv.lsState cs " +
+            "JOIN cs.container c " +
+            "WHERE cs.ignored IS NOT :ignored " +
+            "AND cv.codeValue = :codeValue AND cv.lsType = :valueType AND cv.lsKind = :valueKind AND cv.ignored IS NOT :ignored " +
+            "AND c.ignored IS NOT :ignored ";
+
+        TypedQuery<ContainerValue> q = em.createQuery(hsqlQuery, ContainerValue.class);
+        q.setParameter("valueType", "codeValue");
+        q.setParameter("valueKind", valueKind);
+        q.setParameter("codeValue", codeValue);
+        q.setParameter("ignored", true);
+        return q;
+    }
 }

--- a/src/main/java/com/labsynch/labseer/domain/ExperimentValue.java
+++ b/src/main/java/com/labsynch/labseer/domain/ExperimentValue.java
@@ -174,6 +174,29 @@ public class ExperimentValue extends AbstractValue {
         return q;
     }
 
+    public static TypedQuery<com.labsynch.labseer.domain.ExperimentValue> findExperimentValuesByStateTypeKindAndValueTypeKind(
+        String stateType, String stateKind, String valueType, String valueKind) {
+        if (stateType == null || stateKind.length() == 0)
+            throw new IllegalArgumentException("The stateType argument is required");
+        if (stateKind == null || stateKind.length() == 0)
+            throw new IllegalArgumentException("The stateKind argument is required");
+        if (valueType == null || valueType.length() == 0)
+            throw new IllegalArgumentException("The valueType argument is required");
+        if (valueKind == null || valueKind.length() == 0)
+            throw new IllegalArgumentException("The valueKind argument is required");
+        EntityManager em = entityManager();
+        String hsqlQuery = "SELECT ev FROM ExperimentValue AS ev " + "JOIN ev.lsState evs " + "JOIN evs.experiment exp "
+                + "WHERE evs.lsType = :stateType AND evs.lsKind = :stateKind AND evs.ignored IS NOT :ignored "
+                + "AND ev.lsType = :valueType AND ev.lsKind = :valueKind AND ev.ignored IS NOT :ignored ";
+        TypedQuery<ExperimentValue> q = em.createQuery(hsqlQuery, ExperimentValue.class);
+        q.setParameter("stateType", stateType);
+        q.setParameter("stateKind", stateKind);
+        q.setParameter("valueType", valueType);
+        q.setParameter("valueKind", valueKind);
+        q.setParameter("ignored", true);
+        return q;
+    }
+
     public static TypedQuery<com.labsynch.labseer.domain.ExperimentValue> findExperimentValuesByExperimentCodeNameAndStateTypeKindAndValueTypeKind(
             String experimentCodeName, String stateType, String stateKind, String valueType, String valueKind) {
         if (stateType == null || stateKind.length() == 0)
@@ -642,5 +665,30 @@ public class ExperimentValue extends AbstractValue {
 
     public String toString() {
         return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+    }
+
+    public static TypedQuery<ExperimentValue> findExperimentValuesByLsKindEqualsAndCodeValueEquals(
+            String valueKind, String codeValue) {
+
+        if (valueKind == null || valueKind.length() == 0)
+            throw new IllegalArgumentException("The valueKind argument is required");
+        if (codeValue == null || codeValue.length() == 0)
+            throw new IllegalArgumentException("The valueKind argument is required");
+
+        EntityManager em = entityManager();
+        String hsqlQuery = "SELECT ev FROM ExperimentValue AS ev " +
+                "JOIN ev.lsState es " +
+                "JOIN es.experiment e " +
+                "JOIN e.protocol p " +
+                "WHERE ev.codeValue = :codeValue AND ev.lsType = :valueType AND ev.lsKind = :valueKind AND ev.ignored IS NOT :ignored " +
+                "AND es.ignored IS NOT :ignored " +
+                "AND p.ignored IS NOT :ignored " +
+                "AND e.ignored IS NOT :ignored ";
+        TypedQuery<ExperimentValue> q = em.createQuery(hsqlQuery, ExperimentValue.class);
+        q.setParameter("valueType", "codeValue");
+        q.setParameter("valueKind", valueKind);
+        q.setParameter("codeValue", codeValue);
+        q.setParameter("ignored", true);
+        return q;
     }
 }

--- a/src/main/java/com/labsynch/labseer/domain/ProtocolValue.java
+++ b/src/main/java/com/labsynch/labseer/domain/ProtocolValue.java
@@ -485,4 +485,28 @@ public class ProtocolValue extends AbstractValue {
     public String toString() {
         return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
     }
+
+    public static TypedQuery<ProtocolValue> findProtocolValuesByLsKindEqualsAndCodeValueEquals(
+            String valueKind, String codeValue) {
+
+        if (valueKind == null || valueKind.length() == 0)
+            throw new IllegalArgumentException("The valueKind argument is required");
+        if (codeValue == null || codeValue.length() == 0)
+            throw new IllegalArgumentException("The valueKind argument is required");
+
+        EntityManager em = entityManager();
+        String hsqlQuery = "SELECT pv FROM ProtocolValue AS pv " +
+                "JOIN pv.lsState ps " +
+                "JOIN ps.protocol p " +
+                "WHERE ps.ignored IS NOT :ignored " +
+                "AND pv.codeValue = :codeValue AND pv.lsType = :valueType AND pv.lsKind = :valueKind AND pv.ignored IS NOT :ignored " +
+                "AND p.ignored IS NOT :ignored ";
+        TypedQuery<ProtocolValue> q = em.createQuery(hsqlQuery, ProtocolValue.class);
+        q.setParameter("valueType", "codeValue");
+        q.setParameter("valueKind", valueKind);
+        q.setParameter("codeValue", codeValue);
+        q.setParameter("ignored", true);
+        return q;
+    }
+
 }

--- a/src/main/java/com/labsynch/labseer/domain/SubjectValue.java
+++ b/src/main/java/com/labsynch/labseer/domain/SubjectValue.java
@@ -803,4 +803,36 @@ public class SubjectValue extends AbstractValue {
 		return entityManager().createQuery(jpaQuery, SubjectValue.class).setFirstResult(firstResult)
 				.setMaxResults(maxResults).getResultList();
 	}
+	public static TypedQuery<SubjectValue> findSubjectValuesByLsKindEqualsAndCodeValueEquals(
+		String valueKind, String codeValue) {
+
+	if (valueKind == null || valueKind.length() == 0)
+		throw new IllegalArgumentException("The valueKind argument is required");
+	if (codeValue == null || codeValue.length() == 0)
+		throw new IllegalArgumentException("The valueKind argument is required");
+
+	// Join through protocol to only fetch where top level protocol is not ignored
+	EntityManager em = entityManager();
+	String hsqlQuery = "SELECT sv FROM SubjectValue AS sv " +
+			"JOIN sv.lsState ss " +
+			"JOIN ss.subject s " +
+			"JOIN s.treatmentGroups tg " +
+			"JOIN tg.analysisGroups ag " +
+			"JOIN ag.experiments e " +
+			"JOIN e.protocol p " +
+			"WHERE sv.codeValue = :codeValue AND sv.lsType = :valueType AND sv.lsKind = :valueKind AND sv.ignored IS NOT :ignored " +
+			"AND ss.ignored IS NOT :ignored " +
+			"AND s.ignored IS NOT :ignored " +
+			"AND tg.ignored IS NOT :ignored " +
+			"AND ag.ignored IS NOT :ignored " +
+			"AND e.ignored IS NOT :ignored " +
+			"AND p.ignored IS NOT :ignored ";
+
+	TypedQuery<SubjectValue> q = em.createQuery(hsqlQuery, SubjectValue.class);
+	q.setParameter("valueType", "codeValue");
+	q.setParameter("valueKind", valueKind);
+	q.setParameter("codeValue", codeValue);
+	q.setParameter("ignored", true);
+	return q;
+}
 }

--- a/src/main/java/com/labsynch/labseer/dto/CmpdRegBatchCodeDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/CmpdRegBatchCodeDTO.java
@@ -52,7 +52,7 @@ public class CmpdRegBatchCodeDTO {
 	private String summary;
 
 	public String toJson() {
-		return new JSONSerializer().exclude("*.class").include("linkedExperiments.*", "batchCodes.*")
+		return new JSONSerializer().exclude("*.class").include("linkedExperiments.*", "batchCodes.*", "linkedContainers.*")
 				.transform(new ExcludeNulls(), void.class).serialize(this);
 	}
 

--- a/src/main/java/com/labsynch/labseer/dto/ReparentLotResponseDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/ReparentLotResponseDTO.java
@@ -1,0 +1,89 @@
+package com.labsynch.labseer.dto;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+import com.labsynch.labseer.domain.Lot;
+
+import flexjson.JSONDeserializer;
+import flexjson.JSONSerializer;
+
+public class ReparentLotResponseDTO {
+
+    private Lot newLot;
+
+    private String originalLotCorpName;
+
+    private String originalParentCorpName;
+
+    private String modifiedBy;
+
+    public Lot getNewLot() {
+        return this.newLot;
+    }
+
+    public void setNewLot(Lot newLot) {
+        this.newLot = newLot;
+    }
+
+    public String getOriginalParentCorpName() {
+        return this.originalParentCorpName;
+    }
+
+    public void setOriginalParentCorpName(String originalParentCorpName) {
+        this.originalParentCorpName = originalParentCorpName;
+    }
+
+    public String getOriginalLotCorpName() {
+        return this.originalLotCorpName;
+    }
+
+    public void setOriginalLotCorpName(String originalLotCorpName) {
+        this.originalLotCorpName = originalLotCorpName;
+    }
+
+    public String getModifiedBy() {
+        return this.modifiedBy;
+    }
+
+    public void setModifiedBy(String modifiedBy) {
+        this.modifiedBy = modifiedBy;
+    }
+    
+    public String toString() {
+        return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+    }
+
+    public String toJson() {
+        return new JSONSerializer()
+                .exclude("*.class").serialize(this);
+    }
+
+    public String toJson(String[] fields) {
+        return new JSONSerializer()
+                .include(fields).exclude("*.class").serialize(this);
+    }
+
+    public static ReparentLotDTO fromJsonToReparentLotDTO(String json) {
+        return new JSONDeserializer<ReparentLotDTO>()
+                .use(null, ReparentLotDTO.class).deserialize(json);
+    }
+
+    public static String toJsonArray(Collection<ReparentLotDTO> collection) {
+        return new JSONSerializer()
+                .exclude("*.class").serialize(collection);
+    }
+
+    public static String toJsonArray(Collection<ReparentLotDTO> collection, String[] fields) {
+        return new JSONSerializer()
+                .include(fields).exclude("*.class").serialize(collection);
+    }
+
+    public static Collection<ReparentLotDTO> fromJsonArrayToReparentLoes(String json) {
+        return new JSONDeserializer<List<ReparentLotDTO>>()
+                .use("values", ReparentLotDTO.class).deserialize(json);
+    }
+}

--- a/src/main/java/com/labsynch/labseer/dto/ReparentLotResponseDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/ReparentLotResponseDTO.java
@@ -15,6 +15,20 @@ public class ReparentLotResponseDTO {
 
     private Lot newLot;
 
+    private Boolean originalParentDeleted;
+
+    public Boolean isOriginalParentDeleted() {
+        return this.originalParentDeleted;
+    }
+
+    public Boolean getOriginalParentDeleted() {
+        return this.originalParentDeleted;
+    }
+
+    public void setOriginalParentDeleted(Boolean originalParentDeleted) {
+        this.originalParentDeleted = originalParentDeleted;
+    }
+
     private String originalLotCorpName;
 
     private String originalParentCorpName;

--- a/src/main/java/com/labsynch/labseer/dto/ReparentLotResponseDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/ReparentLotResponseDTO.java
@@ -17,6 +17,14 @@ public class ReparentLotResponseDTO {
 
     private Boolean originalParentDeleted;
 
+    private Integer originalLotNumber;
+
+    private String originalLotCorpName;
+
+    private String originalParentCorpName;
+
+    private String modifiedBy;
+
     public Boolean isOriginalParentDeleted() {
         return this.originalParentDeleted;
     }
@@ -29,11 +37,13 @@ public class ReparentLotResponseDTO {
         this.originalParentDeleted = originalParentDeleted;
     }
 
-    private String originalLotCorpName;
+    public Integer getOriginalLotNumber() {
+        return this.originalLotNumber;
+    }
 
-    private String originalParentCorpName;
-
-    private String modifiedBy;
+    public void setOriginalLotNumber(Integer originalLotNumber) {
+        this.originalLotNumber = originalLotNumber;
+    }
 
     public Lot getNewLot() {
         return this.newLot;
@@ -66,7 +76,7 @@ public class ReparentLotResponseDTO {
     public void setModifiedBy(String modifiedBy) {
         this.modifiedBy = modifiedBy;
     }
-    
+
     public String toString() {
         return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
     }

--- a/src/main/java/com/labsynch/labseer/exceptions/DupeLotException.java
+++ b/src/main/java/com/labsynch/labseer/exceptions/DupeLotException.java
@@ -1,6 +1,6 @@
 package com.labsynch.labseer.exceptions;
 
-public class DupeLotException extends Exception {
+public class DupeLotException extends RuntimeException {
 
     public DupeLotException() {
         // TODO Auto-generated constructor stub

--- a/src/main/java/com/labsynch/labseer/service/AnalysisGroupService.java
+++ b/src/main/java/com/labsynch/labseer/service/AnalysisGroupService.java
@@ -21,4 +21,7 @@ public interface AnalysisGroupService {
 
 	TsvLoaderResponseDTO saveLsAnalysisGroupFromCsv(String analysisGroupFilePath,
 			String treatmentGroupFilePath, String subjectFilePath) throws IOException;
+
+	public int renameBatchCode(String oldCode, String newCode, String modifiedByUser, Long transactionId);
+
 }

--- a/src/main/java/com/labsynch/labseer/service/AnalysisGroupServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/AnalysisGroupServiceImpl.java
@@ -556,7 +556,6 @@ public class AnalysisGroupServiceImpl implements AnalysisGroupService {
 			value.setModifiedBy(modifiedByUser);
 			value.setModifiedDate(new Date());
 			value.setLsTransaction(transactionId);
-			value.persist();
 			AnalysisGroupValue newValue = new AnalysisGroupValue();
 			newValue.setLsType(value.getLsType());
 			newValue.setLsKind(value.getLsKind());

--- a/src/main/java/com/labsynch/labseer/service/AnalysisGroupServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/AnalysisGroupServiceImpl.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import javax.persistence.TypedQuery;
+
 import com.labsynch.labseer.domain.AnalysisGroup;
 import com.labsynch.labseer.domain.AnalysisGroupLabel;
 import com.labsynch.labseer.domain.AnalysisGroupState;
@@ -538,6 +540,38 @@ public class AnalysisGroupServiceImpl implements AnalysisGroupService {
 		}
 
 		return analysisGroup;
+	}
+
+	@Override
+	@Transactional
+	public int renameBatchCode(String oldCode, String newCode, String modifiedByUser, Long transactionId) {
+		// Finds all values with the old code, ignores them and creates a new one one with the new code
+		TypedQuery<AnalysisGroupValue> valueQuery = AnalysisGroupValue.findAnalysisGroupValuesByLsKindEqualsAndCodeValueEquals("batch code", oldCode);
+
+		List<AnalysisGroupValue> values = valueQuery.getResultList();
+		logger.info("Found " + values.size() + " analysis group values with batch code " + oldCode);
+		// Loop through each code value, ignore it and create a new one with the new code
+		for (AnalysisGroupValue value : values) {
+			value.setIgnored(true);
+			value.setModifiedBy(modifiedByUser);
+			value.setModifiedDate(new Date());
+			value.setLsTransaction(transactionId);
+			value.persist();
+			AnalysisGroupValue newValue = new AnalysisGroupValue();
+			newValue.setLsType(value.getLsType());
+			newValue.setLsKind(value.getLsKind());
+			newValue.setCodeValue(newCode);
+			newValue.setRecordedBy(modifiedByUser);
+			newValue.setCodeType(value.getCodeType());
+			newValue.setCodeKind(value.getCodeKind());
+			newValue.setCodeOrigin(value.getCodeOrigin());
+			newValue.setLsState(value.getLsState());
+			newValue.setLsTransaction(transactionId);
+			newValue.persist();
+			logger.info("Ignored analysis group value " + value.getId() + " and created new analysis group value " + newValue.getId() + " with batch code " + newCode);
+		}
+
+		return values.size();
 	}
 
 }

--- a/src/main/java/com/labsynch/labseer/service/AssayService.java
+++ b/src/main/java/com/labsynch/labseer/service/AssayService.java
@@ -1,0 +1,10 @@
+package com.labsynch.labseer.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public interface AssayService {
+    
+	int renameBatchCode(String oldCode, String newCode, String modifiedByUser);
+
+}

--- a/src/main/java/com/labsynch/labseer/service/AssayService.java
+++ b/src/main/java/com/labsynch/labseer/service/AssayService.java
@@ -5,6 +5,6 @@ import org.springframework.stereotype.Service;
 @Service
 public interface AssayService {
     
-	int renameBatchCode(String oldCode, String newCode, String modifiedByUser);
+	Long renameBatchCode(String oldCode, String newCode, String modifiedByUser);
 
 }

--- a/src/main/java/com/labsynch/labseer/service/AssayServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/AssayServiceImpl.java
@@ -29,7 +29,7 @@ public class AssayServiceImpl implements AssayService {
 
 	@Override
 	@Transactional
-	public int renameBatchCode(String oldCode, String newCode, String modifiedByUser) {
+	public Long renameBatchCode(String oldCode, String newCode, String modifiedByUser) {
 		
 		// Create an LS transaction for this
 		LsTransaction lsTransaction = new LsTransaction();
@@ -44,7 +44,7 @@ public class AssayServiceImpl implements AssayService {
 		int treatmentGroupValuesAffected = treatmentGroupService.renameBatchCode(oldCode, newCode, modifiedByUser, lsTransaction.getId());
 		int subjectValuesAffected = subjectService.renameBatchCode(oldCode, newCode, modifiedByUser, lsTransaction.getId());
 		
-		return protocolValuesAffected + experimentValuesAffected + analysisGroupValuesAffected + treatmentGroupValuesAffected + subjectValuesAffected;
+		return lsTransaction.getId();
 	}
 
 }

--- a/src/main/java/com/labsynch/labseer/service/AssayServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/AssayServiceImpl.java
@@ -1,0 +1,50 @@
+package com.labsynch.labseer.service;
+
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.labsynch.labseer.domain.LsTransaction;
+
+@Service
+@Transactional
+public class AssayServiceImpl implements AssayService {
+
+	@Autowired
+	private ProtocolService protocolService;
+
+	@Autowired
+	private ExperimentService experimentService;
+
+	@Autowired
+	private AnalysisGroupService analysisGroupService;
+
+	@Autowired
+	private TreatmentGroupService treatmentGroupService;
+
+	@Autowired
+	private SubjectService subjectService;
+
+	@Override
+	@Transactional
+	public int renameBatchCode(String oldCode, String newCode, String modifiedByUser) {
+		
+		// Create an LS transaction for this
+		LsTransaction lsTransaction = new LsTransaction();
+		lsTransaction.setRecordedDate(new Date());
+		lsTransaction.setRecordedBy(modifiedByUser);
+		lsTransaction.setComments("Rename batch code " + oldCode + " to " + newCode);
+		lsTransaction.persist();
+
+		int protocolValuesAffected = protocolService.renameBatchCode(oldCode, newCode, modifiedByUser, lsTransaction.getId());
+		int experimentValuesAffected = experimentService.renameBatchCode(oldCode, newCode, modifiedByUser, lsTransaction.getId());
+		int analysisGroupValuesAffected = analysisGroupService.renameBatchCode(oldCode, newCode, modifiedByUser, lsTransaction.getId());
+		int treatmentGroupValuesAffected = treatmentGroupService.renameBatchCode(oldCode, newCode, modifiedByUser, lsTransaction.getId());
+		int subjectValuesAffected = subjectService.renameBatchCode(oldCode, newCode, modifiedByUser, lsTransaction.getId());
+		
+		return protocolValuesAffected + experimentValuesAffected + analysisGroupValuesAffected + treatmentGroupValuesAffected + subjectValuesAffected;
+	}
+
+}

--- a/src/main/java/com/labsynch/labseer/service/ContainerService.java
+++ b/src/main/java/com/labsynch/labseer/service/ContainerService.java
@@ -179,4 +179,6 @@ public interface ContainerService {
 	List<ContainerCodeNameStateDTO> saveContainerCodeNameStateDTOArray(
 			List<ContainerCodeNameStateDTO> stateDTOs) throws SQLException;
 
+	int renameBatchCode(String oldCode, String newCode, String modifiedByUser, Long transactionId);
+
 }

--- a/src/main/java/com/labsynch/labseer/service/ContainerServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ContainerServiceImpl.java
@@ -3847,7 +3847,6 @@ public class ContainerServiceImpl implements ContainerService {
 			value.setModifiedBy(modifiedByUser);
 			value.setModifiedDate(new Date());
 			value.setLsTransaction(transactionId);
-			value.persist();
 			ContainerValue newValue = new ContainerValue();
 			newValue.setLsType(value.getLsType());
 			newValue.setLsKind(value.getLsKind());

--- a/src/main/java/com/labsynch/labseer/service/ContainerServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ContainerServiceImpl.java
@@ -3833,4 +3833,36 @@ public class ContainerServiceImpl implements ContainerService {
 		return results;
 	}
 
+	@Override
+	@Transactional
+	public int renameBatchCode(String oldCode, String newCode, String modifiedByUser, Long transactionId) {
+		// Finds all values with the old code, ignores them and creates a new one one with the new code
+		TypedQuery<ContainerValue> valueQuery = ContainerValue.findContainerValuesByLsKindEqualsAndCodeValueEquals("batch code", oldCode);
+
+		List<ContainerValue> values = valueQuery.getResultList();
+		logger.info("Found " + values.size() + " container values with batch code " + oldCode);
+		// Loop through each code value, ignore it and create a new one with the new code
+		for (ContainerValue value : values) {
+			value.setIgnored(true);
+			value.setModifiedBy(modifiedByUser);
+			value.setModifiedDate(new Date());
+			value.setLsTransaction(transactionId);
+			value.persist();
+			ContainerValue newValue = new ContainerValue();
+			newValue.setLsType(value.getLsType());
+			newValue.setLsKind(value.getLsKind());
+			newValue.setCodeValue(newCode);
+			newValue.setRecordedBy(modifiedByUser);
+			newValue.setCodeType(value.getCodeType());
+			newValue.setCodeKind(value.getCodeKind());
+			newValue.setCodeOrigin(value.getCodeOrigin());
+			newValue.setLsState(value.getLsState());
+			newValue.setLsTransaction(transactionId);
+			newValue.persist();
+			logger.info("Ignored subject value " + value.getId() + " and created new subject value " + newValue.getId() + " with batch code " + newCode);
+		}
+
+		return values.size();
+	}
+
 }

--- a/src/main/java/com/labsynch/labseer/service/ExperimentService.java
+++ b/src/main/java/com/labsynch/labseer/service/ExperimentService.java
@@ -91,4 +91,6 @@ public interface ExperimentService {
 	public Collection<String> getExperimentCodesByDateValueComparison(
 			DateValueComparisonRequest requestDTO) throws Exception;
 
+	public int renameBatchCode(String oldCode, String newCode, String modifiedByUser, Long transactionId);
+
 }

--- a/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
@@ -1923,7 +1923,6 @@ public class ExperimentServiceImpl implements ExperimentService {
 			value.setModifiedBy(modifiedByUser);
 			value.setModifiedDate(new Date());
 			value.setLsTransaction(transactionId);
-			value.persist();
 			ExperimentValue newValue = new ExperimentValue();
 			newValue.setLsType(value.getLsType());
 			newValue.setLsKind(value.getLsKind());

--- a/src/main/java/com/labsynch/labseer/service/LotService.java
+++ b/src/main/java/com/labsynch/labseer/service/LotService.java
@@ -10,6 +10,7 @@ import com.labsynch.labseer.dto.LotDTO;
 import com.labsynch.labseer.dto.LotsByProjectDTO;
 import com.labsynch.labseer.dto.PreferredNameDTO;
 import com.labsynch.labseer.dto.ReparentLotResponseDTO;
+import com.labsynch.labseer.exceptions.DupeLotException;
 import com.labsynch.labseer.service.LotServiceImpl.LotOrphanLevel;
 
 public interface LotService {
@@ -20,7 +21,7 @@ public interface LotService {
 
 	String updateLotMetaArray(String jsonArray);
 
-	ReparentLotResponseDTO reparentLot(String lotCorpName, String parentCorpName, String modifiedByUser, Boolean updateInventory, Boolean updateAssayData);
+	ReparentLotResponseDTO reparentLot(String lotCorpName, String parentCorpName, String modifiedByUser, Boolean updateInventory, Boolean updateAssayData) throws DupeLotException;
 
 	public Collection<LotsByProjectDTO> getLotsByProjectsList(List<String> projects);
 

--- a/src/main/java/com/labsynch/labseer/service/LotService.java
+++ b/src/main/java/com/labsynch/labseer/service/LotService.java
@@ -9,6 +9,8 @@ import com.labsynch.labseer.dto.CmpdRegBatchCodeDTO;
 import com.labsynch.labseer.dto.LotDTO;
 import com.labsynch.labseer.dto.LotsByProjectDTO;
 import com.labsynch.labseer.dto.PreferredNameDTO;
+import com.labsynch.labseer.dto.ReparentLotResponseDTO;
+import com.labsynch.labseer.service.LotServiceImpl.LotOrphanLevel;
 
 public interface LotService {
 
@@ -18,7 +20,7 @@ public interface LotService {
 
 	String updateLotMetaArray(String jsonArray);
 
-	Lot reparentLot(String lotCorpName, String parentCorpName, String modifiedByUser);
+	ReparentLotResponseDTO reparentLot(String lotCorpName, String parentCorpName, String modifiedByUser, Boolean updateInventory, Boolean updateAssayData);
 
 	public Collection<LotsByProjectDTO> getLotsByProjectsList(List<String> projects);
 
@@ -47,5 +49,7 @@ public interface LotService {
 	public void deleteLots(Collection<Lot> lots);
 
 	public void deleteLot(Lot lot);
+
+	public LotOrphanLevel checkLotOrphanLevel(Lot lot);
 
 }

--- a/src/main/java/com/labsynch/labseer/service/LotService.java
+++ b/src/main/java/com/labsynch/labseer/service/LotService.java
@@ -21,7 +21,7 @@ public interface LotService {
 
 	String updateLotMetaArray(String jsonArray);
 
-	ReparentLotResponseDTO reparentLot(String lotCorpName, String parentCorpName, String modifiedByUser, Boolean updateInventory, Boolean updateAssayData) throws DupeLotException;
+	ReparentLotResponseDTO reparentLot(String lotCorpName, String parentCorpName, String modifiedByUser, Boolean updateInventory, Boolean updateAssayData, Boolean dryRun) throws DupeLotException;
 
 	public Collection<LotsByProjectDTO> getLotsByProjectsList(List<String> projects);
 

--- a/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
@@ -152,7 +152,7 @@ public class LotServiceImpl implements LotService {
 		saltForm.setParent(adoptiveParent);
 		saltForm.setCorpName(
 				corpNameService.generateSaltFormCorpName(adoptiveParent.getCorpName(), isoSalts));
-		saltFormService.updateSaltWeight(saltForm);
+
 		queryLot.setLotNumber(newLotNumber);
 		logger.debug("new lot number: " + queryLot.getLotNumber());
 
@@ -183,7 +183,8 @@ public class LotServiceImpl implements LotService {
 
 		if(!dryRun) {
 			saltForm.merge();
-
+			saltFormService.updateSaltWeight(saltForm);
+			// recalculate salt form weight
 			queryLot.merge();
 			if(deleteOriginalParentAfterReparent) {
 				// Without fetching a fresh copy of the parent, the delete parent failed as it still had it's salt form attached

--- a/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
@@ -162,6 +162,9 @@ public class LotServiceImpl implements LotService {
 			Parent originalParent = Parent.findParent(originalParentId);
 			Parent.entityManager().refresh(originalParent);
 			parentService.deleteParent(originalParent);
+			reparentLotResponseDTO.setOriginalParentDeleted(true);
+		} else {
+			reparentLotResponseDTO.setOriginalParentDeleted(false);
 		}
 
 		// Null transaction id which gets populated if used

--- a/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
@@ -116,6 +116,8 @@ public class LotServiceImpl implements LotService {
 		Set isoSalts = saltForm.getIsoSalts();
 		isoSalts.size();
 		if(dryRun) {
+			// Detaching an entity closes it's session and detaches it from the persistence context, allowing us to query and modify the item but the changes will not be reflected
+			// to the database.
 			Lot.entityManager().detach(queryLot);
 			SaltForm.entityManager().detach(saltForm);
 			Parent.entityManager().detach(adoptiveParent);

--- a/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
@@ -164,11 +164,13 @@ public class LotServiceImpl implements LotService {
 			parentService.deleteParent(originalParent);
 		}
 
+		// Null transaction id which gets populated if used
+		Long transactionId = null;
 		if (updateAssayData) {
-			assayService.renameBatchCode(lotCorpName, queryLot.getCorpName(), modifiedByUser);
+			transactionId = assayService.renameBatchCode(lotCorpName, queryLot.getCorpName(), modifiedByUser);
 		}
 		if (updateInventory) {
-			// containerService.renameBatchCode(lotCorpName, queryLot.getCorpName(), modifiedByUser);
+			containerService.renameBatchCode(lotCorpName, queryLot.getCorpName(), modifiedByUser, transactionId);
 		}
 	
 		return reparentLotResponseDTO;

--- a/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
@@ -121,6 +121,11 @@ public class LotServiceImpl implements LotService {
 			Parent.entityManager().detach(adoptiveParent);
 		}
 
+		// LotService.checkLotOrphanLevel function calculates what level of the compound would be orphaned if the lot were to be removed.
+		// It will return Parent if the lot is moved, and there are no other SaltForms on the Parent that have lots (leaving Parnent as an orphan)
+		// It will return SaltForm if the lot is moved, and there are other SaltForms on the Parent (leaving SaltForm as an orphan)
+		// We only need to take action if the LotOrphanLevel is Parent because this tells us we should also delete the Parent.
+		// We don't  need to take action if the LotOrphanLevel is SaltForm, because reparent lot also moves the lot salt form.
 		LotOrphanLevel lotOrphanLevel = lotService.checkLotOrphanLevel(queryLot);
 
 		Boolean deleteOriginalParentAfterReparent = false;

--- a/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
@@ -37,7 +37,6 @@ import com.labsynch.labseer.dto.ReparentLotResponseDTO;
 import com.labsynch.labseer.exceptions.DupeLotException;
 import com.labsynch.labseer.utils.PropertiesUtilService;
 
-import org.hibernate.exception.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -79,7 +78,9 @@ public class LotServiceImpl implements LotService {
 	// updates saltForm weight and lot weight
 	@Override
 	public Lot updateLotWeight(Lot lot) {
-		saltFormService.updateSaltWeight(lot.getSaltForm());
+		SaltForm saltForm = lot.getSaltForm();
+		saltFormService.updateSaltWeight(saltForm);
+		saltForm.merge();
 		lot.setLotMolWeight(Lot.calculateLotMolWeight(lot));
 		lot.setModifiedDate(new Date());
 		lot.merge();
@@ -152,7 +153,7 @@ public class LotServiceImpl implements LotService {
 		saltForm.setParent(adoptiveParent);
 		saltForm.setCorpName(
 				corpNameService.generateSaltFormCorpName(adoptiveParent.getCorpName(), isoSalts));
-
+		saltFormService.updateSaltWeight(saltForm);
 		queryLot.setLotNumber(newLotNumber);
 		logger.debug("new lot number: " + queryLot.getLotNumber());
 
@@ -183,8 +184,7 @@ public class LotServiceImpl implements LotService {
 
 		if(!dryRun) {
 			saltForm.merge();
-			saltFormService.updateSaltWeight(saltForm);
-			// recalculate salt form weight
+
 			queryLot.merge();
 			if(deleteOriginalParentAfterReparent) {
 				// Without fetching a fresh copy of the parent, the delete parent failed as it still had it's salt form attached

--- a/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
@@ -109,6 +109,8 @@ public class LotServiceImpl implements LotService {
 		reparentLotResponseDTO.setModifiedBy(modifiedByUser);
 
 		Lot queryLot = Lot.findLotsByCorpNameEquals(lotCorpName).getSingleResult();
+		reparentLotResponseDTO.setOriginalLotNumber(queryLot.getLotNumber());
+
 		SaltForm saltForm = queryLot.getSaltForm();
 		Parent adoptiveParent = Parent.findParentsByCorpNameEquals(parentCorpName).getSingleResult();
 		Set isoSalts = saltForm.getIsoSalts();

--- a/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
@@ -186,6 +186,8 @@ public class LotServiceImpl implements LotService {
 
 			queryLot.merge();
 			if(deleteOriginalParentAfterReparent) {
+				// Without fetching a fresh copy of the parent, the delete parent failed as it still had it's salt form attached
+				// This delete would fail because a conflict.
 				Parent originalParent = Parent.findParent(originalParentId);
 				Parent.entityManager().refresh(originalParent);
 				parentService.deleteParent(originalParent);

--- a/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
@@ -113,8 +113,7 @@ public class LotServiceImpl implements LotService {
 
 		SaltForm saltForm = queryLot.getSaltForm();
 		Parent adoptiveParent = Parent.findParentsByCorpNameEquals(parentCorpName).getSingleResult();
-		Set isoSalts = saltForm.getIsoSalts();
-		isoSalts.size();
+		Set<IsoSalt> isoSalts = saltForm.getIsoSalts();
 		if(dryRun) {
 			// Detaching an entity closes it's session and detaches it from the persistence context, allowing us to query and modify the item but the changes will not be reflected
 			// to the database.

--- a/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
@@ -152,7 +152,7 @@ public class LotServiceImpl implements LotService {
 		saltForm.setParent(adoptiveParent);
 		saltForm.setCorpName(
 				corpNameService.generateSaltFormCorpName(adoptiveParent.getCorpName(), isoSalts));
-
+		saltFormService.updateSaltWeight(saltForm);
 		queryLot.setLotNumber(newLotNumber);
 		logger.debug("new lot number: " + queryLot.getLotNumber());
 
@@ -183,8 +183,7 @@ public class LotServiceImpl implements LotService {
 
 		if(!dryRun) {
 			saltForm.merge();
-			saltFormService.updateSaltWeight(saltForm);
-			// recalculate salt form weight
+
 			queryLot.merge();
 			if(deleteOriginalParentAfterReparent) {
 				Parent originalParent = Parent.findParent(originalParentId);

--- a/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
@@ -119,8 +119,15 @@ public class LotServiceImpl implements LotService {
 			// Detaching an entity closes it's session and detaches it from the persistence context, allowing us to query and modify the item but the changes will not be reflected
 			// to the database.
 			Lot.entityManager().detach(queryLot);
+
+			// Before detaching saltForm in dry run mode, we need to initialize the iso salt collection.  Calling ".size()" is the easiest way I found to do this.
+			// Without initializing the iso salts they can't be used to generateSaltFormCorpName and give the error:
+			//    org.hibernate.LazyInitializationException: failed to lazily initialize a collection of role: com.labsynch.labseer.domain.SaltForm.isoSalts, could not initialize proxy - no Session
+			isoSalts.size();
+
 			SaltForm.entityManager().detach(saltForm);
 			Parent.entityManager().detach(adoptiveParent);
+
 		}
 
 		// LotService.checkLotOrphanLevel function calculates what level of the compound would be orphaned if the lot were to be removed.

--- a/src/main/java/com/labsynch/labseer/service/ProtocolService.java
+++ b/src/main/java/com/labsynch/labseer/service/ProtocolService.java
@@ -42,4 +42,6 @@ public interface ProtocolService {
 	Collection<String> getProtocolCodesByDateValueComparison(
 			DateValueComparisonRequest requestDTO) throws Exception;
 
+	int renameBatchCode(String oldCode, String newCode, String modifiedByUser, Long transactionId);
+
 }

--- a/src/main/java/com/labsynch/labseer/service/ProtocolServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ProtocolServiceImpl.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.labsynch.labseer.domain.DDictValue;
 import com.labsynch.labseer.domain.LsTag;
@@ -48,6 +49,9 @@ public class ProtocolServiceImpl implements ProtocolService {
 
 	@Autowired
 	private AuthorService authorService;
+
+	@Autowired
+	private ProtocolValueService protocolValueService;
 
 	// @PostConstruct
 	// public void init(){
@@ -727,4 +731,35 @@ public class ProtocolServiceImpl implements ProtocolService {
 		return protocolCodes;
 	}
 
+	@Override
+	@Transactional
+	public int renameBatchCode(String oldCode, String newCode, String modifiedByUser, Long transactionId) {
+		// Finds all values with the old code, ignores them and creates a new one one with the new code
+		TypedQuery<ProtocolValue> valueQuery = ProtocolValue.findProtocolValuesByLsKindEqualsAndCodeValueEquals("batch code", oldCode);
+
+		List<ProtocolValue> values = valueQuery.getResultList();
+		logger.info("Found " + values.size() + " protocol values with batch code " + oldCode);
+		// Loop through each code value, ignore it and create a new one with the new code
+		for (ProtocolValue value : values) {
+			value.setIgnored(true);
+			value.setModifiedBy(modifiedByUser);
+			value.setModifiedDate(new Date());
+			value.setLsTransaction(transactionId);
+			value.persist();
+			ProtocolValue newValue = new ProtocolValue();
+			newValue.setLsType(value.getLsType());
+			newValue.setLsKind(value.getLsKind());
+			newValue.setCodeValue(newCode);
+			newValue.setRecordedBy(modifiedByUser);
+			newValue.setCodeType(value.getCodeType());
+			newValue.setCodeKind(value.getCodeKind());
+			newValue.setCodeOrigin(value.getCodeOrigin());
+			newValue.setLsState(value.getLsState());
+			newValue.setLsTransaction(transactionId);
+			newValue.persist();
+			logger.info("Ignored protocol value " + value.getId() + " and created new protocol value " + newValue.getId());
+		}
+
+		return values.size();
+	}
 }

--- a/src/main/java/com/labsynch/labseer/service/ProtocolServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ProtocolServiceImpl.java
@@ -745,7 +745,6 @@ public class ProtocolServiceImpl implements ProtocolService {
 			value.setModifiedBy(modifiedByUser);
 			value.setModifiedDate(new Date());
 			value.setLsTransaction(transactionId);
-			value.persist();
 			ProtocolValue newValue = new ProtocolValue();
 			newValue.setLsType(value.getLsType());
 			newValue.setLsKind(value.getLsKind());

--- a/src/main/java/com/labsynch/labseer/service/SaltFormServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltFormServiceImpl.java
@@ -71,8 +71,6 @@ public class SaltFormServiceImpl implements SaltFormService {
 			logger.debug("current totalSaltWeigth: " + totalSaltWeight);
 		}
 		saltForm.setSaltWeight(totalSaltWeight);
-		saltForm.merge();
-
 	}
 
 	public SaltForm updateSaltForm(Parent parent, SaltForm saltForm, Set<IsoSalt> isoSalts, Lot lot,

--- a/src/main/java/com/labsynch/labseer/service/SubjectService.java
+++ b/src/main/java/com/labsynch/labseer/service/SubjectService.java
@@ -69,4 +69,6 @@ public interface SubjectService {
 
 	void deleteSubjectLeaveStub(Subject subject, Long lsTransaction);
 
+	int renameBatchCode(String oldCode, String newCode, String modifiedByUser, Long transactionId);
+
 }

--- a/src/main/java/com/labsynch/labseer/service/SubjectServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SubjectServiceImpl.java
@@ -1240,7 +1240,6 @@ public class SubjectServiceImpl implements SubjectService {
 			value.setModifiedBy(modifiedByUser);
 			value.setModifiedDate(new Date());
 			value.setLsTransaction(transactionId);
-			value.persist();
 			SubjectValue newValue = new SubjectValue();
 			newValue.setLsType(value.getLsType());
 			newValue.setLsKind(value.getLsKind());

--- a/src/main/java/com/labsynch/labseer/service/SubjectServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SubjectServiceImpl.java
@@ -1226,4 +1226,36 @@ public class SubjectServiceImpl implements SubjectService {
 		return results;
 	}
 
+	@Override
+	@Transactional
+	public int renameBatchCode(String oldCode, String newCode, String modifiedByUser, Long transactionId) {
+		// Finds all values with the old code, ignores them and creates a new one one with the new code
+		TypedQuery<SubjectValue> valueQuery = SubjectValue.findSubjectValuesByLsKindEqualsAndCodeValueEquals("batch code", oldCode);
+
+		List<SubjectValue> values = valueQuery.getResultList();
+		logger.info("Found " + values.size() + " subject values with batch code " + oldCode);
+		// Loop through each code value, ignore it and create a new one with the new code
+		for (SubjectValue value : values) {
+			value.setIgnored(true);
+			value.setModifiedBy(modifiedByUser);
+			value.setModifiedDate(new Date());
+			value.setLsTransaction(transactionId);
+			value.persist();
+			SubjectValue newValue = new SubjectValue();
+			newValue.setLsType(value.getLsType());
+			newValue.setLsKind(value.getLsKind());
+			newValue.setCodeValue(newCode);
+			newValue.setRecordedBy(modifiedByUser);
+			newValue.setCodeType(value.getCodeType());
+			newValue.setCodeKind(value.getCodeKind());
+			newValue.setCodeOrigin(value.getCodeOrigin());
+			newValue.setLsState(value.getLsState());
+			newValue.setLsTransaction(transactionId);
+			newValue.persist();
+			logger.info("Ignored subject value " + value.getId() + " and created new subject value " + newValue.getId() + " with batch code " + newCode);
+		}
+
+		return values.size();
+	}
+
 }

--- a/src/main/java/com/labsynch/labseer/service/TreatmentGroupService.java
+++ b/src/main/java/com/labsynch/labseer/service/TreatmentGroupService.java
@@ -30,4 +30,5 @@ public interface TreatmentGroupService {
 	HashMap<String, TempThingDTO> createTreatmentGroupsFromCSV(
 			String treatmentGroupFilePath, HashMap<String, TempThingDTO> output) throws IOException;
 
+	int renameBatchCode(String oldCode, String newCode, String modifiedByUser, Long transactionId);
 }

--- a/src/main/java/com/labsynch/labseer/service/TreatmentGroupServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/TreatmentGroupServiceImpl.java
@@ -549,7 +549,6 @@ public class TreatmentGroupServiceImpl implements TreatmentGroupService {
 			value.setModifiedBy(modifiedByUser);
 			value.setModifiedDate(new Date());
 			value.setLsTransaction(transactionId);
-			value.persist();
 			TreatmentGroupValue newValue = new TreatmentGroupValue();
 			newValue.setLsType(value.getLsType());
 			newValue.setLsKind(value.getLsKind());

--- a/src/main/java/com/labsynch/labseer/utils/PropertiesUtilService.java
+++ b/src/main/java/com/labsynch/labseer/utils/PropertiesUtilService.java
@@ -134,4 +134,6 @@ public interface PropertiesUtilService {
 
 	Boolean getAllowDuplicateParentAliases();
 
+	Integer getMaxAutoLotNumber();
+
 }

--- a/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
@@ -925,4 +925,25 @@ public class PropertiesUtilServiceImpl implements PropertiesUtilService {
 		return this.allowDuplicateParentAliases;
 	}
 
+
+	Integer maxAutoLotNumber;
+
+	@Value("${client.cmpdreg.metaLot.maxAutoLotNumber}")
+	public void setMaxAutoLotNumber(String maxAutoLotNumber) {
+		if (maxAutoLotNumber.startsWith("${")) {
+			this.maxAutoLotNumber = null;
+		} else {
+			try {
+				this.maxAutoLotNumber = Integer.parseInt(maxAutoLotNumber);
+			} catch (NumberFormatException e) {
+				this.maxAutoLotNumber = null;
+			}
+		}
+	}
+
+	@Override
+	public Integer getMaxAutoLotNumber() {
+		return this.maxAutoLotNumber;
+	}
+
 }


### PR DESCRIPTION
## Description
Updated reparent lot routes to 
 - return a structured output which contains
    -  original parent corp name
    -  original lot corp name
    - original lot number
    - the new lot as updated (or simulated via new dry run flag) 
 - update experimental data
    - renames codeType "codeValue" codeValue "batch code" values on subject, treatment, experiment and protocol levels
 - deletes old parent if it is orphaned
 - optional dry run mode which returns the expected output lot (including updated corp name and lot number)

## Related Issue
ACAS-216

## How Has This Been Tested?
Ran acas client tests and tests described on acas node layer ACAS-216 pull request