### PR TITLE
ACAS-495: Fix salt_form fill structures

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/ChemStructureServiceBBChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/ChemStructureServiceBBChemImpl.java
@@ -962,13 +962,13 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 
 		for (List<Long> group : groups) {
 			
-			p = p + fillMissingParentStructuresByParentIDList(group);
+			p = p + fillMissingSaltFormStructuresBySaltFormIDList(group);
 			// Compute your percentage.
 			percent = (float) Math.floor(p * 100f / totalCount);
 			if (percent != previousPercent) {
 				currentTime = new Date().getTime();
 				// Output if different from the last time.
-				logger.info("filling " + " " + StructureType.PARENT + " structure representations " + percent
+				logger.info("filling " + " " + StructureType.SALT_FORM + " structure representations " + percent
 						+ "% complete (" + p + " of "
 						+ totalCount + ") average speed (rows/min):"
 						+ (p / ((currentTime - startTime) / 60.0 / 1000.0)));
@@ -1002,7 +1002,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 		logger.info("Finished processing " + structureIdSaltFormMolStructureMap.size() + " "
 				+ StructureType.SALT_FORM + " structures");
 		logger.info("Started saving " + processedStructures.size() + " " + StructureType.SALT_FORM + " structures");
-		// Loop through parents
+		// Loop through salt forms
 		for (SaltForm saltForm : saltForms) {
 			String originalCdId = String.valueOf(saltForm.getCdId());
 			BBChemParentStructure processedParentStructure = processedStructures.get(originalCdId);


### PR DESCRIPTION
## Description
 - Fix issue with calling the wrong method and not actually updating salt_form structures
 - Fix comment which referenced parents instead of salt_forms

## Related Issue
ACAS-495

## How Has This Been Tested?
Truncated a bbchem_salt_form_structure table and restarted ACAS
Verified bbchem_salt_form_structure was re populated with all structures from salt_form where mol_structure was not empty.
Verified that salt_form.cd_ids were update with corresponding new entries.