### PR TITLE
Catch no original structure found when running dry run standardization

### DIFF
--- a/src/main/java/com/labsynch/labseer/domain/Lot.java
+++ b/src/main/java/com/labsynch/labseer/domain/Lot.java
@@ -17,6 +17,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.NoResultException;
 import javax.persistence.OneToMany;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
@@ -505,7 +506,12 @@ public class Lot {
         q.setParameter("ignore", false);
 
         // Get string result from typed query
-        String lotAsDrawnStrucucture = q.getSingleResult();
+        String lotAsDrawnStrucucture = null;
+        try {
+            lotAsDrawnStrucucture = q.getSingleResult();
+        } catch (NoResultException e) {
+            logger.error("No original structure found for parent corp name " + parent.getCorpName() + " / parent id " + parent.getId());
+        }
         if (lotAsDrawnStrucucture == null) {
             return parentStructure;
         } else {


### PR DESCRIPTION
## Description
The old version of reparent lot did not catch when it was leaving behind parents with no salt_forms.  This has been fixed but we have systems which have this data state.  This fix allows standardization dry run and standardization to run successfully in this state.  It looks like we already had a check for if we were returning null but we weren't catching a no result exception.

## Related Issue
ACAS-388

## How Has This Been Tested?
Ran the code on a system with the required error state (Parents with no salt forms).