### PR TITLE
ACAS-502: Max auto lot number for bulk loader

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/LotServiceImpl.java
@@ -94,7 +94,7 @@ public class LotServiceImpl implements LotService {
 		if(propertiesUtilService.getMaxAutoLotNumber() != null && lot.getLotNumber() > propertiesUtilService.getMaxAutoLotNumber()){
 			newLotNumber = lot.getLotNumber();
 		} else {
-			newLotNumber = Lot.getMaxParentLotNumber(parent) + 1;
+			newLotNumber = Lot.getMaxParentLotNumber(parent, propertiesUtilService.getMaxAutoLotNumber()) + 1;
 		}
 		return newLotNumber;
 	}
@@ -528,10 +528,13 @@ public class LotServiceImpl implements LotService {
 				int lotCount = 0;
 				if (lot.getParent().getId() == null) {
 					logger.debug("Setting lotCount of new parent = 0");
-				} else if (Lot.getMaxParentLotNumber(lot.getParent()) == null) {
-					logger.debug("this is a null pointer exception. Set lotCount = 0");
 				} else {
-					lotCount = Lot.getMaxParentLotNumber(lot.getParent());
+					Integer maxLotNumber = Lot.getMaxParentLotNumber(lot.getParent(), propertiesUtilService.getMaxAutoLotNumber());
+					if (maxLotNumber == null) {
+						logger.debug("this is a null pointer exception. Set lotCount = 0");
+					} else {
+						lotCount = maxLotNumber;
+					}
 				}
 				logger.debug("Lot Count = " + lotCount);
 				lotNumber = lotCount + 1;


### PR DESCRIPTION
## Description
 - Use max auto lot number if set to select lot numbers < or equal to the max auto lot number when getting the next lot number during bulk reg and reparent lot
 - Previously reparent lot paid attention to maxAutolot number only for the purposes of keeping a lot number if it was above the max auto lot number, however if the target parent had a lot greater than the max auto auto lot number it would still grab this large lot number and add 1 to it.

## Related Issue
ACAS-502

## How Has This Been Tested?
Loaded a compound with lot number 1
Added a lot manually with lot number 1001
Bulk loaded another lot and verified the lot number assigned was lot 2
Reparented a lot onto a parent that had a lot number of 1001 and verified it was assigned lot 3 (lowest lot number below the max auto lot number) 