### PR TITLE
Need to skip ignroed and deleted aliases when checking for duplicates on the parent during bulk load registration

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -552,6 +552,11 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 				// Check list of aliases within file being bulkloaded
 				if (!propertiesUtilService.getAllowDuplicateParentAliases()) {
 					for (ParentAlias alias : parent.getParentAliases()) {
+						// Skip ignored and deleted aliases
+						if (alias.isDeleted() | alias.isIgnored()) {
+							continue;
+						}
+						// Make sure the parent doesn't already have this alias name
 						if (allAliasMaps.get(alias.getAliasName()) == null) {
 							allAliasMaps.put(alias.getAliasName(), numRecordsRead);
 						} else {


### PR DESCRIPTION
## Description
 - Ignored aliases were breaking our duplicate alias detection.  This skips aliases which are ignored or deleted from that validation.

## Related Issue
ACAS-477

## How Has This Been Tested?
Registered a compound with an alias of BLAH and then deleted that alias via the GUI which sets it to ignored in the database
Bulk loaded another lot of the same compound and verified that I got the same erroneous error `Within File, Parent Alias BLAH is not unique`
Applied my fix and the error went away
