### PR TITLE
set timeout on calls to processor for bbchem cmpd reg implmentation ACAS-370

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
@@ -225,6 +225,17 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 		options.put("standardizer_actions", standardizerActions);
 		requestData.put("options", options);
 
+		// Set timeout (default to 900)
+		JsonNode timeoutNode = jsonNode.get("timeout");
+		int timeout;
+		if(timeoutNode == null) {
+			timeout = 900;
+			logger.info("Timeout not set in preprocessor settings, using default of " + String.valueOf(timeout));
+		} else {
+			timeout = timeoutNode.asInt();
+		}
+		requestData.put("timeout", timeout);
+
 		// Split the list of structures into chunks for processing
 		List<List<String>> structureGroups = splitIntoListOfLists(structures);
 


### PR DESCRIPTION
## Description
ACAS is not properly setting timeout on calls to processor, this fix gets the timeout from the configs and if not set defaults to 900 seconds.

## Related Issue
ACAS-370

## How Has This Been Tested?
Ran test and verified that bbchem printed the timeout:

```
2022-07-29 17:26:22 INFO [pid-133] bbchem.preprocessor.views Starting to process 1 structures with a timeout of 900s...
```