### PR TITLE
Update modified date of the Lot.

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
@@ -598,7 +598,7 @@ public class MetalotServiceImpl implements MetalotService {
 					oldLot.setSynthesisDate(lot.getSynthesisDate());
 					oldLot.setChemist(lot.getChemist());
 					oldLot.setModifiedBy(lot.getModifiedBy());
-					oldLot.setModifiedDate(lot.getModifiedDate());
+					oldLot.setModifiedDate(new Date());
 					oldLot.setLotMolWeight(Parent.findParent(lot.getParent().getId()).getMolWeight() + totalSaltWeight);
 					//
 					oldLot.setRetain(lot.getRetain());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update `modifiedDate` field when editing a `Lot`.

## Description
<!--- Describe your changes in detail -->
When a `Lot` is edited, the `modifiedDate` field is not updated. We are copying the `modifiedDate` value from the existing lot which never has the `modifiedDate` value. Here we update the `modifiedDate` field to be current date.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACAS-364](https://jira.schrodinger.com/browse/ACAS-364).

## How Has This Been Tested?
<!--- Describe how this has been tested -->
TDD. Check [acasclient PR](https://github.com/mcneilco/acasclient/pull/87).