### PR TITLE
ACAS-526: Delete standardization dry run compound when deleting a parent compound

### DIFF
--- a/src/main/java/com/labsynch/labseer/domain/DryRunCompound.java
+++ b/src/main/java/com/labsynch/labseer/domain/DryRunCompound.java
@@ -94,10 +94,6 @@ public class DryRunCompound {
         return entityManager().createQuery("SELECT o FROM DryRunCompound o", DryRunCompound.class).getResultList();
     }
 
-    public static List<DryRunCompound> findDryRunCompoundsByParentId(Long parentId) {
-        return entityManager().createQuery("SELECT o FROM DryRunCompound o WHERE o.parentId = :parentId", DryRunCompound.class).setParameter("parentId", parentId).getResultList();
-    }
-
     public static List<DryRunCompound> findAllDryRunCompounds(String sortFieldName, String sortOrder) {
         String jpaQuery = "SELECT o FROM DryRunCompound o";
         if (fieldNames4OrderClauseFilter.contains(sortFieldName)) {

--- a/src/main/java/com/labsynch/labseer/domain/DryRunCompound.java
+++ b/src/main/java/com/labsynch/labseer/domain/DryRunCompound.java
@@ -94,6 +94,10 @@ public class DryRunCompound {
         return entityManager().createQuery("SELECT o FROM DryRunCompound o", DryRunCompound.class).getResultList();
     }
 
+    public static List<DryRunCompound> findDryRunCompoundsByParentId(Long parentId) {
+        return entityManager().createQuery("SELECT o FROM DryRunCompound o WHERE o.parentId = :parentId", DryRunCompound.class).setParameter("parentId", parentId).getResultList();
+    }
+
     public static List<DryRunCompound> findAllDryRunCompounds(String sortFieldName, String sortOrder) {
         String jpaQuery = "SELECT o FROM DryRunCompound o";
         if (fieldNames4OrderClauseFilter.contains(sortFieldName)) {

--- a/src/main/java/com/labsynch/labseer/domain/StandardizationDryRunCompound.java
+++ b/src/main/java/com/labsynch/labseer/domain/StandardizationDryRunCompound.java
@@ -680,6 +680,14 @@ public class StandardizationDryRunCompound {
 				.getSingleResult();
 	}
 
+	public static List<StandardizationDryRunCompound> findStandardizationDryRunCompoundsByParent(Parent parent) {
+		if (parent == null)
+			return null;
+		return entityManager().createQuery(
+				"SELECT o FROM StandardizationDryRunCompound o WHERE o.parent = :parent", StandardizationDryRunCompound.class)
+				.setParameter("parent", parent).getResultList();
+	}
+
 	public static List<StandardizationDryRunCompound> findAllStandardizationDryRunCompounds() {
 		return entityManager()
 				.createQuery("SELECT o FROM StandardizationDryRunCompound o", StandardizationDryRunCompound.class)

--- a/src/main/java/com/labsynch/labseer/service/ParentServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentServiceImpl.java
@@ -18,6 +18,7 @@ import com.labsynch.labseer.domain.Parent;
 import com.labsynch.labseer.domain.ParentAlias;
 import com.labsynch.labseer.domain.ParentAnnotation;
 import com.labsynch.labseer.domain.SaltForm;
+import com.labsynch.labseer.domain.StandardizationDryRunCompound;
 import com.labsynch.labseer.domain.StereoCategory;
 import com.labsynch.labseer.dto.CodeTableDTO;
 import com.labsynch.labseer.dto.ParentAliasDTO;
@@ -334,7 +335,7 @@ public class ParentServiceImpl implements ParentService {
 	@Transactional
 	public void deleteParent(Parent parent) {
 		
-		for(DryRunCompound d : DryRunCompound.findDryRunCompoundsByParentId(parent.getId())) {
+		for(StandardizationDryRunCompound d : StandardizationDryRunCompound.findStandardizationDryRunCompoundsByParent(parent)) {
 			d.remove();
 		}
 

--- a/src/main/java/com/labsynch/labseer/service/ParentServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ParentServiceImpl.java
@@ -12,6 +12,7 @@ import com.labsynch.labseer.chemclasses.CmpdRegMoleculeFactory;
 import com.labsynch.labseer.chemclasses.CmpdRegSDFWriterFactory;
 import com.labsynch.labseer.domain.Author;
 import com.labsynch.labseer.domain.CompoundType;
+import com.labsynch.labseer.domain.DryRunCompound;
 import com.labsynch.labseer.domain.Lot;
 import com.labsynch.labseer.domain.Parent;
 import com.labsynch.labseer.domain.ParentAlias;
@@ -332,6 +333,11 @@ public class ParentServiceImpl implements ParentService {
 	@Override
 	@Transactional
 	public void deleteParent(Parent parent) {
+		
+		for(DryRunCompound d : DryRunCompound.findDryRunCompoundsByParentId(parent.getId())) {
+			d.remove();
+		}
+
 		for(SaltForm s : parent.getSaltForms()) {
 			saltFormService.deleteSaltForm(s);
 		}


### PR DESCRIPTION
## Description
 - Delete standardization dry run compound when deleting a parent compound

## Related Issue
ACAS-526

## How Has This Been Tested?
- Test locally to reproduce
  - Ran acas client test with breakpoint to register an SDF file (then stopped the run so teardown was run)
  - Executed standardization dry run
  - Tried to delete one of the lots (single lot on parent so the parent is also attempted to be deleted)
    - Result was failure to delete lot
 - Test fix
   -  updated the code, ran the same test and now the parent is deleted successfully (including from standardization dry run table)