### PR TITLE
Fixed: Alias dropped when new lot of compound gets registered in bulk loader

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -837,15 +837,13 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 
 						Set<String> parentAliasStrings = new HashSet<>();
 						for(ParentAlias alias : parent.getParentAliases()){
-							if (! alias.isIgnored())
-							{
+							if (! alias.isIgnored()) {
 								parentAliasStrings.add(alias.getAliasName());
 							}
 						}
 						Set<String> foundParentAliasStrings = new HashSet<>(); 
 						for(ParentAlias alias : foundParent.getParentAliases()){
-							if (! alias.isIgnored())
-							{
+							if (! alias.isIgnored()) {
 							foundParentAliasStrings.add(alias.getAliasName());
 							}
 						}
@@ -863,8 +861,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 						// Only need to do this if no problems found in previous loop; otherwise redundant 
 						// to processs that occurs after
 						{
-							for(ParentAlias alias : foundParent.getParentAliases())
-							{
+							for(ParentAlias alias : foundParent.getParentAliases()) {
 								// Check alias in parentAlias (String Comparison)
 								// if not found then equal Aliases is false 
 								if(! alias.isIgnored() && !parentAliasStrings.contains(alias.getAliasName())){
@@ -874,25 +871,20 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 						}	
 
 						// If Incoming Parent and Found Parent Have Equal Aliases 
-						if(equalAliases)
-						{
+						if(equalAliases) {
 							// No Changes or Modifications Needed; Can Break Loop
 							// Continue 
 							parent = foundParent;
 							break searchResultLoop; 
-						}
-						else
-						{
+						} else { 
 							Set<ParentAlias> unionParentAliases = parent.getParentAliases();
 							// Parent Would Be Found Parent w/ Appropriate Updates
 							parent = foundParent;
 							// Update Parent Object to Have "Union" of All Aliases 
-							for(ParentAlias oldAlias : parent.getParentAliases())
-							{
+							for(ParentAlias oldAlias : parent.getParentAliases()) {
 								// If oldAlias Not In UnionParentAliases (Use Previously Set<str> to Do Compare)
 									// Add to Aliases Union List 
-								if(! oldAlias.isIgnored() && !parentAliasStrings.contains(oldAlias.getAliasName()))
-								{
+								if(! oldAlias.isIgnored() && !parentAliasStrings.contains(oldAlias.getAliasName())) {
 									unionParentAliases.add(oldAlias);
 								}
 							}

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -837,18 +837,24 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 
 						Set<String> parentAliasStrings = new HashSet<>();
 						for(ParentAlias alias : parent.getParentAliases()){
-							parentAliasStrings.add(alias.toString());
+							if (! alias.isIgnored())
+							{
+								parentAliasStrings.add(alias.getAliasName());
+							}
 						}
 						Set<String> foundParentAliasStrings = new HashSet<>(); 
 						for(ParentAlias alias : foundParent.getParentAliases()){
-							foundParentAliasStrings.add(alias.toString());
+							if (! alias.isIgnored())
+							{
+							foundParentAliasStrings.add(alias.getAliasName());
+							}
 						}
 
 						for(ParentAlias alias : parent.getParentAliases())
 						{
 							// Check alias in foundParentAlias (String Comparison)
 							// if not found then equalAliases is false 
-							if(!foundParentAliasStrings.contains(alias.toString())){
+							if(! alias.isIgnored() && !foundParentAliasStrings.contains(alias.getAliasName())){
 								equalAliases = false;
 							}
 						}
@@ -861,7 +867,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 							{
 								// Check alias in parentAlias (String Comparison)
 								// if not found then equal Aliases is false 
-								if(!parentAliasStrings.contains(alias.toString())){
+								if(! alias.isIgnored() && !parentAliasStrings.contains(alias.getAliasName())){
 									equalAliases = false; 
 								}
 							}
@@ -885,7 +891,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 							{
 								// If oldAlias Not In UnionParentAliases (Use Previously Set<str> to Do Compare)
 									// Add to Aliases Union List 
-								if(!parentAliasStrings.contains(oldAlias.toString()))
+								if(! oldAlias.isIgnored() && !parentAliasStrings.contains(oldAlias.getAliasName()))
 								{
 									unionParentAliases.add(oldAlias);
 								}

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -492,7 +492,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 			return null;
 		}
 		try {
-			parent = validateParent(parent, mappings, numRecordsRead, results);
+			parent = validateParent(parent, chemist, mappings, numRecordsRead, results);
 		} catch (PersistenceException rollbackException) {
 			logError(rollbackException, numRecordsRead, mol, mappings, errorMolExporter, results,
 					errorCSVOutStream);
@@ -768,7 +768,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 		String warning = categoryCode + ": " + categoryDescription;
 	}
 
-	public Parent validateParent(Parent parent, Collection<BulkLoadPropertyMappingDTO> mappings, int numRecordsRead,
+	public Parent validateParent(Parent parent, String chemist, Collection<BulkLoadPropertyMappingDTO> mappings, int numRecordsRead,
 			Collection<ValidationResponseDTO> validationResponse)
 			throws MissingPropertyException, DupeParentException, SaltedCompoundException, Exception {
 		// Search for the parent structure + stereo category
@@ -825,9 +825,77 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 							|| foundParent.getCorpName().contains(parent.getLabelPrefix().getLabelPrefix()));
 					if (sameStereoCategory & sameStereoComment
 							& (sameCorpName | (noCorpName & sameCorpPrefixOrNoPrefix))) {
-						// parents match
-						parent = foundParent;
-						break searchResultLoop;
+						// parents match (based on above criteria)
+						boolean equalAliases = true; // assumption is aliases are same unless proven to be false
+
+						// Need to Create String Sets to Do 
+						// "Is alias (str) of parent in aliases of foundParent (set of strs)?" (and vice versa) logic 
+
+						// Note: This is not the most efficient / concise code to do this process
+						// however due to readability and the assumingly small number of aliases 
+						// parents will have this is fine 
+
+						Set<String> parentAliasStrings = new HashSet<>();
+						for(ParentAlias alias : parent.getParentAliases()){
+							parentAliasStrings.add(alias.toString());
+						}
+						Set<String> foundParentAliasStrings = new HashSet<>(); 
+						for(ParentAlias alias : foundParent.getParentAliases()){
+							foundParentAliasStrings.add(alias.toString());
+						}
+
+						for(ParentAlias alias : parent.getParentAliases())
+						{
+							// Check alias in foundParentAlias (String Comparison)
+							// if not found then equalAliases is false 
+							if(!foundParentAliasStrings.contains(alias.toString())){
+								equalAliases = false;
+							}
+						}
+
+						if(equalAliases) 
+						// Only need to do this if no problems found in previous loop; otherwise redundant 
+						// to processs that occurs after
+						{
+							for(ParentAlias alias : foundParent.getParentAliases())
+							{
+								// Check alias in parentAlias (String Comparison)
+								// if not found then equal Aliases is false 
+								if(!parentAliasStrings.contains(alias.toString())){
+									equalAliases = false; 
+								}
+							}
+						}	
+
+						// If Incoming Parent and Found Parent Have Equal Aliases 
+						if(equalAliases)
+						{
+							// No Changes or Modifications Needed; Can Break Loop
+							// Continue 
+							parent = foundParent;
+							break searchResultLoop; 
+						}
+						else
+						{
+							Set<ParentAlias> unionParentAliases = parent.getParentAliases();
+							// Parent Would Be Found Parent w/ Appropriate Updates
+							parent = foundParent;
+							// Update Parent Object to Have "Union" of All Aliases 
+							for(ParentAlias oldAlias : parent.getParentAliases())
+							{
+								// If oldAlias Not In UnionParentAliases (Use Previously Set<str> to Do Compare)
+									// Add to Aliases Union List 
+								if(!parentAliasStrings.contains(oldAlias.toString()))
+								{
+									unionParentAliases.add(oldAlias);
+								}
+							}
+							parent.setParentAliases(unionParentAliases);
+							// If Alias List Updated Then Updated Modified By and Modified Date 
+							parent.setModifiedDate(new Date());
+							parent.setModifiedBy(chemist);
+							
+						}
 					} else if (sameStereoCategory & sameStereoComment & !sameCorpName & !noCorpName) {
 						// corp name conflict
 						logger.error(


### PR DESCRIPTION
**Steps to Reproduce**

Bulk load a new structure with a Parent Alias mapped in. This creates a new parent with the alias, and a new lot.

Then load the same structure with a different Parent Alias value. This will create a new lot on the existing parent.

**Bug Behavior**

A new lot is created, but the alias from the second upload is ignored. The parent ends up with one alias (only the one from the first upload).

**Fixed Behavior**

A new lot will be created and the existing parent will be updated to add the new Parent Alias value. The parent will end up with two aliases (one from each upload)

**Example**

One of the tests I conducted was to have one compound with the alias "Dale's Favorite Compound" and I uploaded the same structure with the alias of "Second Alias". The result was two lots with the same parent. The parent contains both aliases. 

<img width="634" alt="Screen Shot 2022-11-02 at 11 09 04 AM" src="https://user-images.githubusercontent.com/97194463/199526442-8f574572-1463-46fc-95a6-07b74d3a1723.png">

