### PR TITLE
ACAS-488: Write list of mols to SDF

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/CmpdRegSDFWriter.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/CmpdRegSDFWriter.java
@@ -1,12 +1,15 @@
 package com.labsynch.labseer.chemclasses;
 
 import java.io.IOException;
+import java.util.List;
 
 import com.labsynch.labseer.exceptions.CmpdRegMolFormatException;
 
 public interface CmpdRegSDFWriter {
 
 	public boolean writeMol(CmpdRegMolecule mol) throws CmpdRegMolFormatException, IOException;
+
+	public boolean writeMols(List<CmpdRegMolecule> cmpdRegMoleculeList) throws CmpdRegMolFormatException, IOException;
 
 	public void close() throws IOException;
 

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureService.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureService.java
@@ -26,6 +26,8 @@ public interface BBChemStructureService {
 
     public String getSDF(BBChemParentStructure structure) throws IOException;
 
+    public String getSDF(List<BBChemParentStructure> bbchemStructures) throws IOException;
+
     public List<BBChemParentStructure> parseSDF(String molfile) throws CmpdRegMolFormatException;
 
     public List<String> getMolFragments(String molfile) throws CmpdRegMolFormatException;

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
@@ -476,7 +476,7 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 	}
 
 	@Override
-	public String getSDF(BBChemParentStructure bbChemStructure) throws IOException {
+	public String getSDF(List<BBChemParentStructure> bbChemStructures) throws IOException {
 
 		String url = getUrlFromPreprocessorSettings("exportSDFURL");
 
@@ -486,27 +486,41 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 
 		// Create sdfs arraynode and mol node
 		ArrayNode sdfsNode = mapper.createArrayNode();
-		ObjectNode molNode = mapper.createObjectNode();
 
-		// Add the properties to the mol node
-		ArrayNode propertiesNode = mapper.createArrayNode();
-		for (Map.Entry<String, String> entry : bbChemStructure.getProperties().entrySet()) {
-			ObjectNode propertyNode = mapper.createObjectNode();
-			propertyNode.put("name", entry.getKey());
-			propertyNode.put("value", entry.getValue());
-			propertiesNode.add(propertyNode);
+		for(BBChemParentStructure bbChemStructure : bbChemStructures) {
+			ObjectNode molNode = mapper.createObjectNode();
 
+			// Add the properties to the mol node
+			ArrayNode propertiesNode = mapper.createArrayNode();
+			for (Map.Entry<String, String> entry : bbChemStructure.getProperties().entrySet()) {
+				ObjectNode propertyNode = mapper.createObjectNode();
+				propertyNode.put("name", entry.getKey());
+				propertyNode.put("value", entry.getValue());
+				propertiesNode.add(propertyNode);
+	
+			}
+			molNode.put("properties", propertiesNode);
+	
+			// Add the structure to the mol node
+			molNode.put("sdf", bbChemStructure.getMol());
+	
+			// Add the mol node to the sdfs array node
+			sdfsNode.add(molNode);
+	
+			// Add the sdfs to the request data
+			requestData.put("sdfs", sdfsNode);
+	
+			// Post to the service and parse the response
+			String requestString = requestData.toString();
+			logger.debug("requestString: " + requestString);
+			String postResponse = SimpleUtil.postRequestToExternalServer(url, requestString, logger);
+			logger.debug("Got response: " + postResponse);
+	
+			// Parse the response json
+			ObjectMapper responseMapper = new ObjectMapper();
+			JsonNode responseNode = responseMapper.readTree(postResponse);
+			return responseNode.asText();
 		}
-		molNode.put("properties", propertiesNode);
-
-		// Add the structure to the mol node
-		molNode.put("sdf", bbChemStructure.getMol());
-
-		// Add the mol node to the sdfs array node
-		sdfsNode.add(molNode);
-
-		// Add the sdfs to the request data
-		requestData.put("sdfs", sdfsNode);
 
 		// Post to the service and parse the response
 		String requestString = requestData.toString();
@@ -518,6 +532,15 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 		ObjectMapper responseMapper = new ObjectMapper();
 		JsonNode responseNode = responseMapper.readTree(postResponse);
 		return responseNode.asText();
+
+	}
+
+	@Override
+	public String getSDF(BBChemParentStructure bbChemStructure) throws IOException {
+
+		ArrayList<BBChemParentStructure> structureList = new ArrayList<BBChemParentStructure>();
+		structureList.add(bbChemStructure);
+		return getSDF(structureList);
 	}
 
 	@Override

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
@@ -507,25 +507,18 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 			// Add the mol node to the sdfs array node
 			sdfsNode.add(molNode);
 	
-			// Add the sdfs to the request data
-			requestData.put("sdfs", sdfsNode);
 	
-			// Post to the service and parse the response
-			String requestString = requestData.toString();
-			logger.debug("requestString: " + requestString);
-			String postResponse = SimpleUtil.postRequestToExternalServer(url, requestString, logger);
-			logger.debug("Got response: " + postResponse);
-	
-			// Parse the response json
-			ObjectMapper responseMapper = new ObjectMapper();
-			JsonNode responseNode = responseMapper.readTree(postResponse);
-			return responseNode.asText();
 		}
 
+		// Add the sdfs to the request data
+		requestData.put("sdfs", sdfsNode);
+		
 		// Post to the service and parse the response
 		String requestString = requestData.toString();
+		logger.info("Making to bbchem sdf export service");
 		logger.debug("requestString: " + requestString);
 		String postResponse = SimpleUtil.postRequestToExternalServer(url, requestString, logger);
+		logger.info("Got response from bbchem sdf export service");
 		logger.debug("Got response: " + postResponse);
 
 		// Parse the response json

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/CmpdRegSDFWriterBBChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/CmpdRegSDFWriterBBChemImpl.java
@@ -3,6 +3,8 @@ package com.labsynch.labseer.chemclasses.bbchem;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.labsynch.labseer.chemclasses.CmpdRegMolecule;
 import com.labsynch.labseer.chemclasses.CmpdRegSDFWriter;
@@ -50,6 +52,23 @@ public class CmpdRegSDFWriterBBChemImpl implements CmpdRegSDFWriter {
         CmpdRegMoleculeBBChemImpl molWrapper = (CmpdRegMoleculeBBChemImpl) molecule;
         try {
             this.writer.write(bbChemStructureServices.getSDF(molWrapper.molecule));
+        } catch (Exception e) {
+            logger.error("Unable to write mol", e);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean writeMols(List<CmpdRegMolecule> cmpdRegMoleculeList) throws CmpdRegMolFormatException, IOException {
+        try {
+            List<BBChemParentStructure> cmpdRegMoleculeBBChemImplList = new ArrayList<BBChemParentStructure>();
+            for (CmpdRegMolecule molecule : cmpdRegMoleculeList) {
+                CmpdRegMoleculeBBChemImpl molWrapper = (CmpdRegMoleculeBBChemImpl) molecule;
+                cmpdRegMoleculeBBChemImplList.add(molWrapper.molecule);
+            }
+
+            this.writer.write(bbChemStructureServices.getSDF(cmpdRegMoleculeBBChemImplList));
         } catch (Exception e) {
             logger.error("Unable to write mol", e);
             return false;

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/CmpdRegSDFWriterBBChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/CmpdRegSDFWriterBBChemImpl.java
@@ -51,7 +51,8 @@ public class CmpdRegSDFWriterBBChemImpl implements CmpdRegSDFWriter {
     public boolean writeMol(CmpdRegMolecule molecule) throws CmpdRegMolFormatException, IOException {
         CmpdRegMoleculeBBChemImpl molWrapper = (CmpdRegMoleculeBBChemImpl) molecule;
         try {
-            this.writer.write(bbChemStructureServices.getSDF(molWrapper.molecule));
+            String sdfText = bbChemStructureServices.getSDF(molWrapper.molecule);
+            this.writer.write(sdfText);
         } catch (Exception e) {
             logger.error("Unable to write mol", e);
             return false;
@@ -67,8 +68,8 @@ public class CmpdRegSDFWriterBBChemImpl implements CmpdRegSDFWriter {
                 CmpdRegMoleculeBBChemImpl molWrapper = (CmpdRegMoleculeBBChemImpl) molecule;
                 cmpdRegMoleculeBBChemImplList.add(molWrapper.molecule);
             }
-
-            this.writer.write(bbChemStructureServices.getSDF(cmpdRegMoleculeBBChemImplList));
+            String sdfText = bbChemStructureServices.getSDF(cmpdRegMoleculeBBChemImplList);
+            this.writer.write(sdfText);
         } catch (Exception e) {
             logger.error("Unable to write mol", e);
             return false;

--- a/src/main/java/com/labsynch/labseer/chemclasses/indigo/CmpdRegSDFWriterIndigoImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/indigo/CmpdRegSDFWriterIndigoImpl.java
@@ -1,6 +1,7 @@
 package com.labsynch.labseer.chemclasses.indigo;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +28,14 @@ public class CmpdRegSDFWriterIndigoImpl implements CmpdRegSDFWriter {
 		this.writer = indigo.writeBuffer();
 	}
 
+	@Override
+    public boolean writeMols(List<CmpdRegMolecule> cmpdRegMoleculeList) throws CmpdRegMolFormatException, IOException {
+        for (CmpdRegMolecule molecule : cmpdRegMoleculeList) {
+			writeMol(molecule);
+		}
+        return true;
+    }
+	
 	@Override
 	public boolean writeMol(CmpdRegMolecule molecule) throws CmpdRegMolFormatException, IOException {
 		CmpdRegMoleculeIndigoImpl molWrapper = (CmpdRegMoleculeIndigoImpl) molecule;

--- a/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegSDFWriterJChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegSDFWriterJChemImpl.java
@@ -2,6 +2,7 @@ package com.labsynch.labseer.chemclasses.jchem;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.List;
 
 import org.apache.commons.io.output.ByteArrayOutputStream;
 
@@ -37,6 +38,14 @@ public class CmpdRegSDFWriterJChemImpl implements CmpdRegSDFWriter {
 	public void close() throws IOException {
 		this.molExporter.close();
 	}
+
+	@Override
+    public boolean writeMols(List<CmpdRegMolecule> cmpdRegMoleculeList) throws CmpdRegMolFormatException, IOException {
+        for (CmpdRegMolecule molecule : cmpdRegMoleculeList) {
+			writeMol(molecule);
+		}
+        return true;
+    }
 
 	@Override
 	public boolean writeMol(CmpdRegMolecule molecule) throws CmpdRegMolFormatException, IOException {

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -3,6 +3,7 @@ package com.labsynch.labseer.service;
 import java.io.File;
 import java.io.IOException;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -590,6 +591,7 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 				.getCmpdRegMolecules(standardizationDryRunHashCompoundHashmap, StructureType.STANDARDIZATION_DRY_RUN);
 
 		// Loop stndznCompounds and write cmpdreg molecule to the sdf file
+		List<CmpdRegMolecule> cmpdRegMoleculeList = new ArrayList<CmpdRegMolecule>();
 		for (StandardizationDryRunCompound stndznCompound : stndznCompounds) {
 			CmpdRegMolecule cmpdRegMolecule = cmpdRegMolecules.get(stndznCompound.getCorpName());
 			if (cmpdRegMolecule != null) {
@@ -609,10 +611,9 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 						String.valueOf(stndznCompound.isAsDrawnDisplayChange()));
 				cmpdRegMolecule.setProperty("Stereo Category", stndznCompound.getStereoCategory());
 				cmpdRegMolecule.setProperty("Stereo Comment", stndznCompound.getStereoComment());
-				sdfWriter.writeMol(cmpdRegMolecule);
 			}
 		}
-		sdfWriter.close();
+		sdfWriter.writeMols(cmpdRegMoleculeList);
 
 		// Return the path to the sdf file
 		return sdfFileName;

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -611,10 +611,11 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 						String.valueOf(stndznCompound.isAsDrawnDisplayChange()));
 				cmpdRegMolecule.setProperty("Stereo Category", stndznCompound.getStereoCategory());
 				cmpdRegMolecule.setProperty("Stereo Comment", stndznCompound.getStereoComment());
+				cmpdRegMoleculeList.add(cmpdRegMolecule);
 			}
 		}
 		sdfWriter.writeMols(cmpdRegMoleculeList);
-
+		sdfWriter.close();
 		// Return the path to the sdf file
 		return sdfFileName;
 	}


### PR DESCRIPTION
## Description
 - Add `writeMols(List<CmpdRegMolecule> cmpdRegMoleculeList)`
 - This speeds up some implementations which are faster writing to SDF in bulk than one at a time
 - Fixed a bug that we weren't closing the file which is required to fully flush the file writer. Without this change we could intermittently loose a few mols in the output file.

## Related Issue
ACAS-488

## How Has This Been Tested?
Tested by downloading 18K compounds which takes about 1 minute with this new code