### PR TITLE
ACAS-504 Followup: Fix for writing SDF

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/CmpdRegSDFWriterBBChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/CmpdRegSDFWriterBBChemImpl.java
@@ -67,6 +67,8 @@ public class CmpdRegSDFWriterBBChemImpl implements CmpdRegSDFWriter {
             CmpdRegMoleculeBBChemImpl molWrapper = (CmpdRegMoleculeBBChemImpl) molecule;
             cmpdRegMoleculeBBChemImplList.add(molWrapper.molecule);
         }
+        // reset the molCache now that we've taken these molecules out
+        this.molCache = new ArrayList<CmpdRegMoleculeBBChemImpl>();
         // Convert them all to SDF text
         try{
             String sdfText = bbChemStructureServices.getSDF(cmpdRegMoleculeBBChemImplList);


### PR DESCRIPTION
## Description
I noticed in my testing after merging ACAS-504 that the "Download All Salts SDF" button in Salt Browser was writing the same salt out 3 times to the SDF. I traced it back to the fact that the code calls "close()" then calls "getBufferString" twice. This should be safe to do, so I fixed my modifications to CmpdRegSDFWriterBBChemImpl to clear out the molCache whenever "close" or "getBufferString" is called, so it's safe to call multiple times.

## Related Issue

## How Has This Been Tested?
Tested locally that after this fix, the Salts SDF only had one entry per Salt.