### PR TITLE
ACAS-504: Improve BBChem bulk SDF upload performance

### DIFF
--- a/Dockerfile-multistage
+++ b/Dockerfile-multistage
@@ -7,7 +7,7 @@ ENV     CHEMISTRY_PACKAGE=${CHEMISTRY_PACKAGE}
 
 FROM 	dependencies as jchem
 COPY 	lib/jchem-16.4.25.0.jar /lib/jchem-16.4.25.0.jar
-RUN   mvn install:install-file -Dfile=/lib/jchem-16.4.25.0.jar -DartifactId=jchem -DgroupId=com.chemaxon -Dversion=16.4.25.0 -Dpackaging=jar -DgeneratePom=true -DcreateChecksum=true
+RUN 	--mount=type=cache,target=/root/.m2  mvn install:install-file -Dfile=/lib/jchem-16.4.25.0.jar -DartifactId=jchem -DgroupId=com.chemaxon -Dversion=16.4.25.0 -Dpackaging=jar -DgeneratePom=true -DcreateChecksum=true
 
 FROM 	dependencies as bbchem
 

--- a/src/main/java/com/labsynch/labseer/chemclasses/CmpdRegSDFReader.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/CmpdRegSDFReader.java
@@ -1,6 +1,7 @@
 package com.labsynch.labseer.chemclasses;
 
 import java.io.IOException;
+import java.util.Collection;
 
 import com.labsynch.labseer.exceptions.CmpdRegMolFormatException;
 
