### PR TITLE
ACAS-489 Followup: Bug fixes for whitespace and for alias set comparisons

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -1766,7 +1766,8 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 		if (lookUpString != null) {
 			// found LiveDesign Corp Name
 			logger.info("Found one or more parent alias: " + lookUpProperty + "  " + lookUpString);
-			String[] aliases = lookUpString.split(";");
+			// Split on semicolon and trim whitespace
+			String[] aliases = Arrays.stream(lookUpString.split(";")).map(String::trim).toArray(String[]::new);
 			if (parent.getParentAliases() == null) {
 				logger.info("---------- the parent Alias set is null ----------------");
 				parent.setParentAliases(new HashSet<ParentAlias>());


### PR DESCRIPTION
## Description
Fixed ACASClient tests (https://github.com/mcneilco/acasclient/pull/101) enough to uncover two more bugs:

### Semicolon-delimited aliases were not getting whitespace trimmed: 
```
>  <Parent Alias>
Fourth Alias; Fifth Alias; Sixth Alias; Seventh Alias;
```
parsed as (note leading whitespace):
```
["Fourth Alias"," Fifth Alias"," Sixth Alias"," Seventh Alias"]
```

### updateParentAliases was introducing duplicates
After fixing the above issue, noticed test was still failing. `compareParentAliases` function seems correct, but `updateParentAliases` function was not producing correct results, leading to duplicate aliases getting created.
The logical flow inside that function was confusing  enough that I rewrote it to be able to result in the correct behavior.

## Related Issue

## How Has This Been Tested?
Ran acasclient tests locally and confirmed this fixes the test failures on test_051 mentioned here https://github.com/mcneilco/acasclient/pull/101