### PR TITLE
ACAS-498 Add writeup TEXT column to FileList

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiFileSaveController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiFileSaveController.java
@@ -41,6 +41,7 @@ public class ApiFileSaveController {
 
 	@RequestMapping(method = RequestMethod.POST)
 	public HttpEntity<String> create(@RequestParam("description[]") List<String> description,
+			@RequestParam("writeup[]") List<String> writeup,
 			@RequestParam("subdir") String subdir,
 			@RequestParam("ie") boolean ie,
 			@RequestParam("file[]") List<MultipartFile> file) {
@@ -49,6 +50,7 @@ public class ApiFileSaveController {
 
 		FileSaveSendDTO fileSave = new FileSaveSendDTO();
 		fileSave.setDescription(description);
+		fileSave.setWriteup(writeup);
 		fileSave.setFile(file);
 		fileSave.setIe(ie);
 		fileSave.setSubdir(subdir);

--- a/src/main/java/com/labsynch/labseer/domain/FileList.java
+++ b/src/main/java/com/labsynch/labseer/domain/FileList.java
@@ -69,6 +69,8 @@ public class FileList {
 
     private String filePath;
 
+    private String writeup;
+
     public MultipartFile getFile() {
         return file;
     }
@@ -316,7 +318,7 @@ public class FileList {
     transient EntityManager entityManager;
 
     public static final List<String> fieldNames4OrderClauseFilter = java.util.Arrays.asList("logger", "lot",
-            "description", "name", "type", "size", "url", "ie", "uploaded", "file", "fileName", "subdir", "filePath");
+            "description", "name", "type", "size", "url", "ie", "uploaded", "file", "fileName", "subdir", "filePath", "writeup");
 
     public static final EntityManager entityManager() {
         EntityManager em = new FileList().entityManager;
@@ -421,5 +423,13 @@ public class FileList {
 
     public void setFilePath(String filePath) {
         this.filePath = filePath;
+    }
+
+    public String getWriteup() {
+        return this.writeup;
+    }
+
+    public void setWriteup(String writeup) {
+        this.writeup = writeup;
     }
 }

--- a/src/main/java/com/labsynch/labseer/dto/FileSaveReturnDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/FileSaveReturnDTO.java
@@ -34,6 +34,8 @@ public class FileSaveReturnDTO {
 
     private String description;
 
+    private String writeup;
+
     private Boolean uploaded;
 
     private Boolean ie;
@@ -150,6 +152,14 @@ public class FileSaveReturnDTO {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public String getWriteup() {
+        return this.writeup;
+    }
+
+    public void setWriteup(String writeup) {
+        this.writeup = writeup;
     }
 
     public Boolean getUploaded() {

--- a/src/main/java/com/labsynch/labseer/dto/FileSaveSendDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/FileSaveSendDTO.java
@@ -38,6 +38,8 @@ public class FileSaveSendDTO {
 
 	private List<String> description = new ArrayList<String>();
 
+	private List<String> writeup = new ArrayList<String>();
+
 	@Transient
 	private List<MultipartFile> file = new ArrayList<MultipartFile>();
 
@@ -55,6 +57,8 @@ public class FileSaveSendDTO {
 
 		List<String> descriptionList = this.description;
 
+		List<String> writeupList = this.writeup;
+
 		List<FileSaveReturnDTO> fileSaveArray = new ArrayList<FileSaveReturnDTO>();
 
 		logger.debug("FileSaveSendDTO: Number of files to save: " + fileList.size());
@@ -65,6 +69,7 @@ public class FileSaveSendDTO {
 
 			if (!file.isEmpty()) {
 				String description = descriptionList.get(i);
+				String writeup = writeupList.get(i);
 				FileSaveReturnDTO fileSaveReturn = new FileSaveReturnDTO();
 				try {
 					InputStream in = file.getInputStream();
@@ -113,6 +118,7 @@ public class FileSaveSendDTO {
 					fileSaveReturn.setUploaded(true);
 					fileSaveReturn.setUrl(urlString);
 					fileSaveReturn.setDescription(description);
+					fileSaveReturn.setWriteup(writeup);
 					fileSaveReturn.setIe(this.getIe());
 					fileSaveReturn.setSubdir(this.getSubdir());
 
@@ -191,6 +197,14 @@ public class FileSaveSendDTO {
 
 	public void setDescription(List<String> description) {
 		this.description = description;
+	}
+
+	public List<String> getWriteup() {
+		return this.writeup;
+	}
+
+	public void setWriteup(List<String> writeup) {
+		this.writeup = writeup;
 	}
 
 	public void setFile(List<MultipartFile> file) {

--- a/src/main/resources/db/migration/postgres/V2.4.0.6__file_add_writeup_column.sql
+++ b/src/main/resources/db/migration/postgres/V2.4.0.6__file_add_writeup_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE file_list ADD COLUMN writeup TEXT;


### PR DESCRIPTION
## Description
ACAS-498 adds a new "Writeup" text field associated with each analytical file attached to a Lot in CReg. The purpose of this is to store standard NMR and LCMS writeup information (https://pubsapp.acs.org/paragonplus/submission/acs_nmr_guidelines.pdf) used in publications, alongside the corresponding pdfs and raw data.

The portion in this PR adds a new "writeup" TEXT type column to the `file_list` table, and plumbs that new field through the FileList domain class and a few DTO classes, and through the API method used when saving analytical files.

## Related Issue

## How Has This Been Tested?
Tested locally that I can upload and save an analytical file with a writeup. Confirmed that it's rendered properly when the page is reloaded after save.
<img width="903" alt="Screen Shot 2022-11-03 at 1 05 37 PM" src="https://user-images.githubusercontent.com/18313455/199823935-5f30a545-9795-4d1b-b9cf-e8d85de90328.png">