### PR TITLE
Fix issue with missing implmentation by removing interface

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/LsThingService.java
+++ b/src/main/java/com/labsynch/labseer/service/LsThingService.java
@@ -113,8 +113,6 @@ public interface LsThingService {
 
 	Collection<Long> searchLsThingIdsByQueryDTO(LsThingQueryDTO query) throws Exception;
 
-	Collection<LsThing> getLsThingsByIds(Collection<Long> lsThingIds);
-
 	Collection<CodeTableDTO> convertToCodeTables(Collection<LsThing> lsThings);
 
 	Collection<CodeTableDTO> convertToCodeTables(Collection<LsThing> lsThings, String labelType);


### PR DESCRIPTION
## Description
Removed interface for LsThingService. getLsThingsByIds which has been replaced with LsThing.findLsThingsByIdsIn

## Related Issue
ACAS-460

## How Has This Been Tested?
Ran builds of BBChem, Indigo and Jchem docker images