### PR TITLE
Acas 387 url fix

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
@@ -48,16 +48,16 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 	private static final String ERROR_STRUCTURE = "ERROR_STRUCTURE";
 
 
-	private final String CONVERTER_PATH = "/converter/api/v0/convert";
+	private final String CONVERTER_PATH = "/converter/api/v0/convert/";
 	private final String EXPORTSDF_PATH = "/sdf_export/api/v0/";
 	private final String FINGERPRINT_PATH = "/fingerprint/api/v0/";
 	private final String IMAGE_PATH = "/image/api/v0/";	
 	private final String PARSESDF_PATH =  "/parse/api/v0/";	
-	private final String PROCESS_PATH = "/preprocessor/api/v0/process";
-	private final String SPLIT_PATH = "/split/api/v0";
-	private final String SUBSTRUCTURE_PATH = "/substructure/api/v0";
+	private final String PROCESS_PATH = "/preprocessor/api/v0/process/";
+	private final String SPLIT_PATH = "/split/api/v0/";
+	private final String SUBSTRUCTURE_PATH = "/substructure/match/api/v0/";
 	private final String CONFIG_CHECK_PATH = "/preprocessor/api/v0/config/check";
-	private final String CONFIG_FIX_PATH = "/preprocessor/api/v0/config/fix";
+	private final String CONFIG_FIX_PATH = "/preprocessor/api/v0/config/fix/";
 	private final String HEALTH_PATH = "/preprocessor/api/v0/health";
 
 	@Override

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
@@ -693,8 +693,8 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 			}
 			return matchMap;
 		} catch (Exception e) {
-			logger.error("Error posting to fingerprint service: " + e.getMessage());
-			throw new CmpdRegMolFormatException("Error posting to fingerprint service: " + e.getMessage());
+			logger.error("Error posting to substructure service: " + e.getMessage());
+			throw new CmpdRegMolFormatException("Error posting to substructure service: " + e.getMessage());
 		}
 	}
 


### PR DESCRIPTION
## Description
 - Fixing issues with URL refactor

## Related Issue
ACAS-387

## How Has This Been Tested?
Placed debugger in each BBChemStructureService URL and verified each one worked.


Path | Worked
-- | --
private final String CONVERTER_PATH = "/converter/api/v0/convert/"; | 1
private final String EXPORTSDF_PATH = "/sdf_export/api/v0/"; | 1
private final String FINGERPRINT_PATH = "/fingerprint/api/v0/"; | 1
private final String IMAGE_PATH = "/image/api/v0/"; | 1
private final String PARSESDF_PATH = "/parse/api/v0/"; | 1
private final String PROCESS_PATH = "/preprocessor/api/v0/process/"; | 1
private final String SPLIT_PATH = "/split/api/v0/"; | 1
private final String SUBSTRUCTURE_PATH = "/substructure/api/v0/"; | 1
private final String CONFIG_CHECK_PATH = "/preprocessor/api/v0/config/check/"; | 1
private final String CONFIG_FIX_PATH = "/preprocessor/api/v0/config/fix/"; | 1
private final String HEALTH_PATH = "/preprocessor/api/v0/health/"; | 1

