### PR TITLE
ACAS-504 followup: Fix NullPointerException when loading a second lot of the same compound

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -828,6 +828,8 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 	public Parent validateParent(Parent parent, String chemist, Collection<BulkLoadPropertyMappingDTO> mappings, int numRecordsRead,
 			Collection<ValidationResponseDTO> validationResponse)
 			throws MissingPropertyException, DupeParentException, SaltedCompoundException, Exception {
+		// Grab the parent's CmpdRegMolecule in case it is lost when overwriting the parent variable
+		CmpdRegMolecule standardizedMol = parent.getCmpdRegMolecule();
 		// Search for the parent structure + stereo category
 		if (parent.getStereoCategory() == null)
 			throw new MissingPropertyException("Parent Stereo Category must be provided");
@@ -1024,6 +1026,11 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 		}
 		// Validate lot aliases locally and in the database
 		parentAliasService.validateParentAliases(parent.getParentAliases());
+
+		// If the parent's cmpdRegMolecule was lost, put it back
+		if (parent.getCmpdRegMolecule() == null){
+			parent.setCmpdRegMolecule(standardizedMol);
+		}
 
 		return parent;
 	}


### PR DESCRIPTION
## Description
- Bug occurs when loading a structure which has already been registered
- Root cause is that the `validateParent` function overwrites the `parent` variable with a `foundParent` from the database if it finds a match, and the `foundParent` doesn't have the new transient `cmpdRegMolecule` variable filled in with the standardized CmpdRegMolecule.

@dalejerikson and I looked at this together, and came up with three possible styles of fixes:

1. Add more "if cmpdRegMolecule is null" checks, and re-standardize the structure if we've lost the standardizedMolecule
2. Grab the standardized molecule from `parent` before it gets overwritten, then pop that same value back into the new `parent` that came from the database.
3. When we find a match (`foundParent`), hydrate the standardized CmpdRegMolecule from the structure tables in the database, and fill that in to the parent.cmpdRegMolecule attribute.

Option 1 is inefficient. I went with Option 2, since it was quick to add, and I don't think there will be a chemically significant difference between the incoming standardized Mol and the "loaded from the database" standardized Mol, in cases where they have been deemed as exact matches by structure search.
Option 3 seems like the "most correct" approach but it was going to be an involved fix that would need to support all three cheminformatics engines, so I opted not to go that direction so that I could get this fix out quickly and avoid making lots more code changes that might introduce other new bugs.

## Related Issue


## How Has This Been Tested?
- In local bbchem dev environment, reproduced the issue and confirmed it was fixed after this change.

I will work on adding an acasclient test for this as well, since it's a common thing to load multiple lots.