### PR TITLE
Hotfix - Editing Salt Treats No Change to Abbrev / Name As Duplicate in System 

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/SaltServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltServiceImpl.java
@@ -245,26 +245,35 @@ public class SaltServiceImpl implements SaltService {
 			warnings.add(warning);
 		}
 
-		List<Salt> saltsByName = Salt.findSaltsByNameEquals(newSalt.getName()).getResultList();
-		if (saltsByName.size() > 0 && !newSalt.getName().equals(oldSalt.getName())) {
-			ErrorMessage error = new ErrorMessage();
-			error.setLevel("error");
-			error.setMessage("Duplicate salt name. Another salt exists with the same name.");
-			warnings.add(error);
+		if(!newSalt.getName().equals(oldSalt.getName()))
+		{
+			List<Salt> saltsByName = Salt.findSaltsByNameEquals(newSalt.getName()).getResultList();
+			if (saltsByName.size() > 0) {
+				ErrorMessage error = new ErrorMessage();
+				error.setLevel("error");
+				error.setMessage("Duplicate salt name. Another salt exists with the same name.");
+				warnings.add(error);
+			}
 		}
-		List<Salt> saltsByAbbrev = Salt.findSaltsByAbbrevEquals(newSalt.getAbbrev()).getResultList();
-		if (saltsByAbbrev.size() > 0 && !newSalt.getAbbrev().equals(oldSalt.getAbbrev())) {
-			ErrorMessage error = new ErrorMessage();
-			error.setLevel("error");
-			error.setMessage("Duplicate salt abbreviation. Another salt exists with the same abbreviation.");
-			warnings.add(error);
+		if(!newSalt.getAbbrev().equals(oldSalt.getAbbrev()))
+		{
+			List<Salt> saltsByAbbrev = Salt.findSaltsByAbbrevEquals(newSalt.getAbbrev()).getResultList();
+			if (saltsByAbbrev.size() > 0) {
+				ErrorMessage error = new ErrorMessage();
+				error.setLevel("error");
+				error.setMessage("Duplicate salt abbreviation. Another salt exists with the same abbreviation.");
+				warnings.add(error);
+			}
 		}
-		List<Salt> saltsByFormula = Salt.findSaltsByFormulaEquals(newSalt.getFormula()).getResultList();
-		if (saltsByFormula.size() > 0 && !newSalt.getFormula().equals(oldSalt.getFormula())) {
-			ErrorMessage error = new ErrorMessage();
-			error.setLevel("warning");
-			error.setMessage("Duplicate salt formula. Another salt exists with the same formula.");
-			warnings.add(error);
+		if(!newSalt.getFormula().equals(oldSalt.getFormula()))
+		{
+			List<Salt> saltsByFormula = Salt.findSaltsByFormulaEquals(newSalt.getFormula()).getResultList();
+			if (saltsByFormula.size() > 0) {
+				ErrorMessage error = new ErrorMessage();
+				error.setLevel("warning");
+				error.setMessage("Duplicate salt formula. Another salt exists with the same formula.");
+				warnings.add(error);
+			}
 		}
 			
 		// Get IsoSalts From Salt 

--- a/src/main/java/com/labsynch/labseer/service/SaltServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltServiceImpl.java
@@ -246,21 +246,21 @@ public class SaltServiceImpl implements SaltService {
 		}
 
 		List<Salt> saltsByName = Salt.findSaltsByNameEquals(newSalt.getName()).getResultList();
-		if (saltsByName.size() > 0) {
+		if (saltsByName.size() > 0 && !newSalt.getName().equals(oldSalt.getName())) {
 			ErrorMessage error = new ErrorMessage();
 			error.setLevel("error");
 			error.setMessage("Duplicate salt name. Another salt exists with the same name.");
 			warnings.add(error);
 		}
 		List<Salt> saltsByAbbrev = Salt.findSaltsByAbbrevEquals(newSalt.getAbbrev()).getResultList();
-		if (saltsByAbbrev.size() > 0) {
+		if (saltsByAbbrev.size() > 0 && !newSalt.getName().equals(oldSalt.getName())) {
 			ErrorMessage error = new ErrorMessage();
 			error.setLevel("error");
 			error.setMessage("Duplicate salt abbreviation. Another salt exists with the same abbreviation.");
 			warnings.add(error);
 		}
 		List<Salt> saltsByFormula = Salt.findSaltsByFormulaEquals(newSalt.getFormula()).getResultList();
-		if (saltsByFormula.size() > 0) {
+		if (saltsByFormula.size() > 0 && !newSalt.getFormula().equals(oldSalt.getFormula())) {
 			ErrorMessage error = new ErrorMessage();
 			error.setLevel("warning");
 			error.setMessage("Duplicate salt formula. Another salt exists with the same formula.");

--- a/src/main/java/com/labsynch/labseer/service/SaltServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltServiceImpl.java
@@ -253,7 +253,7 @@ public class SaltServiceImpl implements SaltService {
 			warnings.add(error);
 		}
 		List<Salt> saltsByAbbrev = Salt.findSaltsByAbbrevEquals(newSalt.getAbbrev()).getResultList();
-		if (saltsByAbbrev.size() > 0 && !newSalt.getName().equals(oldSalt.getName())) {
+		if (saltsByAbbrev.size() > 0 && !newSalt.getAbbrev().equals(oldSalt.getAbbrev())) {
 			ErrorMessage error = new ErrorMessage();
 			error.setLevel("error");
 			error.setMessage("Duplicate salt abbreviation. Another salt exists with the same abbreviation.");


### PR DESCRIPTION
**Reproduce/Test:**

As a CReg admin, navigate to the CmpdRed Salts panel, pick any salt from the table and edit the abbreviation or name.
Click the 'Next' button.

**Bug Results:**

Any changes cannot be saved since they are always referred to as duplicates of existing values, even though they are added as a part of the same workflow.

**Post-Fix Results:**

After reviewing the dependencies, the changes should be allowed to save. There should be no error/warning for the name OR abbreviation already existing in the system if the name OR abbreviation (respectively) of the active salt edit isn't changed. 

