### PR TITLE
Upgraded JChem to look at Repository for JAR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,24 @@
 ARG 	CHEMISTRY_PACKAGE=jchem
-FROM maven:3-openjdk-8 as builder
+FROM maven:3-openjdk-11 as builder
 
 FROM 	builder as dependencies
 ARG     CHEMISTRY_PACKAGE
 ENV     CHEMISTRY_PACKAGE=${CHEMISTRY_PACKAGE}
 
 FROM 	dependencies as jchem
-ADD 	lib/jchem-16.4.25.0.jar /lib/jchem-16.4.25.0.jar
-RUN     mvn install:install-file -Dfile=/lib/jchem-16.4.25.0.jar -DartifactId=jchem -DgroupId=com.chemaxon -Dversion=16.4.25.0 -Dpackaging=jar -DgeneratePom=true -DcreateChecksum=true
+# ADD 	lib/jchem-16.4.25.0.jar /lib/jchem-16.4.25.0.jar
+# RUN     mvn install:install-file -Dfile=/lib/jchem-16.4.25.0.jar -DartifactId=jchem -DgroupId=com.chemaxon -Dversion=16.4.25.0 -Dpackaging=jar -DgeneratePom=true -DcreateChecksum=true
 
 FROM 	${CHEMISTRY_PACKAGE} as compile
+ADD settings.xml /root/.m2/settings.xml
 ADD 	pom.xml /src/pom.xml
 WORKDIR /src
-RUN 	mvn dependency:resolve -P ${CHEMISTRY_PACKAGE}
+RUN 	mvn dependency:resolve -P ${CHEMISTRY_PACKAGE} -X
 ADD 	. /src
 RUN 	mvn clean && \
-        mvn compile war:war -P ${CHEMISTRY_PACKAGE}
-
-FROM tomcat:9.0.62-jre8-openjdk-slim-buster
+        mvn compile war:war -P ${CHEMISTRY_PACKAGE} -X
+# RUN mvn compile war:war -P ${CHEMISTRY_PACKAGE}
+FROM tomcat:9.0.62-jre11-openjdk-slim-buster
 
 RUN apt-get update && \
     apt-get install -y openssl libfontconfig libfreetype6 curl
@@ -36,10 +37,10 @@ ENV NODE_PATH /usr/lib/node_modules
 RUN	useradd -u 1000 -ms /bin/bash runner
 
 # Allow certificates to be added by runner
-RUN chgrp runner /usr/local/openjdk-8/lib/security/cacerts && \
-    chmod g+w /usr/local/openjdk-8/lib/security/cacerts && \
+RUN chgrp runner /usr/local/openjdk-11/lib/security/cacerts && \
+    chmod g+w /usr/local/openjdk-11/lib/security/cacerts && \
     mkdir -p /usr/lib/jvm/java/jre/lib/security && \
-    ln -s /usr/local/openjdk-8/lib/security/cacerts /usr/lib/jvm/java/jre/lib/security/cacerts
+    ln -s /usr/local/openjdk-11/lib/security/cacerts /usr/lib/jvm/java/jre/lib/security/cacerts
 
 # Get acas-roo-server compiled code
 COPY 	--chown=runner:runner --from=compile /src/target/acas*.war /usr/local/tomcat/webapps/acas.war

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.]]>
 	<description>ACAS Java persistence layer</description>
 	<properties>
 		<aspectj.version>1.9.7</aspectj.version>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.build.timestamp.format>yyyyMMdd_HHmm</maven.build.timestamp.format>
 		<date>${maven.build.timestamp}</date>
@@ -58,6 +58,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.]]>
 		<url>https://github.com/mcneilco/acas-roo-server.git</url>
 	</scm>
 	<repositories>
+		<repository>
+			<id>Chemaxon Public Repository</id>
+			<url>https://hub.chemaxon.com/artifactory/libs-release</url>
+		</repository>
 		<repository>
 			<id>spring-release</id>
 			<name>Spring Release</name>
@@ -104,20 +108,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.]]>
 			<dependencies>
 				<dependency>
 					<groupId>com.chemaxon</groupId>
-					<artifactId>jchem</artifactId>
-					<version>${jchem.version}</version>
-				</dependency>
-				<!-- JCHEM 16 requires dom4j 1.3. This depdendency can be removed when we upgrade jchem to jchem > 17 -->
-				<dependency>
-					<groupId>dom4j</groupId>
-					<artifactId>dom4j</artifactId>
-					<version>1.3</version>
-				</dependency>
-				<!-- JHEM 16 requires trove4j https://mvnrepository.com/artifact/net.sf.trove4j/trove4j -->
-				<dependency>
-					<groupId>net.sf.trove4j</groupId>
-					<artifactId>trove4j</artifactId>
-					<version>3.0.3</version>
+					<artifactId>jchem-main</artifactId>
+					<version>22.12.0</version>
 				</dependency>
 			</dependencies>
 			<properties>


### PR DESCRIPTION
Upgraded JChem to use JChem private repo -- still need to figure out the authentication part of the deployment because it involves putting API Keys into a file outside of the repo.

## Description
- Made changes to the POM to upgrade to tomcat JDK 11 image and use Java 11 in related dependencies
- Made changes to the POM to point at the ChemAxon Repo for obtaining the JAR
- Made changes to the DockerFile (Needs more review) to remove the local add of the ChemAxon Jar.

## Related Issue
No Related Issues

## How Has This Been Tested?
I wrote one very simple test to load an SDF file, but we should talk about adding this to a more structured unit test for roo.