### PR TITLE
Update swapParentStructures to raise BAD_REQUEST for invalid user inputs.

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiParentController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiParentController.java
@@ -94,7 +94,7 @@ public class ApiParentController {
 		HashMap<String,Object> response = new HashMap<>();
 		response.put("hasError", hasError);
 		response.put("errorMessage", errorMessage);
-		HttpStatus status = (hasError)? HttpStatus.INTERNAL_SERVER_ERROR : HttpStatus.OK;
+		HttpStatus status = (hasError)? HttpStatus.BAD_REQUEST : HttpStatus.OK;
 		
 		headers.add("Content-Type", "application/json; charset=utf-8");
 		return new ResponseEntity<String>(new JSONSerializer().serialize(response), headers, status);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
**Issue:**
When `swapParentStructures` API is called via LiveDesign with an invalid corporate name or when there are validation errors or when swap is going to introduce duplicates the response incorrectly mentions that LiveDesign is restarting.

**Bug:**
In `swapParentStructures` API when the swap doesn't go through we set the response status code to `INTERNAL_SERVER_ERROR` which LiveDesign treats as "an internal error".

**Fix:**
We didn't actually have any internal errors on the server but the client gave bad inputs and so we now change the response status to be `BAD_REQUEST`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACAS-430](https://jira.schrodinger.com/browse/ACAS-430)

## How Has This Been Tested?
<!--- Describe how this has been tested -->
Checked on an actual LiveDesign server that response json reaches the client.
Update acasclient logic and ran all acasclient tests.