### PR TITLE
ACAS-496: Fill missing salt structure representations on start, allow duplicates.

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -829,14 +829,6 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 
 	private int runStandardization() throws CmpdRegMolFormatException, IOException, StandardizerException {
 		logger.info("standardization initialized");
-		logger.info("save missing salt structures - started");
-		try {
-			Collection<Salt> missingSaltStructures = saltStructureService.saveMissingStructures();
-			logger.info("saved " + missingSaltStructures.size() + " missing salt structures");
-		} catch (StructureSaveException e) {
-			throw new StandardizerException(e);
-		}
-		logger.info("save missing salt structures - complete");
 		logger.info("restandardize parent structures - started");
 		int result = -1;
 		try {


### PR DESCRIPTION
## Description
 - Fill missing salt structure representation on startup rather than on standardization
 - Allow duplicate salt structures instead of skipping over duplicates when filling in missing structures (in rare cases some system may have duplicate salt structures and this process shouldn't fix that).
 - 

## Related Issue
ACAS-496

## How Has This Been Tested?
Ran the following sql to create a salt duplicate:

```
insert into salt (select nextval('hibernate_sequence'), abbrev, 0, formula, false, mol_structure, mol_weight, 'test', original_structure, 0, charge from salt limit 1);
 ```

With the original code, verified that restarting ACAS did not fill in the salt structure and printed that it was a duplicate salt.

With the new code, varied that the correct row was created in bbchem_salt_structure and the cd_id of the salt was updated to match the new structure row.
