### PR TITLE
ACAS-271: Preserve file naming in SDF bulk loader

### DIFF
--- a/src/main/java/com/labsynch/labseer/domain/BulkLoadFile.java
+++ b/src/main/java/com/labsynch/labseer/domain/BulkLoadFile.java
@@ -32,6 +32,9 @@ public class BulkLoadFile {
     @Size(max = 1000)
     private String fileName;
 
+    @Size(max = 1000)
+    private String originalFileName;
+
     private int numberOfMols;
 
     private int fileSize;
@@ -50,9 +53,10 @@ public class BulkLoadFile {
     public BulkLoadFile() {
     }
 
-    public BulkLoadFile(String fileName, int numberOfMols, int fileSize, String jsonTemplate, String recordedBy,
+    public BulkLoadFile(String fileName, String originalFileName, int numberOfMols, int fileSize, String jsonTemplate, String recordedBy,
             Date recordedDate) {
         this.fileName = fileName;
+        this.originalFileName = originalFileName;
         this.numberOfMols = numberOfMols;
         this.fileSize = fileSize;
         this.jsonTemplate = jsonTemplate;
@@ -270,6 +274,14 @@ public class BulkLoadFile {
 
     public void setFileName(String fileName) {
         this.fileName = fileName;
+    }
+
+    public String getOriginalFileName() {
+        return this.originalFileName;
+    }
+
+    public void setOriginalFileName(String originalFileName) {
+        this.originalFileName = originalFileName;
     }
 
     public int getNumberOfMols() {

--- a/src/main/java/com/labsynch/labseer/dto/BulkLoadRegisterSDFRequestDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/BulkLoadRegisterSDFRequestDTO.java
@@ -16,6 +16,8 @@ public class BulkLoadRegisterSDFRequestDTO {
 
     private String filePath;
 
+    private String originalFileName;
+
     private String userName;
 
     private Date fileDate;
@@ -51,6 +53,14 @@ public class BulkLoadRegisterSDFRequestDTO {
 
     public void setFilePath(String filePath) {
         this.filePath = filePath;
+    }
+
+    public String getOriginalFileName() {
+        return this.originalFileName;
+    }
+
+    public void setOriginalFileName(String originalFileName) {
+        this.originalFileName = originalFileName;
     }
 
     public String getUserName() {

--- a/src/main/java/com/labsynch/labseer/dto/PurgeFileResponseDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/PurgeFileResponseDTO.java
@@ -19,14 +19,17 @@ public class PurgeFileResponseDTO {
 
     private String fileName;
 
+    private String originalFileName;
+
     public PurgeFileResponseDTO() {
 
     }
 
-    public PurgeFileResponseDTO(String summary, boolean success, String fileName) {
+    public PurgeFileResponseDTO(String summary, boolean success, String fileName, String originalFileName) {
         this.summary = summary;
         this.success = success;
         this.fileName = fileName;
+        this.originalFileName = originalFileName;
     }
 
     public String toJson() {
@@ -56,6 +59,14 @@ public class PurgeFileResponseDTO {
 
     public void setFileName(String fileName) {
         this.fileName = fileName;
+    }
+
+    public String getOriginalFileName() {
+        return this.originalFileName;
+    }
+
+    public void setOriginalFileName(String originalFileName) {
+        this.originalFileName = originalFileName;
     }
 
     public static PurgeFileResponseDTO fromJsonToPurgeFileResponseDTO(String json) {

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -2334,6 +2334,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 		int numParents = 0;
 		int numContainers = 0;
 		String fileName = bulkLoadFile.getFileName();
+		String originalFileName = bulkLoadFile.getOriginalFileName();
 		Collection<Lot> lots = Lot.findLotsByBulkLoadFileEquals(bulkLoadFile).getResultList();
 		Set<String> lotCorpNames = new HashSet<String>();
 		for (Lot lot : lots) {
@@ -2395,8 +2396,8 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 		}
 		bulkLoadFile.remove();
 
-		String summary = generateSuccessfulPurgeHtml(fileName, numParents, numSaltForms, numLots, numContainers);
-		return new PurgeFileResponseDTO(summary, true, fileName);
+		String summary = generateSuccessfulPurgeHtml(originalFileName, numParents, numSaltForms, numLots, numContainers);
+		return new PurgeFileResponseDTO(summary, true, fileName, originalFileName);
 	}
 
 	public String generateSuccessfulPurgeHtml(String fileName, int numberOfParents,

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -279,6 +279,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 	public BulkLoadRegisterSDFResponseDTO registerSdf(BulkLoadRegisterSDFRequestDTO registerRequestDTO) {
 		// get properties out the request
 		String inputFileName = registerRequestDTO.getFilePath();
+		String originalFileName = registerRequestDTO.getOriginalFileName();
 		Long startTime = new Date().getTime();
 		String chemist = registerRequestDTO.getUserName();
 		Collection<ValidationResponseDTO> results = new ArrayList();
@@ -316,7 +317,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 			logger.info("shortFileName: " + shortFileName);
 
 			int fileSizeInBytes = (int) (new File(inputFileName)).length();
-			BulkLoadFile bulkLoadFile = new BulkLoadFile(shortFileName, 0, fileSizeInBytes,
+			BulkLoadFile bulkLoadFile = new BulkLoadFile(shortFileName, originalFileName, 0, fileSizeInBytes,
 					BulkLoadPropertyMappingDTO.toJsonArray(mappings), chemist, new Date());
 			if (registerRequestDTO.getFileDate() != null)
 				bulkLoadFile.setFileDate(registerRequestDTO.getFileDate());

--- a/src/main/resources/db/migration/postgres/V2.4.0.1__bulk_load_file_original_name.sql
+++ b/src/main/resources/db/migration/postgres/V2.4.0.1__bulk_load_file_original_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bulk_load_file ADD COLUMN original_file_name character varying(1000);
+UPDATE bulk_load_file SET original_file_name = file_name where original_file_name IS NULL;


### PR DESCRIPTION
## Description
ACAS introduces spaces and numbers in parentheses to keep SDF and zip filenames distinct because it drops them all into a common privateUploads folder. This makes life harder for users who may upload the same file multiple times but get different filenames when they re-download that same file from ACAS, or when they download derived zipfiles.

This acas-roo-server change adds an "originalFileName" column to bulk_load_file to track the original file name, and passes it back to the node layer for rendering.

## Related Issue

## How Has This Been Tested?
Local testing of uploading the same file many times. Confirmed that the validation download zip, its contents, the registration download zip, and all the links on the purge files page (including the link / summary after purging) all show the original filename, and all download the correct numbered / distinct file.