### PR TITLE
ACAS-6: Switch to generic V3000/V2000 mol reader

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/StructureServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StructureServiceImpl.java
@@ -26,8 +26,9 @@ import org.openscience.cdk.depict.Depiction;
 import org.openscience.cdk.depict.DepictionGenerator;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtomContainer;
-import org.openscience.cdk.io.MDLV2000Reader;
+import org.openscience.cdk.io.ISimpleChemObjectReader;
 import org.openscience.cdk.io.MDLV2000Writer;
+import org.openscience.cdk.io.ReaderFactory;
 import org.openscience.cdk.layout.StructureDiagramGenerator;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmilesGenerator;
@@ -146,7 +147,7 @@ public class StructureServiceImpl implements StructureService {
 	}
 
 	private IAtomContainer readMolStructure(String molStructure) throws IOException, CDKException {
-		MDLV2000Reader mdlReader = new MDLV2000Reader(new StringReader(molStructure));
+		ISimpleChemObjectReader mdlReader = new ReaderFactory().createReader(new StringReader(molStructure));
 		IAtomContainer molecule = SilentChemObjectBuilder.getInstance().newInstance(IAtomContainer.class);
 		molecule = mdlReader.read(molecule);
 		mdlReader.close();


### PR DESCRIPTION
## Description
Fixing an issue mentioned in https://github.com/mcneilco/acas/pull/1002
The V2000 reader cannot read V3000 MOL strings, whereas this implementation works for both V3000 and V2000 MOL strings.

## Related Issue

## How Has This Been Tested?
Tested in local dev setup and confirmed both V3000 and V2000 inputs generated images successfully.