### PR TITLE
ACAS-481: Standardization duplicate checking to refactor for speed optimization

### DIFF
--- a/src/main/java/com/labsynch/labseer/domain/DryRunCompound.java
+++ b/src/main/java/com/labsynch/labseer/domain/DryRunCompound.java
@@ -10,6 +10,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 import javax.persistence.Version;
 
@@ -287,6 +288,31 @@ public class DryRunCompound {
         return q;
     }
 
+    public static TypedQuery<DryRunCompound> checkForDuplicateDryRunCompoundByCdId(Long dryRunRowId, int[] cdIds) {
+        if(cdIds == null)
+            throw new IllegalArgumentException("The cdIds argument is required");
+        if(dryRunRowId == null)
+            throw new IllegalArgumentException("The dryRunRowId argument is required");
+
+        DryRunCompound dryRunCompound = findDryRunCompound(dryRunRowId);
+        if(dryRunCompound == null)
+            throw new IllegalArgumentException("The dryRunRowId argument is invalid - no dryRunRow with id " + dryRunRowId + " found");
+        
+        EntityManager em = DryRunCompound.entityManager();
+        String queryBuilder = "SELECT o FROM DryRunCompound AS o WHERE o.cdId IN (:cdIds) AND o.id != :id and o.stereoCategory = :stereoCategory";
+        TypedQuery<DryRunCompound> q = em.createQuery(queryBuilder, DryRunCompound.class);
+        q.setParameter("cdIds", cdIds);
+        q.setParameter("id", dryRunCompound.getId());
+        q.setParameter("stereoCategory", dryRunCompound.getStereoCategory());
+        if(dryRunCompound.getStereoComment() == null) {
+            queryBuilder += " AND o.stereoComment IS NULL";
+        } else {
+            queryBuilder += " AND o.stereoComment = :stereoComment";
+            q.setParameter("stereoComment", dryRunCompound.getStereoComment());
+        }
+        return q;
+    }
+
     public String toString() {
         return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
     }
@@ -320,4 +346,5 @@ public class DryRunCompound {
         return new JSONDeserializer<List<DryRunCompound>>()
                 .use("values", DryRunCompound.class).deserialize(json);
     }
+
 }

--- a/src/main/java/com/labsynch/labseer/domain/DryRunCompound.java
+++ b/src/main/java/com/labsynch/labseer/domain/DryRunCompound.java
@@ -10,7 +10,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.PersistenceContext;
-import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 import javax.persistence.Version;
 

--- a/src/main/java/com/labsynch/labseer/domain/DryRunCompound.java
+++ b/src/main/java/com/labsynch/labseer/domain/DryRunCompound.java
@@ -288,31 +288,6 @@ public class DryRunCompound {
         return q;
     }
 
-    public static TypedQuery<DryRunCompound> checkForDuplicateDryRunCompoundByCdId(Long dryRunRowId, int[] cdIds) {
-        if(cdIds == null)
-            throw new IllegalArgumentException("The cdIds argument is required");
-        if(dryRunRowId == null)
-            throw new IllegalArgumentException("The dryRunRowId argument is required");
-
-        DryRunCompound dryRunCompound = findDryRunCompound(dryRunRowId);
-        if(dryRunCompound == null)
-            throw new IllegalArgumentException("The dryRunRowId argument is invalid - no dryRunRow with id " + dryRunRowId + " found");
-        
-        EntityManager em = DryRunCompound.entityManager();
-        String queryBuilder = "SELECT o FROM DryRunCompound AS o WHERE o.cdId IN (:cdIds) AND o.id != :id and o.stereoCategory = :stereoCategory";
-        TypedQuery<DryRunCompound> q = em.createQuery(queryBuilder, DryRunCompound.class);
-        q.setParameter("cdIds", cdIds);
-        q.setParameter("id", dryRunCompound.getId());
-        q.setParameter("stereoCategory", dryRunCompound.getStereoCategory());
-        if(dryRunCompound.getStereoComment() == null) {
-            queryBuilder += " AND o.stereoComment IS NULL";
-        } else {
-            queryBuilder += " AND o.stereoComment = :stereoComment";
-            q.setParameter("stereoComment", dryRunCompound.getStereoComment());
-        }
-        return q;
-    }
-
     public String toString() {
         return ReflectionToStringBuilder.toString(this, ToStringStyle.SHORT_PREFIX_STYLE);
     }

