### PR TITLE
ACAS-6: Follow-up fix for image rendering

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiSaltController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiSaltController.java
@@ -268,7 +268,7 @@ public class ApiSaltController {
 
 			ErrorMessage error = new ErrorMessage();
 			error.setLevel("error");
-			error.setMessage("Duplicate salt name. Another salt exist with the same name.");
+			error.setMessage("Duplicate salt name. Another salt exists with the same name.");
 			errors.add(error);
 		}
 		List<Salt> saltsByAbbrev = Salt.findSaltsByAbbrevEquals(salt.getAbbrev()).getResultList();
@@ -278,7 +278,7 @@ public class ApiSaltController {
 
 			ErrorMessage error = new ErrorMessage();
 			error.setLevel("error");
-			error.setMessage("Duplicate salt abbreviation. Another salt exist with the same abbreviation.");
+			error.setMessage("Duplicate salt abbreviation. Another salt exists with the same abbreviation.");
 			errors.add(error);
 		}
 		if (validSalt & !dryrun) {

--- a/src/main/java/com/labsynch/labseer/api/ApiStructureImageController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiStructureImageController.java
@@ -1,5 +1,6 @@
 package com.labsynch.labseer.api;
 
+import java.util.Base64;
 import java.util.List;
 
 import com.labsynch.labseer.domain.Lot;
@@ -57,6 +58,29 @@ public class ApiStructureImageController {
         headers.setExpires(0); // Expire the cache
 
         return new ResponseEntity<byte[]>(image, headers, HttpStatus.OK);
+
+    }
+
+    @RequestMapping(value = "/convertMol/base64", method = RequestMethod.POST)
+    @ResponseBody
+    public ResponseEntity<String> convertMolToBase64Image(@RequestBody String molStructure,
+            @RequestParam(value = "hSize", required = false) Integer hSize,
+            @RequestParam(value = "wSize", required = false) Integer wSize,
+            @RequestParam(value = "format", required = false) String format) {
+
+        byte[] image = structureImageService.convertMolToImage(molStructure, hSize, wSize, format);
+        Base64.Encoder encoder = Base64.getEncoder();
+		String encodedString = encoder.encodeToString(image);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.IMAGE_PNG);
+        headers.add("Access-Control-Allow-Headers", "Content-Type");
+        headers.add("Access-Control-Allow-Origin", "*");
+        headers.add("Cache-Control", "no-store, no-cache, must-revalidate"); // HTTP 1.1
+        headers.add("Pragma", "no-cache"); // HTTP 1.0
+        headers.setExpires(0); // Expire the cache
+
+        return new ResponseEntity<String>(encodedString, headers, HttpStatus.OK);
 
     }
 

--- a/src/main/java/com/labsynch/labseer/service/SaltServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltServiceImpl.java
@@ -249,21 +249,21 @@ public class SaltServiceImpl implements SaltService {
 		if (saltsByName.size() > 0) {
 			ErrorMessage error = new ErrorMessage();
 			error.setLevel("error");
-			error.setMessage("Duplicate salt name. Another salt exist with the same name.");
+			error.setMessage("Duplicate salt name. Another salt exists with the same name.");
 			warnings.add(error);
 		}
 		List<Salt> saltsByAbbrev = Salt.findSaltsByAbbrevEquals(newSalt.getAbbrev()).getResultList();
 		if (saltsByAbbrev.size() > 0) {
 			ErrorMessage error = new ErrorMessage();
 			error.setLevel("error");
-			error.setMessage("Duplicate salt abbreviation. Another salt exist with the same abbreviation.");
+			error.setMessage("Duplicate salt abbreviation. Another salt exists with the same abbreviation.");
 			warnings.add(error);
 		}
 		List<Salt> saltsByFormula = Salt.findSaltsByFormulaEquals(newSalt.getFormula()).getResultList();
 		if (saltsByFormula.size() > 0) {
 			ErrorMessage error = new ErrorMessage();
 			error.setLevel("warning");
-			error.setMessage("Duplicate salt formula. Another salt exist with the same formula.");
+			error.setMessage("Duplicate salt formula. Another salt exists with the same formula.");
 			warnings.add(error);
 		}
 			


### PR DESCRIPTION
## Description
Add a new route to render a MOL string as base64-encoded PNG.
Also fixed a small grammar issue in duplicate messages.

## How Has This Been Tested?
Tested locally alongside changes from https://github.com/mcneilco/acas/pull/1002