### PR TITLE
Add more descriptive error message when user attempts to delete Stereo Category and Vendors with dependencies

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiStereoCategoryController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiStereoCategoryController.java
@@ -215,11 +215,11 @@ public class ApiStereoCategoryController {
 			logger.info("Hit an exception: " + e);
 			Long parentCount = Parent.countParentsByStereoCategory(stereoCategory);
 			logger.info("Unable to delete the stereoCategory: \"" + stereoCategory.getName()+ "\". " + parentCount
-			+ " parents associated with the stereoCategory.");
+			+ " parent(s) associated with the stereoCategory.");
 			ErrorMessage error = new ErrorMessage();
 			error.setLevel("ERROR");
 			error.setMessage("Unable to delete the stereoCategory: \"" + stereoCategory.getName()+ "\". " + parentCount
-					+ " parents associated with the stereoCategory.");
+					+ " parent(s) associated with the stereoCategory.");
 			errors.add(error);
 			return new ResponseEntity<String>(ErrorMessage.toJsonArray(errors), headers, HttpStatus.CONFLICT);
 		}

--- a/src/main/java/com/labsynch/labseer/api/ApiVendorController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiVendorController.java
@@ -212,12 +212,10 @@ public class ApiVendorController {
 		} catch (Exception e) {
 			logger.info("Hit an exception: " + e);
 			Long lotCount = Lot.countLotsByVendor(vendor);
-			logger.info("Unable to delete Vendor: \"" + vendor.getName() + "\". " + lotCount + " lots associated with the vendor."
-					+ vendor.getName());
+			logger.info("Unable to delete the Vendor: \"" + vendor.getName() + "\". " + lotCount + " lot(s) associated with the vendor.");
 			ErrorMessage error = new ErrorMessage();
 			error.setLevel("ERROR");
-			error.setMessage("Unable to delete Vendor: \"" + vendor.getName() + "\". " + lotCount + " lots associated with the vendor."
-					+ vendor.getName());
+			error.setMessage("Unable to delete the Vendor: \"" + vendor.getName() + "\". " + lotCount + " lot(s) associated with the vendor.");
 			errors.add(error);
 			return new ResponseEntity<String>(ErrorMessage.toJsonArray(errors), headers, HttpStatus.CONFLICT);
 		}


### PR DESCRIPTION
Making Vendor and Stereo Category Error Messages More Verbose

## Related Issue
https://github.com/mcneilco/acas/pull/1015

## How Has This Been Tested?
Testing reproduction cases as described in pull request in ACAS 