--- a/src/main/java/com/labsynch/labseer/domain/Parent.java
+++ b/src/main/java/com/labsynch/labseer/domain/Parent.java
@@ -710,6 +710,31 @@ public class Parent {
         return q;
     }
 
+    public static TypedQuery<Parent> checkForDuplicateParentByCdId(Long parentId, int[] cdIds) {
+        if(cdIds == null)
+            throw new IllegalArgumentException("The cdIds argument is required");
+        if(parentId == null)
+            throw new IllegalArgumentException("The parentId argument is required");
+
+        Parent parent = findParent(parentId);
+        if(parent == null)
+            throw new IllegalArgumentException("The parentId argument is invalid - no parent with id " + parentId + " found");
+        
+        EntityManager em = Parent.entityManager();
+        String queryBuilder = "SELECT o FROM Parent AS o WHERE o.cdId IN (:cdIds) AND o.id != :id and o.stereoCategory = :stereoCategory";
+        TypedQuery<Parent> q = em.createQuery(queryBuilder, Parent.class);
+        q.setParameter("cdIds", cdIds);
+        q.setParameter("id", parent.getId());
+        q.setParameter("stereoCategory", parent.getStereoCategory());
+        if(parent.getStereoComment() == null) {
+            queryBuilder += " AND o.stereoComment IS NULL";
+        } else {
+            queryBuilder += " AND o.stereoComment = :stereoComment";
+            q.setParameter("stereoComment", parent.getStereoComment());
+        }
+        return q;
+    }
+
     public String toJson() {
         return new JSONSerializer()
                 .exclude("*.class").serialize(this);

--- a/src/main/java/com/labsynch/labseer/domain/Parent.java
+++ b/src/main/java/com/labsynch/labseer/domain/Parent.java
@@ -713,6 +713,9 @@ public class Parent {
     }
 
     public static TypedQuery<Parent> checkForDuplicateParentByCdId(Long parentId, int[] cdIds) {
+        // Given a parent ID and list of structure ids
+        // Return a list of duplicates which have theame stereo category and stereo comment as the parent id
+        // exclude the parent id from the list
         if(cdIds == null)
             throw new IllegalArgumentException("The cdIds argument is required");
         if(parentId == null)
@@ -734,9 +737,9 @@ public class Parent {
         q.setParameter("cdIds", Arrays.stream(cdIds).boxed().collect( Collectors.toList() ));
         q.setParameter("id", parent.getId());
         q.setParameter("stereoCategory", parent.getStereoCategory());
-		if(parent.getStereoComment() != null) {
-			q.setParameter("stereoComment", parent.getStereoComment());
-		}
+        if(parent.getStereoComment() != null) {
+            q.setParameter("stereoComment", parent.getStereoComment());
+        }
         return q;
     }
 

--- a/src/main/java/com/labsynch/labseer/domain/Parent.java
+++ b/src/main/java/com/labsynch/labseer/domain/Parent.java
@@ -1,11 +1,13 @@
 package com.labsynch.labseer.domain;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -721,17 +723,20 @@ public class Parent {
             throw new IllegalArgumentException("The parentId argument is invalid - no parent with id " + parentId + " found");
         
         EntityManager em = Parent.entityManager();
-        String queryBuilder = "SELECT o FROM Parent AS o WHERE o.cdId IN (:cdIds) AND o.id != :id and o.stereoCategory = :stereoCategory";
-        TypedQuery<Parent> q = em.createQuery(queryBuilder, Parent.class);
-        q.setParameter("cdIds", cdIds);
-        q.setParameter("id", parent.getId());
-        q.setParameter("stereoCategory", parent.getStereoCategory());
+        String queryBuilder = "SELECT o FROM Parent AS o WHERE o.CdId IN (:cdIds) AND o.id != :id and o.stereoCategory = :stereoCategory";
+
         if(parent.getStereoComment() == null) {
             queryBuilder += " AND o.stereoComment IS NULL";
         } else {
             queryBuilder += " AND o.stereoComment = :stereoComment";
-            q.setParameter("stereoComment", parent.getStereoComment());
         }
+        TypedQuery<Parent> q = em.createQuery(queryBuilder, Parent.class);
+        q.setParameter("cdIds", Arrays.stream(cdIds).boxed().collect( Collectors.toList() ));
+        q.setParameter("id", parent.getId());
+        q.setParameter("stereoCategory", parent.getStereoCategory());
+		if(parent.getStereoComment() != null) {
+			q.setParameter("stereoComment", parent.getStereoComment());
+		}
         return q;
     }
 

--- a/src/main/java/com/labsynch/labseer/domain/StandardizationDryRunCompound.java
+++ b/src/main/java/com/labsynch/labseer/domain/StandardizationDryRunCompound.java
@@ -3,9 +3,11 @@ package com.labsynch.labseer.domain;
 import static java.lang.Math.toIntExact;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -650,6 +652,34 @@ public class StandardizationDryRunCompound {
 		q.setParameter("corpName", corpName);
 		return q;
 	}
+
+    public static TypedQuery<StandardizationDryRunCompound> checkForDuplicateStandardizationDryRunCompoundByCdId(Long standardizationDryRunRowId, int[] cdIds) {
+        if(cdIds == null)
+            throw new IllegalArgumentException("The cdIds argument is required");
+        if(standardizationDryRunRowId == null)
+            throw new IllegalArgumentException("The standardizationDryRunRowId argument is required");
+
+        StandardizationDryRunCompound standardizationDryRunCompound = findStandardizationDryRunCompound(standardizationDryRunRowId);
+        if(standardizationDryRunCompound == null)
+            throw new IllegalArgumentException("The standardizationDryRunRowId argument is invalid - no standardizationDryRunRow with id " + standardizationDryRunRowId + " found");
+        
+        EntityManager em = StandardizationDryRunCompound.entityManager();
+        String queryBuilder = "SELECT o FROM StandardizationDryRunCompound AS o WHERE o.CdId IN (:cdIds) AND o.id != :id and o.stereoCategory = :stereoCategory";
+
+        if(standardizationDryRunCompound.getStereoComment() == null) {
+            queryBuilder += " AND o.stereoComment IS NULL";
+        } else {
+            queryBuilder += " AND o.stereoComment = :stereoComment";
+        }
+        TypedQuery<StandardizationDryRunCompound> q = em.createQuery(queryBuilder, StandardizationDryRunCompound.class);
+        q.setParameter("cdIds", Arrays.stream(cdIds).boxed().collect( Collectors.toList() ));
+        q.setParameter("id", standardizationDryRunCompound.getId());
+        q.setParameter("stereoCategory", standardizationDryRunCompound.getStereoCategory());
+		if(standardizationDryRunCompound.getStereoComment() != null) {
+			q.setParameter("stereoComment", standardizationDryRunCompound.getStereoComment());
+		}
+        return q;
+    }
 
 	@PersistenceContext
 	transient EntityManager entityManager;

--- a/src/main/java/com/labsynch/labseer/domain/StandardizationDryRunCompound.java
+++ b/src/main/java/com/labsynch/labseer/domain/StandardizationDryRunCompound.java
@@ -653,32 +653,35 @@ public class StandardizationDryRunCompound {
 		return q;
 	}
 
-    public static TypedQuery<StandardizationDryRunCompound> checkForDuplicateStandardizationDryRunCompoundByCdId(Long standardizationDryRunRowId, int[] cdIds) {
-        if(cdIds == null)
-            throw new IllegalArgumentException("The cdIds argument is required");
-        if(standardizationDryRunRowId == null)
-            throw new IllegalArgumentException("The standardizationDryRunRowId argument is required");
+    public static TypedQuery<StandardizationDryRunCompound> checkForDuplicateStandardizationDryRunCompoundByCdId(Long standardizationDryRunCompoundId, int[] cdIds) {
+		// Given a a standardization dry run compound id ID and list of structure ids
+		// Return a list of StandardizationDryRunCompounds which have theame stereo category and stereo comment as the parent id
+		// exclude the StandardizationDryRunCompound id from the list
+		if(cdIds == null)
+			throw new IllegalArgumentException("The cdIds argument is required");
+		if(standardizationDryRunCompoundId == null)
+			throw new IllegalArgumentException("The standardizationDryRunRowId argument is required");
 
-        StandardizationDryRunCompound standardizationDryRunCompound = findStandardizationDryRunCompound(standardizationDryRunRowId);
-        if(standardizationDryRunCompound == null)
-            throw new IllegalArgumentException("The standardizationDryRunRowId argument is invalid - no standardizationDryRunRow with id " + standardizationDryRunRowId + " found");
-        
-        EntityManager em = StandardizationDryRunCompound.entityManager();
-        String queryBuilder = "SELECT o FROM StandardizationDryRunCompound AS o WHERE o.CdId IN (:cdIds) AND o.id != :id and o.stereoCategory = :stereoCategory";
+		StandardizationDryRunCompound standardizationDryRunCompound = findStandardizationDryRunCompound(standardizationDryRunCompoundId);
+		if(standardizationDryRunCompound == null)
+			throw new IllegalArgumentException("The standardizationDryRunRowId argument is invalid - no standardizationDryRunRow with id " + standardizationDryRunCompoundId + " found");
+		
+		EntityManager em = StandardizationDryRunCompound.entityManager();
+		String queryBuilder = "SELECT o FROM StandardizationDryRunCompound AS o WHERE o.CdId IN (:cdIds) AND o.id != :id and o.stereoCategory = :stereoCategory";
 
-        if(standardizationDryRunCompound.getStereoComment() == null) {
-            queryBuilder += " AND o.stereoComment IS NULL";
-        } else {
-            queryBuilder += " AND o.stereoComment = :stereoComment";
-        }
-        TypedQuery<StandardizationDryRunCompound> q = em.createQuery(queryBuilder, StandardizationDryRunCompound.class);
-        q.setParameter("cdIds", Arrays.stream(cdIds).boxed().collect( Collectors.toList() ));
-        q.setParameter("id", standardizationDryRunCompound.getId());
-        q.setParameter("stereoCategory", standardizationDryRunCompound.getStereoCategory());
+		if(standardizationDryRunCompound.getStereoComment() == null) {
+			queryBuilder += " AND o.stereoComment IS NULL";
+		} else {
+			queryBuilder += " AND o.stereoComment = :stereoComment";
+		}
+		TypedQuery<StandardizationDryRunCompound> q = em.createQuery(queryBuilder, StandardizationDryRunCompound.class);
+		q.setParameter("cdIds", Arrays.stream(cdIds).boxed().collect( Collectors.toList() ));
+		q.setParameter("id", standardizationDryRunCompound.getId());
+		q.setParameter("stereoCategory", standardizationDryRunCompound.getStereoCategory());
 		if(standardizationDryRunCompound.getStereoComment() != null) {
 			q.setParameter("stereoComment", standardizationDryRunCompound.getStereoComment());
 		}
-        return q;
+		return q;
     }
 
 	@PersistenceContext

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -479,7 +479,6 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			List<StandardizationDryRunCompound> dryRunDupes = StandardizationDryRunCompound.checkForDuplicateStandardizationDryRunCompoundByCdId(dryRunCompound.getId(), hits).getResultList();
 			newDupeCount = dryRunDupes.size();
 			if(newDupeCount > 0) {
-				dryRunCompound.setChangedStructure(true);
 				newDuplicateCorpNames = dryRunDupes
 					.stream()
 					.map(d -> d.getCorpName())

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -477,7 +477,7 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			// don't want to limit the hit counts here)
 			hits = chemStructureService.searchMolStructures(cmpdRegMolecules.get(tmpStructureKey),
 					StructureType.STANDARDIZATION_DRY_RUN, SearchType.DUPLICATE_TAUTOMER, -1F, -1);
-			List<DryRunCompound> dryRunDupes = DryRunCompound.checkForDuplicateDryRunCompoundByCdId(dryRunCompound.getId(), hits).getResultList();
+			List<StandardizationDryRunCompound> dryRunDupes = StandardizationDryRunCompound.checkForDuplicateStandardizationDryRunCompoundByCdId(dryRunCompound.getId(), hits).getResultList();
 			newDupeCount = dryRunDupes.size();
 			if(newDupeCount > 0) {
 				dryRunCompound.setChangedStructure(true);

--- a/src/main/java/com/labsynch/labseer/utils/Request.java
+++ b/src/main/java/com/labsynch/labseer/utils/Request.java
@@ -7,9 +7,13 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.concurrent.Callable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.commons.io.IOUtils;
 
 public class Request implements Callable<Response> {
+
+	Logger logger = LoggerFactory.getLogger(Request.class);
 
     private HttpURLConnection con;
     private URL obj;
@@ -49,6 +53,7 @@ public class Request implements Callable<Response> {
             String body = IOUtils.toString(inputStream);
             return new Response(id, responseCode, body);
         } catch (IOException e) {
+            logger.error("Error in Request", e);
             response = "{\"output\":\"some error occurred\"}";
             return new Response(id, 404, response);
         }

--- a/src/main/resources/db/migration/postgres/V2.4.0.2__standardization_dry_run_indexes.sql
+++ b/src/main/resources/db/migration/postgres/V2.4.0.2__standardization_dry_run_indexes.sql
@@ -1,0 +1,27 @@
+DO $$ 
+DECLARE
+	m   varchar[];
+	arr varchar[] := array[
+['stndzn_dry_run_stereo_category_idx', 'create index stndzn_dry_run_stereo_category_idx on standardization_dry_run_compound(stereo_category)'],
+['stndzn_dry_run_stereo_comment_idx', 'create index stndzn_dry_run_stereo_comment_idx on standardization_dry_run_compound(stereo_comment)'],
+['parent_stereocomment_idx', 'create index parent_stereocomment_idx on parent(stereo_comment)']
+  ];
+BEGIN
+  FOREACH m SLICE 1 IN ARRAY arr
+LOOP 
+   RAISE NOTICE '%', m[2];
+   IF EXISTS (
+    SELECT 1
+    FROM   pg_class c
+    JOIN   pg_namespace n ON n.oid = c.relnamespace
+    WHERE  lower(c.relname) = lower(m[1])
+    AND    n.nspname = CURRENT_SCHEMA
+    ) THEN
+    RAISE NOTICE 'INDEX EXISTS';
+   ELSE
+     EXECUTE m[2];
+     RAISE NOTICE 'CREATED INDEX %', m[1];
+
+END IF;
+END LOOP;
+END $$;


### PR DESCRIPTION
## Description
 - Pushes duplicate checking logic into the database for Standardization to speed up cases where there are many structure duplicates on the system that differ by stereo category and stereo comment.

## Related Issue
ACAS-481

## How Has This Been Tested?
Ran standardization dry run on a large scale system and times improved drastically from an unknown time (because it took to long to even give a time to 10871.80/rows per minute).