### PR TITLE
ACAS-494: Fill missing structure ignore empty mols

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/ChemStructureServiceBBChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/ChemStructureServiceBBChemImpl.java
@@ -858,7 +858,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 		EntityManager em = BBChemParentStructure.entityManager();
 		Query q = em.createNativeQuery("SELECT p.id FROM " + structureType.name() + " p LEFT JOIN "
 				+ getBBChemStructureTableNameFromStructureType(structureType)
-				+ " b on p.cd_id=b.id where p.mol_structure is not null and b.id is null");
+				+ " b on p.cd_id=b.id where p.mol_structure is not null and p.mol_structure != '' and b.id is null");
 		return q.getResultList();
 	}
 

--- a/src/main/resources/db/migration/bbchem/postgres/V2.4.0.4__bbchem_fill_missing_structures_fix.sql
+++ b/src/main/resources/db/migration/bbchem/postgres/V2.4.0.4__bbchem_fill_missing_structures_fix.sql
@@ -1,0 +1,10 @@
+-- Delete bbchem_salt_form structures which are a result of having an empty mol_structure.
+DELETE FROM bbchem_salt_form_structure
+USING salt_form
+WHERE bbchem_salt_form_structure.id = salt_form.cd_id
+and salt_form.mol_structure = '';
+
+-- Update cd_ids to be 0 for compounds which have an empty mol_structure
+UPDATE salt_form
+SET cd_id = 0
+where salt_form.mol_structure = '';


### PR DESCRIPTION
## Description
**Steps to Reproduce**: 

- On a system with ACAS w/BBChem register a compound with the UI (not bulk loader).
- Restart ACAS
- Once acas is up, do a database search for the salt_form like:
- select * from salt_form where corp_name = 'CMPD-0000003';

**Expected Results:**
The salt_form.cd_id should be 0

**Actual Results:**
The salt_form.cd_id is set to a number

**Extra Information:**
ACAS runs a process on startup looking for structures that are filled in but are missing a chemical representation in the corresponding structure table (in this case that table is bbchem_salt_form_structure). The code is not ignoring mol_structures which are set to "" and trying to register them.
This isn't causing any obvious problems in the database but its unnecessary work and causes some confusion. If a structure is empty it's cd_id should be 0.

## Related Issue
ACAS-494

## How Has This Been Tested?
To test flyway migration, restarted a system and verified all structures with a number > 0 for cd_id and mol_structure = '' went away using:

```
 id | mol | substructure | similarity | pre_reg | recorded_date | reg | version | registration_comment | registration_status | standardization_comment | standardization_status | id | cd_id | cas_number | corp_name | ignore | mol_structure | registration_date | salt_weight | version | chemist | parent | bulk_load_file 
----+-----+--------------+------------+---------+---------------+-----+---------+----------------------+---------------------+-------------------------+------------------------+----+-------+------------+-----------+--------+---------------+-------------------+-------------+---------+---------+--------+----------------
(0 rows)
```

Verified all mol_structures with null or '' as mol structure had 0 as cd_id

```
acas=> select distinct cd_id from salt_form where mol_structure is null or mol_structure = '';
 cd_id 
-------
     0
```

To test new fill salt form structure code on startup I register a new compound and restarted ACAS (after the flyway migration had already been run).  I verified with the above queries that the cd_id did not get changed and no new salt forms structures had been created.  Additionally the logs print:

```
No SALT_FORM ids missing structure representations
```