@@ -9,5 +10,7 @@ public interface CmpdRegSDFReader {
 	public void close() throws IOException;
 
 	public CmpdRegMolecule readNextMol() throws IOException, CmpdRegMolFormatException;
+
+	public Collection<CmpdRegMolecule> readNextMols(int nMols) throws IOException, CmpdRegMolFormatException;
 
 }

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureService.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureService.java
@@ -31,7 +31,7 @@ public interface BBChemStructureService {
 
     public List<BBChemParentStructure> parseSDF(String molfile) throws CmpdRegMolFormatException;
 
-    public List<String> getMolFragments(String molfile) throws CmpdRegMolFormatException;
+    public List<List<String>> getMolFragments(List<String> molfile) throws CmpdRegMolFormatException;
 
     public HashMap<? extends AbstractBBChemStructure, Boolean> substructureMatch(String queryMol,
             List<? extends AbstractBBChemStructure> needMatchMolFiles) throws CmpdRegMolFormatException;

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
@@ -510,7 +510,7 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 		
 		// Post to the service and parse the response
 		String requestString = requestData.toString();
-		logger.info("Making to bbchem sdf export service");
+		logger.info("Making call to bbchem sdf export service");
 		logger.debug("requestString: " + requestString);
 		String postResponse = SimpleUtil.postRequestToExternalServer(url, requestString, logger);
 		logger.info("Got response from bbchem sdf export service");
@@ -612,7 +612,7 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 		try {
 			String requestString = requestData.toString();
 			logger.debug("requestString: " + requestString);
-			logger.info("Making to bbchem split service");
+			logger.info("Making call to bbchem split service");
 			HttpURLConnection connection = SimpleUtil.postRequest(url, requestString, logger);
 			logger.info("Got response from bbchem split service");
 			String postResponse = null;

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/ChemStructureServiceBBChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/ChemStructureServiceBBChemImpl.java
@@ -5,6 +5,8 @@ import static java.lang.Math.toIntExact;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -522,11 +524,26 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 	public boolean checkForSalt(String molfile) throws CmpdRegMolFormatException {
 		boolean foundNonCovalentSalt = false;
 		// Get all fragments
-		List<String> allFrags = bbChemStructureService.getMolFragments(molfile);
+		List<String> allFrags = bbChemStructureService.getMolFragments(Arrays.asList(molfile)).get(0);
 		if (allFrags.size() > 1.0) {
 			foundNonCovalentSalt = true;
 		}
 		return foundNonCovalentSalt;
+	}
+
+	@Override
+	public List<Boolean> checkForSalts(Collection<String> molfiles) throws CmpdRegMolFormatException {
+		List<Boolean> hasSaltList = new ArrayList<Boolean>();
+		List<List<String>> fragmentsList = bbChemStructureService.getMolFragments(new ArrayList(molfiles));
+		for (List<String> allFrags : fragmentsList) {
+			if (allFrags.size() > 1.0) {
+				hasSaltList.add(true);
+			}
+			else{
+				hasSaltList.add(false);
+			}
+		}
+		return hasSaltList;
 	}
 
 	@Override
@@ -622,7 +639,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 	public StrippedSaltDTO stripSalts(CmpdRegMolecule inputStructure) throws CmpdRegMolFormatException {
 
 		// Get all fragments
-		List<String> allFrags = bbChemStructureService.getMolFragments(inputStructure.getMolStructure());
+		List<String> allFrags = bbChemStructureService.getMolFragments(Arrays.asList(inputStructure.getMolStructure())).get(0);
 
 		// Loop through the fragments and search for salts that match
 		// If a fragment matches, add it to the salt counts

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/CmpdRegSDFReaderBBChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/CmpdRegSDFReaderBBChemImpl.java
@@ -3,6 +3,8 @@ package com.labsynch.labseer.chemclasses.bbchem;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Scanner;
 
 import com.labsynch.labseer.chemclasses.CmpdRegMolecule;
@@ -45,6 +47,32 @@ public class CmpdRegSDFReaderBBChemImpl implements CmpdRegSDFReader {
         } else {
             return null;
         }
+    }
+
+    @Override
+    public Collection<CmpdRegMolecule> readNextMols(int nMols) throws IOException, CmpdRegMolFormatException {
+        int molsRead = 0;
+        String sdfContents = "";
+        // read nMols MOL strings from the SDF
+        while (molsRead < nMols){
+            if(this.scanner.hasNext()) {
+                sdfContents += scanner.next();
+                sdfContents += "$$$$\n";
+                molsRead++;
+            } else {
+                break;
+            }
+        }
+        Collection<CmpdRegMolecule> cmpdRegMols = new ArrayList<CmpdRegMolecule>();
+        if (sdfContents.length() > 0){
+            Collection<BBChemParentStructure> molecules = bbChemStructureService.parseSDF(sdfContents);
+            for (BBChemParentStructure molecule : molecules) {
+                CmpdRegMolecule cmpdRegMol = new CmpdRegMoleculeBBChemImpl(molecule, bbChemStructureService);
+                cmpdRegMols.add(cmpdRegMol);
+            }
+        }
+        
+        return cmpdRegMols;
     }
 
 }

--- a/src/main/java/com/labsynch/labseer/chemclasses/indigo/ChemStructureServiceIndigoImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/indigo/ChemStructureServiceIndigoImpl.java
@@ -306,6 +306,15 @@ public class ChemStructureServiceIndigoImpl implements ChemStructureService {
 	}
 
 	@Override
+	public List<Boolean> checkForSalts(Collection<String> molfiles) throws CmpdRegMolFormatException {
+		List<Boolean> hasSaltList = new ArrayList<Boolean>();
+		for (String molfile : molfiles) {
+			hasSaltList.add(checkForSalt(molfile));
+		}
+		return hasSaltList;
+	}
+
+	@Override
 	public StrippedSaltDTO stripSalts(CmpdRegMolecule inputStructure) throws CmpdRegMolFormatException {
 		CmpdRegMoleculeIndigoImpl molWrapper = (CmpdRegMoleculeIndigoImpl) inputStructure;
 		IndigoObject rawMolecule = molWrapper.molecule;

--- a/src/main/java/com/labsynch/labseer/chemclasses/indigo/ChemStructureServiceIndigoImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/indigo/ChemStructureServiceIndigoImpl.java
@@ -5,6 +5,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -205,7 +206,9 @@ public class ChemStructureServiceIndigoImpl implements ChemStructureService {
 			Query query = em.createNativeQuery(baseQuery + bingoFunction + orderBy);
 
 			query.setParameter("queryMol", mol.molfile());
-			query.setMaxResults(maxResults);
+			if (maxResultCount > -1) {
+				query.setMaxResults(maxResults);
+			}
 
 			// May need additional research / decisions around which options to use
 			// Basic Indigo search types corresponding to JChem search types

--- a/src/main/java/com/labsynch/labseer/chemclasses/indigo/CmpdRegSDFReaderIndigoImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/indigo/CmpdRegSDFReaderIndigoImpl.java
@@ -39,17 +39,17 @@ public class CmpdRegSDFReaderIndigoImpl implements CmpdRegSDFReader {
 	public Collection<CmpdRegMolecule> readNextMols(int nMols) throws IOException, CmpdRegMolFormatException {
 		int molsRead = 0;
 		Collection<CmpdRegMolecule> cmpdRegMols = new ArrayList<CmpdRegMolecule>();
-        // read nMols MOL strings from the SDF
-        while (molsRead < nMols){
-            if(this.reader.hasNext()) {
-                CmpdRegMoleculeIndigoImpl molecule = new CmpdRegMoleculeIndigoImpl(reader.next());
+		// read nMols MOL strings from the SDF
+		while (molsRead < nMols){
+			if(this.reader.hasNext()) {
+				CmpdRegMoleculeIndigoImpl molecule = new CmpdRegMoleculeIndigoImpl(reader.next());
 				cmpdRegMols.add(molecule);
-                molsRead++;
-            } else {
-                break;
-            }
-        }
-        return cmpdRegMols;
-	}
+				molsRead++;
+			} else {
+				break;
+			}
+		}
+		return cmpdRegMols;
+		}
 
 }

--- a/src/main/java/com/labsynch/labseer/chemclasses/indigo/CmpdRegSDFReaderIndigoImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/indigo/CmpdRegSDFReaderIndigoImpl.java
@@ -1,6 +1,8 @@
 package com.labsynch.labseer.chemclasses.indigo;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 
 import com.epam.indigo.Indigo;
 import com.epam.indigo.IndigoObject;
@@ -36,12 +38,12 @@ public class CmpdRegSDFReaderIndigoImpl implements CmpdRegSDFReader {
 	@Override
 	public Collection<CmpdRegMolecule> readNextMols(int nMols) throws IOException, CmpdRegMolFormatException {
 		int molsRead = 0;
-        String sdfContents = "";
+		Collection<CmpdRegMolecule> cmpdRegMols = new ArrayList<CmpdRegMolecule>();
         // read nMols MOL strings from the SDF
         while (molsRead < nMols){
-            if(this.scanner.hasNext()) {
+            if(this.reader.hasNext()) {
                 CmpdRegMoleculeIndigoImpl molecule = new CmpdRegMoleculeIndigoImpl(reader.next());
-				cmpdRegMols.add(cmpdRegMol);
+				cmpdRegMols.add(molecule);
                 molsRead++;
             } else {
                 break;

--- a/src/main/java/com/labsynch/labseer/chemclasses/indigo/CmpdRegSDFReaderIndigoImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/indigo/CmpdRegSDFReaderIndigoImpl.java
@@ -33,4 +33,21 @@ public class CmpdRegSDFReaderIndigoImpl implements CmpdRegSDFReader {
 		}
 	}
 
+	@Override
+	public Collection<CmpdRegMolecule> readNextMols(int nMols) throws IOException, CmpdRegMolFormatException {
+		int molsRead = 0;
+        String sdfContents = "";
+        // read nMols MOL strings from the SDF
+        while (molsRead < nMols){
+            if(this.scanner.hasNext()) {
+                CmpdRegMoleculeIndigoImpl molecule = new CmpdRegMoleculeIndigoImpl(reader.next());
+				cmpdRegMols.add(cmpdRegMol);
+                molsRead++;
+            } else {
+                break;
+            }
+        }
+        return cmpdRegMols;
+	}
+
 }

--- a/src/main/java/com/labsynch/labseer/chemclasses/jchem/ChemStructureServiceJChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/jchem/ChemStructureServiceJChemImpl.java
@@ -558,6 +558,15 @@ public class ChemStructureServiceJChemImpl implements ChemStructureService {
 	}
 
 	@Override
+	public List<Boolean> checkForSalts(Collection<String> molfiles) throws CmpdRegMolFormatException {
+		List<Boolean> hasSaltList = new ArrayList<Boolean>();
+		for (String molfile : molfiles) {
+			hasSaltList.add(checkForSalt(molfile));
+		}
+		return hasSaltList;
+	}
+
+	@Override
 	public StrippedSaltDTO stripSalts(CmpdRegMolecule inputStructure) {
 		CmpdRegMoleculeJChemImpl molWrapper = (CmpdRegMoleculeJChemImpl) inputStructure;
 		Molecule mol = molWrapper.molecule;

--- a/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegSDFReaderJChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegSDFReaderJChemImpl.java
@@ -3,6 +3,7 @@ package com.labsynch.labseer.chemclasses.jchem;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 
 import com.labsynch.labseer.chemclasses.CmpdRegMolecule;

--- a/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegSDFReaderJChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegSDFReaderJChemImpl.java
@@ -40,4 +40,22 @@ public class CmpdRegSDFReaderJChemImpl implements CmpdRegSDFReader {
 		CmpdRegMoleculeJChemImpl molecule = new CmpdRegMoleculeJChemImpl(mol);
 		return molecule;
 	}
+
+	@Override
+	public Collection<CmpdRegMolecule> readNextMols(int nMols) throws IOException, CmpdRegMolFormatException {
+		int molsRead = 0;
+        String sdfContents = "";
+        // read nMols MOL strings from the SDF
+        while (molsRead < nMols){
+			Molecule mol = this.molImporter.read();
+            if(mol != null) {
+                CmpdRegMoleculeJChemImpl molecule = new CmpdRegMoleculeJChemImpl(mol);
+				cmpdRegMols.add(cmpdRegMol);
+                molsRead++;
+            } else {
+                break;
+            }
+        }
+        return cmpdRegMols;
+	}
 }

--- a/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegSDFReaderJChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegSDFReaderJChemImpl.java
@@ -3,6 +3,7 @@ package com.labsynch.labseer.chemclasses.jchem;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.Collection;
 
 import com.labsynch.labseer.chemclasses.CmpdRegMolecule;
 import com.labsynch.labseer.chemclasses.CmpdRegSDFReader;
@@ -44,13 +45,13 @@ public class CmpdRegSDFReaderJChemImpl implements CmpdRegSDFReader {
 	@Override
 	public Collection<CmpdRegMolecule> readNextMols(int nMols) throws IOException, CmpdRegMolFormatException {
 		int molsRead = 0;
-		String sdfContents = "";
+		Collection<CmpdRegMolecule> cmpdRegMols = new ArrayList<CmpdRegMolecule>();
 		// read nMols MOL strings from the SDF
 		while (molsRead < nMols){
 			Molecule mol = this.molImporter.read();
 			if(mol != null) {
 				CmpdRegMoleculeJChemImpl molecule = new CmpdRegMoleculeJChemImpl(mol);
-				cmpdRegMols.add(cmpdRegMol);
+				cmpdRegMols.add(molecule);
 				molsRead++;
 			} else {
 				break;

--- a/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegSDFReaderJChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegSDFReaderJChemImpl.java
@@ -44,18 +44,18 @@ public class CmpdRegSDFReaderJChemImpl implements CmpdRegSDFReader {
 	@Override
 	public Collection<CmpdRegMolecule> readNextMols(int nMols) throws IOException, CmpdRegMolFormatException {
 		int molsRead = 0;
-        String sdfContents = "";
-        // read nMols MOL strings from the SDF
-        while (molsRead < nMols){
+		String sdfContents = "";
+		// read nMols MOL strings from the SDF
+		while (molsRead < nMols){
 			Molecule mol = this.molImporter.read();
-            if(mol != null) {
-                CmpdRegMoleculeJChemImpl molecule = new CmpdRegMoleculeJChemImpl(mol);
+			if(mol != null) {
+				CmpdRegMoleculeJChemImpl molecule = new CmpdRegMoleculeJChemImpl(mol);
 				cmpdRegMols.add(cmpdRegMol);
-                molsRead++;
-            } else {
-                break;
-            }
-        }
-        return cmpdRegMols;
-	}
+				molsRead++;
+			} else {
+				break;
+			}
+		}
+		return cmpdRegMols;
+		}
 }

--- a/src/main/java/com/labsynch/labseer/domain/Parent.java
+++ b/src/main/java/com/labsynch/labseer/domain/Parent.java
@@ -36,6 +36,7 @@ import javax.persistence.criteria.Root;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import com.labsynch.labseer.chemclasses.CmpdRegMolecule;
 import com.labsynch.labseer.dto.LabelPrefixDTO;
 import com.labsynch.labseer.dto.SearchFormDTO;
 
@@ -138,6 +139,9 @@ public class Parent {
 
     @Transient
     private transient LabelPrefixDTO labelPrefix;
+
+    @Transient
+    private transient CmpdRegMolecule cmpdRegMolecule;
 
     @Transactional
     public static void deleteAllParents() {
@@ -956,6 +960,14 @@ public class Parent {
 
     public void setIsMixture(Boolean isMixture) {
         this.isMixture = isMixture;
+    }
+
+    public CmpdRegMolecule getCmpdRegMolecule() {
+        return this.cmpdRegMolecule;
+    }
+
+    public void setCmpdRegMolecule(CmpdRegMolecule cmpdRegMolecule) {
+        this.cmpdRegMolecule = cmpdRegMolecule;
     }
 
     @PersistenceContext

--- a/src/main/java/com/labsynch/labseer/domain/Parent.java
+++ b/src/main/java/com/labsynch/labseer/domain/Parent.java
@@ -143,6 +143,9 @@ public class Parent {
     @Transient
     private transient CmpdRegMolecule cmpdRegMolecule;
 
+    @Transient
+    private transient Boolean multipleFragments;
+
     @Transactional
     public static void deleteAllParents() {
         List<Parent> parents = Parent.findAllParents();
@@ -968,6 +971,14 @@ public class Parent {
 
     public void setCmpdRegMolecule(CmpdRegMolecule cmpdRegMolecule) {
         this.cmpdRegMolecule = cmpdRegMolecule;
+    }
+
+    public Boolean getMultipleFragments() {
+        return this.multipleFragments;
+    }
+
+    public void setMultipleFragments(Boolean multipleFragments) {
+        this.multipleFragments = multipleFragments;
     }
 
     @PersistenceContext

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -1623,8 +1623,10 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 		if (standardizedMol == null) {
 			if (propertiesUtilService.getUseExternalStandardizerConfig()) {
 				// Standardize this single structure
-				String standardizedMolStructure = chemStructureService.standardizeStructure(mol.getMolStructure());
-				standardizedMol = moleculeFactory.getCmpdRegMolecule(standardizedMolStructure);
+				HashMap<String, String> inMap = new HashMap<String, String>();
+				inMap.put("tmp", mol.getMolStructure());
+				HashMap<String, CmpdRegMolecule> outMap = chemStructureService.standardizeStructures(inMap);
+				standardizedMol = outMap.get("tmp");
 			} else {
 				// If standardization is disabled, pass through the current mol as the "standardized" structures
 				standardizedMol = mol;

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -401,13 +401,11 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 			CmpdRegSDFWriter registeredMolExporter = sdfWriterFactory.getCmpdRegSDFWriter(registeredSDFName);
 			HashMap<String, Integer> allAliasMaps = new HashMap<String, Integer>();
 
-			// CmpdRegMolecule mol = null;
 			int numRecordsRead = 0;
 			int numNewParentsLoaded = 0;
 			int numNewLotsOldParentsLoaded = 0;
 			boolean done = false;
 
-			//TODO try to refactor this into a chunked reader with a clean iterator
 			int batchSize = propertiesUtilService.getStandardizationBatchSize();
 			while (!done) {
 				// Read the next set of molecules from the SDF
@@ -861,7 +859,6 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 					"mol is empty and registerNoStructureCompoundsAsUniqueParents so not checking for dupe parents by structure but other dupe checking will be done");
 		} else {
 			dupeParentList = chemStructureService.searchMolStructures(parent.getCmpdRegMolecule(), StructureType.PARENT, ChemStructureService.SearchType.DUPLICATE_TAUTOMER, -1F, -1);
-			// dupeParentList = chemStructureService.checkDupeMol(parent.getMolStructure(), StructureType.PARENT);
 		}
 		if (dupeParentList.length > 0) {
 			searchResultLoop: for (int foundParentCdId : dupeParentList) {
@@ -1024,8 +1021,6 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 	public Parent validateParentAgainstDryRunCompound(Parent parent, int numRecordsRead,
 			Collection<ValidationResponseDTO> validationResponse)
 			throws MissingPropertyException, DupeParentException, SaltedCompoundException, Exception {
-		// int[] dupeDryRunCompoundsList = chemStructureService.checkDupeMol(parent.getMolStructure(),
-		// 		StructureType.DRY_RUN);
 		int[] dupeDryRunCompoundsList = chemStructureService.searchMolStructures(parent.getCmpdRegMolecule(), StructureType.DRY_RUN, ChemStructureService.SearchType.DUPLICATE_TAUTOMER,  -1F, -1);
 		if (dupeDryRunCompoundsList.length > 0) {
 			searchResultLoop: for (int foundParentCdId : dupeDryRunCompoundsList) {

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -272,7 +272,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 	@Transactional
 	public int saveDryRunCompound(CmpdRegMolecule mol, Parent parent, int numRecordsRead, DryRunCompound dryRunCompound)
 			throws CmpdRegMolFormatException {
-		int cdId = chemStructureService.saveStructure(mol.getMolStructure(), StructureType.DRY_RUN, false);
+		int cdId = chemStructureService.saveStructure(parent.getCmpdRegMolecule(), StructureType.DRY_RUN, false);
 		dryRunCompound = new DryRunCompound();
 		dryRunCompound.setCdId(cdId);
 		dryRunCompound.setRecordNumber(numRecordsRead);
@@ -833,7 +833,8 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 			logger.warn(
 					"mol is empty and registerNoStructureCompoundsAsUniqueParents so not checking for dupe parents by structure but other dupe checking will be done");
 		} else {
-			dupeParentList = chemStructureService.checkDupeMol(parent.getMolStructure(), StructureType.PARENT);
+			dupeParentList = chemStructureService.searchMolStructures(parent.getCmpdRegMolecule(), StructureType.PARENT, ChemStructureService.SearchType.DUPLICATE_TAUTOMER, -1F, -1);
+			// dupeParentList = chemStructureService.checkDupeMol(parent.getMolStructure(), StructureType.PARENT);
 		}
 		if (dupeParentList.length > 0) {
 			searchResultLoop: for (int foundParentCdId : dupeParentList) {
@@ -992,8 +993,9 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 	public Parent validateParentAgainstDryRunCompound(Parent parent, int numRecordsRead,
 			Collection<ValidationResponseDTO> validationResponse)
 			throws MissingPropertyException, DupeParentException, SaltedCompoundException, Exception {
-		int[] dupeDryRunCompoundsList = chemStructureService.checkDupeMol(parent.getMolStructure(),
-				StructureType.DRY_RUN);
+		// int[] dupeDryRunCompoundsList = chemStructureService.checkDupeMol(parent.getMolStructure(),
+		// 		StructureType.DRY_RUN);
+		int[] dupeDryRunCompoundsList = chemStructureService.searchMolStructures(parent.getCmpdRegMolecule(), StructureType.DRY_RUN, ChemStructureService.SearchType.DUPLICATE_TAUTOMER,  -1F, -1);
 		if (dupeDryRunCompoundsList.length > 0) {
 			searchResultLoop: for (int foundParentCdId : dupeDryRunCompoundsList) {
 				List<DryRunCompound> foundDryRunCompounds = DryRunCompound.findDryRunCompoundsByCdId(foundParentCdId)

--- a/src/main/java/com/labsynch/labseer/service/ChemStructureService.java
+++ b/src/main/java/com/labsynch/labseer/service/ChemStructureService.java
@@ -2,7 +2,9 @@ package com.labsynch.labseer.service;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 
 import com.labsynch.labseer.chemclasses.CmpdRegMolecule;
@@ -62,6 +64,8 @@ public interface ChemStructureService {
 	public String getMolFormula(String molStructure) throws CmpdRegMolFormatException;
 
 	boolean checkForSalt(String molfile) throws CmpdRegMolFormatException;
+
+	public List<Boolean> checkForSalts(Collection<String> molfiles) throws CmpdRegMolFormatException;
 
 	double getExactMass(String molStructure) throws CmpdRegMolFormatException;
 

--- a/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
@@ -327,34 +327,18 @@ public class MetalotServiceImpl implements MetalotService {
 				if (hasMultipleFragments == null){
 					hasMultipleFragments = chemService.checkForSalt(parent.getMolStructure());
 				}
-				if (hasMultipleFragments) {
-					// multiple fragments
-					if (parent.getIsMixture() != null) {
-						if (!parent.getIsMixture()) {
-							ErrorMessage multifragmentError = new ErrorMessage();
-							multifragmentError.setLevel("error");
-							multifragmentError
-									.setMessage("Multiple fragments found. Please register the neutral base parent ");
-							logger.error(multifragmentError.getMessage());
-							errors.add(multifragmentError);
-							metalotError = true;
-							logger.error("found a compound with multiple fragments -- mark as an error.");
-							logger.error("Salted molfile: " + parent.getMolStructure());
-							throw new SaltedCompoundException("Salted parent structure");
-						} else {
-							// continue to save - structure is appropriately marked as a mixture
-						}
-					} else {
-						ErrorMessage multifragmentError = new ErrorMessage();
-						multifragmentError.setLevel("error");
-						multifragmentError.setMessage("Multiple fragments found. Please register the neutral base parent ");
-						logger.error(multifragmentError.getMessage());
-						errors.add(multifragmentError);
-						metalotError = true;
-						logger.error("found a compound with multiple fragments -- mark as an error.");
-						logger.error("Salted molfile: " + parent.getMolStructure());
-						throw new SaltedCompoundException("Salted parent structure");
-					}
+				// If it has multiple fragments and "isMixture" is null or false, throw an error
+				if (hasMultipleFragments && (parent.getIsMixture() == null || !parent.getIsMixture())) {
+					ErrorMessage multifragmentError = new ErrorMessage();
+					multifragmentError.setLevel("error");
+					multifragmentError
+							.setMessage("Multiple fragments found. Please register the neutral base parent ");
+					logger.error(multifragmentError.getMessage());
+					errors.add(multifragmentError);
+					metalotError = true;
+					logger.error("found a compound with multiple fragments -- mark as an error.");
+					logger.error("Salted molfile: " + parent.getMolStructure());
+					throw new SaltedCompoundException("Salted parent structure");
 				}
 			}
 			if (parentAliases.size() > 0){

--- a/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
@@ -322,33 +322,39 @@ public class MetalotServiceImpl implements MetalotService {
 				metalotError = true;
 				throw new DupeParentException("Duplicate parent structure");
 
-			} else if (chemService.checkForSalt(parent.getMolStructure())) {
-				// multiple fragments
-				if (parent.getIsMixture() != null) {
-					if (!parent.getIsMixture()) {
+			} else {
+				Boolean hasMultipleFragments = parent.getMultipleFragments();
+				if (hasMultipleFragments == null){
+					hasMultipleFragments = chemService.checkForSalt(parent.getMolStructure());
+				}
+				if (hasMultipleFragments) {
+					// multiple fragments
+					if (parent.getIsMixture() != null) {
+						if (!parent.getIsMixture()) {
+							ErrorMessage multifragmentError = new ErrorMessage();
+							multifragmentError.setLevel("error");
+							multifragmentError
+									.setMessage("Multiple fragments found. Please register the neutral base parent ");
+							logger.error(multifragmentError.getMessage());
+							errors.add(multifragmentError);
+							metalotError = true;
+							logger.error("found a compound with multiple fragments -- mark as an error.");
+							logger.error("Salted molfile: " + parent.getMolStructure());
+							throw new SaltedCompoundException("Salted parent structure");
+						} else {
+							// continue to save - structure is appropriately marked as a mixture
+						}
+					} else {
 						ErrorMessage multifragmentError = new ErrorMessage();
 						multifragmentError.setLevel("error");
-						multifragmentError
-								.setMessage("Multiple fragments found. Please register the neutral base parent ");
+						multifragmentError.setMessage("Multiple fragments found. Please register the neutral base parent ");
 						logger.error(multifragmentError.getMessage());
 						errors.add(multifragmentError);
 						metalotError = true;
 						logger.error("found a compound with multiple fragments -- mark as an error.");
 						logger.error("Salted molfile: " + parent.getMolStructure());
 						throw new SaltedCompoundException("Salted parent structure");
-					} else {
-						// continue to save - structure is appropriately marked as a mixture
 					}
-				} else {
-					ErrorMessage multifragmentError = new ErrorMessage();
-					multifragmentError.setLevel("error");
-					multifragmentError.setMessage("Multiple fragments found. Please register the neutral base parent ");
-					logger.error(multifragmentError.getMessage());
-					errors.add(multifragmentError);
-					metalotError = true;
-					logger.error("found a compound with multiple fragments -- mark as an error.");
-					logger.error("Salted molfile: " + parent.getMolStructure());
-					throw new SaltedCompoundException("Salted parent structure");
 				}
 			}
 			if (parentAliases.size() > 0){

--- a/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.labsynch.labseer.chemclasses.CmpdRegMolecule;
 import com.labsynch.labseer.domain.FileList;
 import com.labsynch.labseer.domain.IsoSalt;
 import com.labsynch.labseer.domain.Lot;
@@ -225,10 +226,18 @@ public class MetalotServiceImpl implements MetalotService {
 		String dupeParentNames = "";
 		if (parent.getId() == null) {
 			logger.debug("this is a new parent");
-			String molStructure;
 			if (propertiesUtilService.getUseExternalStandardizerConfig()) {
-				molStructure = chemService.standardizeStructure(parent.getMolStructure());
-				parent.setMolStructure(molStructure);
+				// Check if we already have a standardized CmpdRegMolecule attached
+				// BulkLoadServiceImpl attaches one for performance reasons
+				if (parent.getCmpdRegMolecule() == null){
+					//TODO refactor into chemService.getStandardizedMolecule(String);
+					HashMap<String, String> inMap = new HashMap<String, String>();
+					inMap.put("tmp", parent.getMolStructure());
+					HashMap<String, CmpdRegMolecule> stdzMap = chemService.standardizeStructures(inMap);
+					parent.setCmpdRegMolecule(stdzMap.get("tmp"));
+				}
+				// Set the parent's structure to the standardized MOL string
+				parent.setMolStructure(parent.getCmpdRegMolecule().getMolStructure());
 			}
 			int dupeParentCount = 0;
 			if (!metaLot.isSkipParentDupeCheck()) {
@@ -348,7 +357,11 @@ public class MetalotServiceImpl implements MetalotService {
 			}
 			if (!dupeParent) {
 				boolean checkForDupe = false;
-				cdId = chemService.saveStructure(parent.getMolStructure(), StructureType.PARENT, checkForDupe);
+				// If the parent doesn't have a CmpdRegMolecule attached, create one and attach it
+				if (parent.getCmpdRegMolecule() == null) {
+					parent.setCmpdRegMolecule(chemService.toMolecule(parent.getMolStructure()));
+				}
+				cdId = chemService.saveStructure(parent.getCmpdRegMolecule(), StructureType.PARENT, checkForDupe);
 				if (cdId == -1) {
 					logger.error("Bad molformat. Please fix the molfile: " + parent.getMolStructure());
 					throw new CmpdRegMolFormatException();
@@ -363,12 +376,12 @@ public class MetalotServiceImpl implements MetalotService {
 					}
 					DecimalFormat dExactMass = new DecimalFormat("#.######");
 					parent.setExactMass(
-							Double.valueOf(dExactMass.format(chemService.getExactMass(parent.getMolStructure()))));
+							Double.valueOf(dExactMass.format(parent.getCmpdRegMolecule().getExactMass())));
 					DecimalFormat dMolWeight = new DecimalFormat("#.###");
 					parent.setMolWeight(
-							Double.valueOf(dMolWeight.format(chemService.getMolWeight(parent.getMolStructure()))));
+							Double.valueOf(dMolWeight.format(parent.getCmpdRegMolecule().getMass())));
 
-					parent.setMolFormula(chemService.getMolFormula(parent.getMolStructure()));
+					parent.setMolFormula(parent.getCmpdRegMolecule().getFormula());
 					// add unique constraint to parent corp name as well (parent and lot)
 					boolean corpNameAlreadyExists = checkCorpNameAlreadyExists(parent.getCorpName());
 					while (corpNameAlreadyExists) {


### PR DESCRIPTION
@brianbolt I'm still doing more testing and thinking more about this, but I think I have the "first draft". I'd like a review from you to see if there are major things I've missed, bugs you can spot, or better ideas you have based on what I've done so far.

## Description
- The basic observation here is that calling BBChem many times with small payloads is slow, and calling it few times with large payloads is fast. Thus the changes here try to take as many points where we call BBChem, and front-load them to doing calls in bulk.
- Read incoming SDF in large batches - during file / property scanning, property validation, and the dryrun/non-dryrun `registerSDF`.
- Call "standardize" i.e. "process" upfront and store the resulting CmpdRegMolecule as a transient property on the parent, pulling it out when needed rather than re-processing the molStructure string.
- Created a new method to call the "split" endpoint (which is part of getMolFragments) en masse. We have two usages of this: "checkForSalt" which returns a boolean, and "stripSalts" which actually does stuff with the split fragments. I've only optimized the "checkForSalt" portion, so we'll do a follow-up call to "split" as part of "stripSalts" for any records that do have multiple fragments.
- Switched the BBChem SDF writer to store a cache of molecules, then write everything out at once during the "close" or "getBufferString" method. I'm worried this may introduce bugs that make it hard to track down malformatted MOL blocks. I didn't do a great job with error handling.

## Related Issue

## How Has This Been Tested?
Tested loading, purging, and re-loading a 999 record file on a remote LD/ACAS machine.
Compounds loaded successfully, with a ~20x speed improvement, and the summary files looked normal. Have not yet tested this locally in Indigo.