### PR TITLE
ACAS-523: Skip throwing duplicate alias error if dupe is on the same parent

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -962,7 +962,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 								+ parent.getCorpName() + " db corp name: " + foundParent.getCorpName());
 		}
 		// Validate lot aliases locally and in the database
-		parentAliasService.validateParentAliases(parent.getParentAliases());
+		parentAliasService.validateParentAliases(parent.getId(), parent.getParentAliases());
 
 		return parent;
 	}

--- a/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
@@ -344,7 +344,7 @@ public class MetalotServiceImpl implements MetalotService {
 			}
 			if (parentAliases.size() > 0){
 				// Validate parent aliases
-				parentAliasService.validateParentAliases(parentAliases);
+				parentAliasService.validateParentAliases(parent.getId(), parentAliases);
 			}
 			if (!dupeParent) {
 				boolean checkForDupe = false;

--- a/src/main/java/com/labsynch/labseer/service/ParentAliasService.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentAliasService.java
@@ -21,5 +21,5 @@ public interface ParentAliasService {
 
 	Parent updateParentAliasByTypeAndKind(Parent parent, String lsType, String lsKind, String aliasList);
 
-	void validateParentAliases(Set<ParentAlias> aliasesToBeSaved) throws NonUniqueAliasException;
+	void validateParentAliases(Long parentId, Set<ParentAlias> aliasesToBeSaved) throws NonUniqueAliasException;
 }

--- a/src/main/java/com/labsynch/labseer/service/ParentAliasServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentAliasServiceImpl.java
@@ -33,7 +33,7 @@ public class ParentAliasServiceImpl implements ParentAliasService {
 		logger.debug(ParentAlias.toJsonArray(aliasesToBeSaved));
 		Set<ParentAlias> savedAliases = new HashSet<ParentAlias>();
 		if (aliasesToBeSaved != null && !aliasesToBeSaved.isEmpty()) {
-			validateParentAliases(aliasesToBeSaved);
+			validateParentAliases(parent.getId(), aliasesToBeSaved);
 			for (ParentAlias aliasToBeSaved : aliasesToBeSaved) {
 				logger.debug(aliasToBeSaved.toJson());
 				aliasToBeSaved.setParent(parent);
@@ -51,7 +51,7 @@ public class ParentAliasServiceImpl implements ParentAliasService {
 	}
 
 	@Override
-	public void validateParentAliases(Set<ParentAlias> aliasesToBeSaved) throws NonUniqueAliasException {
+	public void validateParentAliases(Long parentId, Set<ParentAlias> aliasesToBeSaved) throws NonUniqueAliasException {
 
 		// Check for unique parent aliases in what is being passed in
 		if (!propertiesUtilService.getAllowDuplicateParentAliases()) {
@@ -76,7 +76,8 @@ public class ParentAliasServiceImpl implements ParentAliasService {
 					List<ParentAlias> foundAliases = ParentAlias
 							.findParentAliasesByAliasNameEquals(aliasToBeSaved.getAliasName())
 							.getResultList();
-					foundAliases.removeIf(alias -> alias.isIgnored() | alias.isDeleted());
+					foundAliases.removeIf(alias -> alias.isIgnored() | alias.isDeleted() | 
+											(alias.getParent() != null && alias.getParent().getId() == parentId));
 					for (ParentAlias foundAlias : foundAliases) {
 						if (aliasToBeSaved.getId() != null
 								&& aliasToBeSaved.getId().equals(foundAlias.getId())) {
@@ -97,7 +98,7 @@ public class ParentAliasServiceImpl implements ParentAliasService {
 		Set<ParentAlias> aliasesToBeSaved = parentAliases;
 		Set<ParentAlias> savedAliases = new HashSet<ParentAlias>();
 		if (aliasesToBeSaved != null && !aliasesToBeSaved.isEmpty()) {
-			validateParentAliases(aliasesToBeSaved);
+			validateParentAliases(parent.getId(), aliasesToBeSaved);
 			for (ParentAlias aliasToBeSaved : aliasesToBeSaved) {
 				// Check for unique parent aliases in the database
 				aliasToBeSaved.setParent(parent);


### PR DESCRIPTION
## Description
- Bug was that trying to load the same alias onto an existing parent would yield a duplicate alias error, rather than being a no-op
- Fix is to pass in the parent ID for the parent whose aliases are being validated, and skip reporting duplicates if the duplicate alias was found on the same parent

## Related Issue

## How Has This Been Tested?
Ran acasclient tests locally with config `client.cmpdreg.metaLot.allowDuplicateParentAliases=false`
Confirmed that @dalejerikson 's `test_051_bulk_load_update_parent_alias` now passes

One other test fails with this config: `test_005_swap_parent_structures`, but that is expected because that case intentionally registers a duplicate alias to test an error thrown when an alias is ambiguous.