### PR TITLE
ACAS-407: Backport critical kubernetes-relevant fixes to 1.13.7 release branch

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
@@ -225,6 +225,17 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 		options.put("standardizer_actions", standardizerActions);
 		requestData.put("options", options);
 
+		// Set timeout (default to 900)
+		JsonNode timeoutNode = jsonNode.get("timeout");
+		int timeout;
+		if(timeoutNode == null) {
+			timeout = 900;
+			logger.info("Timeout not set in preprocessor settings, using default of " + String.valueOf(timeout));
+		} else {
+			timeout = timeoutNode.asInt();
+		}
+		requestData.put("timeout", timeout);
+
 		// Split the list of structures into chunks for processing
 		List<List<String>> structureGroups = splitIntoListOfLists(structures);
 

--- a/src/main/java/com/labsynch/labseer/domain/Lot.java
+++ b/src/main/java/com/labsynch/labseer/domain/Lot.java
@@ -17,6 +17,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.NoResultException;
 import javax.persistence.OneToMany;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
@@ -505,7 +506,12 @@ public class Lot {
         q.setParameter("ignore", false);
 
         // Get string result from typed query
-        String lotAsDrawnStrucucture = q.getSingleResult();
+        String lotAsDrawnStrucucture = null;
+        try {
+            lotAsDrawnStrucucture = q.getSingleResult();
+        } catch (NoResultException e) {
+            logger.error("No original structure found for parent corp name " + parent.getCorpName() + " / parent id " + parent.getId());
+        }
         if (lotAsDrawnStrucucture == null) {
             return parentStructure;
         } else {


### PR DESCRIPTION
## Description
Backporting fixes for ACAS-388 (#348) and ACAS-370 (#346) to release/1.13.7

## Related Issue

## How Has This Been Tested?
These fixes have been tested in release/2022.1.x. No additional testing is planned.