### PR TITLE
ACAS-400: Fix error flow for duplicate parent aliases

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiMetalotController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiMetalotController.java
@@ -117,7 +117,7 @@ public class ApiMetalotController {
 		if (hasError) {
 			headers.add("lot save error", "true");
 			return new ResponseEntity<String>(ErrorMessage.toJsonArray(mr.getErrors()), headers,
-					HttpStatus.INTERNAL_SERVER_ERROR);
+					HttpStatus.BAD_REQUEST);
 		} else {
 			// MetalotReturnDTO miniLot = new MetalotReturnDTO();
 			// miniLot.setId(mr.getMetalot().getLot().getId());

--- a/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
@@ -342,6 +342,10 @@ public class MetalotServiceImpl implements MetalotService {
 					throw new SaltedCompoundException("Salted parent structure");
 				}
 			}
+			if (parentAliases.size() > 0){
+				// Validate parent aliases
+				parentAliasService.validateParentAliases(parentAliases);
+			}
 			if (!dupeParent) {
 				boolean checkForDupe = false;
 				cdId = chemService.saveStructure(parent.getMolStructure(), StructureType.PARENT, checkForDupe);


### PR DESCRIPTION
## Description
- This is meant to fix a bug when CReg is configured to reject duplicate aliases and you try to register a new compound with a duplicate alias. Currently CReg will save the parent, then return a 500 server error. Locally the error gets rendered properly in the client, but gives the false impression that the parent wasn't registered. In typical LiveDesign deployment scenarios, the 500 error is trapped by nginx and the CReg client can't properly handle & display the cause of the error.
- Added a call to "validateParentAliases" within the MetaLot processAndSave route _before_ the parent is saved. Previously it only happened as part of "updateParentAliases" which happened after the parent was saved.
- Switched the error response of MetaLot from 500 to 400. Along the way I discovered that the ACAS node proxy actually checks the content of the response for the word "Duplicate" and amends the status code to 409 if it finds that, but otherwise passes the status through. For all of the caught errors in MetaLot saving, a 400 "bad request" error which indicates bad inputs is more accurate than 500 "internal server error" which indicates an unexpected backend failure.

## Related Issue

## How Has This Been Tested?
Tested in local development. Will need to verify this in LD deployments.