### PR TITLE
ACAS-403: Fix lack of molWeight updates when swapping structures

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/ParentSwapStructuresServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentSwapStructuresServiceImpl.java
@@ -24,6 +24,9 @@ public class ParentSwapStructuresServiceImpl implements ParentSwapStructuresServ
     public ParentService parentService;
 
 	@Autowired
+	public ParentStructureService parentStructureService;
+
+	@Autowired
 	public ChemStructureService chemStructureService;
 
     @Override
@@ -80,13 +83,13 @@ public class ParentSwapStructuresServiceImpl implements ParentSwapStructuresServ
 		dupeParents2.remove(corpName1);
 		dupeParents2.remove(corpName2);
 		if (dupeParents1.isEmpty() && dupeParents2.isEmpty()) {
+			// Swap the structures
 			String mol = parent1.getMolStructure();
 			parent1.setMolStructure(parent2.getMolStructure());
-			parent1.setModifiedDate(new Date());
-			parent1.setModifiedBy(parentSwapStructuresDTO.getUsername());
 			parent2.setMolStructure(mol);
-			parent2.setModifiedDate(new Date());
-			parent2.setModifiedBy(parentSwapStructuresDTO.getUsername());
+			// Follow through with updates to formula, mol weight, lot mol weights, and structure tables
+			parent1 = parentStructureService.update(parent1);
+			parent2 = parentStructureService.update(parent2);
 			logger.info(String.format("Swapping corpName1=%s & corpName2=%s swap successful.", corpName1, corpName2));
 			return "";
 		} else {


### PR DESCRIPTION
## Description
Parent structure swap route was not updating molecular weight, mol formula, lot molweights, or structure tables.
Switched to using existing parentStructureService.update method which does all this.

## Related Issue

## How Has This Been Tested?
Added additional acasclient tests to confirm mol weight and mol formula changes. Confirmed those tests were broken before this change and fixed afterwards.

Structure table updates will need to be tested on a BBChem system since indigo does not use a separate structure table AFAIK.