### PR TITLE
ACAS-473: Fix BBChem in-memory SDF writer

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/CmpdRegSDFWriterBBChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/CmpdRegSDFWriterBBChemImpl.java
@@ -1,8 +1,9 @@
 package com.labsynch.labseer.chemclasses.bbchem;
 
-import java.io.File;
+import java.io.Writer;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,9 +24,7 @@ public class CmpdRegSDFWriterBBChemImpl implements CmpdRegSDFWriter {
     @Autowired
     private BBChemStructureService bbChemStructureServices;
 
-    private FileWriter writer;
-
-    private File tempFile;
+    private Writer writer;
 
     public CmpdRegSDFWriterBBChemImpl(String fileName) {
         try {
@@ -37,14 +36,7 @@ public class CmpdRegSDFWriterBBChemImpl implements CmpdRegSDFWriter {
     }
 
     public CmpdRegSDFWriterBBChemImpl() {
-        try {
-            this.tempFile = File.createTempFile("bbchem-molwriter-", ".sdf");
-            this.tempFile.deleteOnExit();
-            this.writer = new FileWriter(this.tempFile.getAbsolutePath());
-        } catch (IOException e) {
-            logger.error("Unable to write sdf", e);
-        }
-
+        this.writer = new StringWriter();
     }
 
     @Override
@@ -80,9 +72,6 @@ public class CmpdRegSDFWriterBBChemImpl implements CmpdRegSDFWriter {
     @Override
     public void close() throws IOException {
         this.writer.close();
-        if (this.tempFile != null && this.tempFile.exists()) {
-            this.tempFile.delete();
-        }
     }
 
     @Override


### PR DESCRIPTION
## Description
- This change is a fix for the in-memory / file-less SDF writer in the BBChem implementation. It is used by the SaltService to produce an SDF when users download all salts.
- Prior implementation returned a string like `java.io.FileWriter@490b189e`
- This fixes it to use a StringWriter whose "toString" method works as intended and returns all the text that has been written to the writer.

## Related Issue

## How Has This Been Tested?
Tested on frost-acas-quickstart.dev.bb.schrodinger.com by tagging `ACAS-473-dev1` from my dev branch, and deploying the tag onto that server which uses bbchem.
Confirmed the issue before updating roo, and confirmed it produces a proper SDF after this change.