### PR TITLE
ACAS-413: DB migration for endpoint management (2nd attempt)

### DIFF
--- a/src/main/resources/db/migration/postgres/V2.4.1.0__data_column_order_states.sql
+++ b/src/main/resources/db/migration/postgres/V2.4.1.0__data_column_order_states.sql
@@ -41,6 +41,24 @@ insert into ls_transaction (id, comments, recorded_date, version, recorded_by)
 -- Part 1: Fill in 'data column' DDict Values based on saved data
 -- Create a reusable function to insert missing ddict values
 create or replace function add_data_column_ddict_value(val varchar, ls_kind varchar) returns bigint as $$
+	--create ddict type if not exists
+	insert into ddict_type (id, ignored, name, version)
+		select nextval('ddict_type_pkseq') as id, false as ignored, 'data column', 0
+		where not exists (select * from ddict_type where name = 'data column');
+	--create ddict kind if not exists
+	insert into ddict_kind (id, ignored, ls_type, ls_type_and_kind, name, version)
+		select
+			nextval('ddict_kind_pkseq') as id,
+			false as ignored,
+			'data column' as ls_type,
+			'data column_'||ls_kind as ls_type_and_kind,
+			ls_kind as name,
+			0 as version
+			where not exists (
+				select * from ddict_kind where ls_type = 'data column' and name = ls_kind
+			);
+
+	--create ddict value if not exists
 	insert into ddict_value (id, ignored, code_name, label_text, ls_type, ls_kind, ls_type_and_kind, short_name, version)
 		select
 			nextval('ddict_value_pkseq') as id,

--- a/src/main/resources/db/migration/postgres/V2.4.1.0__data_column_order_states.sql
+++ b/src/main/resources/db/migration/postgres/V2.4.1.0__data_column_order_states.sql
@@ -242,7 +242,7 @@ create table tmp_expt_column_order_data as
 		select e.protocol_id,
 			col_type.string_value as column_type, --the coalesce is used to account for having the same data in stringValues or in codeValues
 			col_name.string_value as column_name,
-			col_name.string_value as units,
+			col_units.string_value as units,
 			col_conc.numeric_value as concentration,
 		 	col_conc_units.string_value as conc_units,
 			hide_col.string_value as hide_column,
@@ -269,7 +269,7 @@ create table tmp_expt_column_order_data as
 			e.protocol_id,
 			col_type.string_value,
 			col_name.string_value,
-			col_name.string_value,
+			col_units.string_value,
 			col_conc.numeric_value,
 		 	col_conc_units.string_value,
 			hide_col.string_value,

--- a/src/main/resources/db/migration/postgres/V2.4.1.0__data_column_order_states.sql
+++ b/src/main/resources/db/migration/postgres/V2.4.1.0__data_column_order_states.sql
@@ -1,3 +1,5 @@
+do $script$
+begin
 -- As part of ACAS-413
 -- Setup a temp table with all the existing experiment columns
 -- We create an artificial "column_order" that will only be used for experiments
@@ -24,6 +26,13 @@ create table tmp_expt_columns as
 		left join analysis_group_value agv_time on ags.id = agv_time.analysis_state_id and agv_time.ignored = false and agv_time.ls_kind = 'time'
 		where p.ignored = false
 	) a;
+
+-- Exit early if there is no expt data as this indicates a fresh system
+if not exists (select * from tmp_expt_columns)
+then
+	drop table tmp_expt_columns;
+	return;
+end if;
 
 --Create an ls_transaction to tie all our states and values to
 insert into ls_transaction (id, comments, recorded_date, version, recorded_by)
@@ -433,3 +442,5 @@ drop function create_expt_data_column_order_state(bigint, bigint, int, varchar, 
 drop function create_protocol_data_column_order_state(bigint, bigint, int, varchar, varchar, varchar, float8, varchar, float8, varchar, varchar, varchar);
 drop function fix_experiment_string_values(varchar, varchar, varchar);
 drop function fix_protocol_string_values(varchar, varchar, varchar);
+
+end $script$

--- a/src/main/resources/db/migration/postgres/V2.4.1.0__data_column_order_states.sql
+++ b/src/main/resources/db/migration/postgres/V2.4.1.0__data_column_order_states.sql
@@ -81,16 +81,16 @@ create or replace function add_data_column_ddict_value(val varchar, ls_kind varc
 	$$ language sql;
 
 --column name
-select add_data_column_ddict_value(column_name, 'column name'::varchar) from
+perform add_data_column_ddict_value(column_name, 'column name'::varchar) from
 (select distinct column_name from tmp_expt_columns) a;
 --units
-select add_data_column_ddict_value(units, 'column units'::varchar) from
+perform add_data_column_ddict_value(units, 'column units'::varchar) from
 (select distinct units from tmp_expt_columns) a where a.units is not null;
 --conc units
-select add_data_column_ddict_value(conc_units, 'column conc units'::varchar) from
+perform add_data_column_ddict_value(conc_units, 'column conc units'::varchar) from
 (select distinct conc_units from tmp_expt_columns) a where a.conc_units is not null;
 --time units
-select add_data_column_ddict_value(time_units, 'column time units'::varchar) from
+perform add_data_column_ddict_value(time_units, 'column time units'::varchar) from
 (select distinct time_units from tmp_expt_columns) a where a.time_units is not null;
 --End Part 1
 
@@ -219,7 +219,7 @@ create or replace function create_expt_data_column_order_state(expt_id bigint, t
 $$ language plpgsql;
 
 -- Create 'data column order' states and values for all experiments which are missing them
-select create_expt_data_column_order_state(experiment_id, (select id from ls_transaction where comments = 'V2.4.1.0 data column order states migration'),
+perform create_expt_data_column_order_state(experiment_id, (select id from ls_transaction where comments = 'V2.4.1.0 data column order states migration'),
 										   column_order::int, column_type, column_name, units, concentration, conc_units, col_time, time_units, hide_column, false)
 	from tmp_expt_columns where experiment_id in
 		(select e.id from experiment e
@@ -380,7 +380,7 @@ create or replace function create_protocol_data_column_order_state(protocol_id b
 $$ language plpgsql;
 
 -- Create states and values on any protocol that is missing data column order states
-select create_protocol_data_column_order_state(protocol_id, (select id from ls_transaction where comments = 'V2.4.1.0 data column order states migration'),
+perform create_protocol_data_column_order_state(protocol_id, (select id from ls_transaction where comments = 'V2.4.1.0 data column order states migration'),
 										   new_column_order::int, column_type, column_name, units, concentration, conc_units, column_time, time_units, hide_column, condition_column)
 	from tmp_expt_column_order_data where protocol_id in
 		(select p.id from protocol p
@@ -415,12 +415,12 @@ create or replace function fix_experiment_string_values(ls_kind varchar, code_ty
 $$ language plpgsql;
 
 --migrate experiment values
-select fix_experiment_string_values('column type', 'data column', 'column type');
-select fix_experiment_string_values('column name', 'data column', 'column name');
-select fix_experiment_string_values('column units', 'data column', 'column units');
-select fix_experiment_string_values('column conc units', 'data column', 'column conc units');
-select fix_experiment_string_values('hide column', 'boolean', 'boolean');
-select fix_experiment_string_values('condition column', 'boolean', 'boolean');
+perform fix_experiment_string_values('column type', 'data column', 'column type');
+perform fix_experiment_string_values('column name', 'data column', 'column name');
+perform fix_experiment_string_values('column units', 'data column', 'column units');
+perform fix_experiment_string_values('column conc units', 'data column', 'column conc units');
+perform fix_experiment_string_values('hide column', 'boolean', 'boolean');
+perform fix_experiment_string_values('condition column', 'boolean', 'boolean');
 
 -- function for migrating protocol values
 create or replace function fix_protocol_string_values(ls_kind varchar, code_type varchar, code_kind varchar) returns int as $$
@@ -445,12 +445,12 @@ create or replace function fix_protocol_string_values(ls_kind varchar, code_type
 $$ language plpgsql;
 
 --migrate protocol values
-select fix_protocol_string_values('column type', 'data column', 'column type');
-select fix_protocol_string_values('column name', 'data column', 'column name');
-select fix_protocol_string_values('column units', 'data column', 'column units');
-select fix_protocol_string_values('column conc units', 'data column', 'column conc units');
-select fix_protocol_string_values('hide column', 'boolean', 'boolean');
-select fix_protocol_string_values('condition column', 'boolean', 'boolean');
+perform fix_protocol_string_values('column type', 'data column', 'column type');
+perform fix_protocol_string_values('column name', 'data column', 'column name');
+perform fix_protocol_string_values('column units', 'data column', 'column units');
+perform fix_protocol_string_values('column conc units', 'data column', 'column conc units');
+perform fix_protocol_string_values('hide column', 'boolean', 'boolean');
+perform fix_protocol_string_values('condition column', 'boolean', 'boolean');
 
 -- Cleanup: drop tables and functions created during this migration
 drop table tmp_expt_columns;


### PR DESCRIPTION
## Description
- Earlier PR #394 was merged but caused issues and was reverted
- Primary issue was that it failed on brand new / empty systems due to some missing sequences that are created when ACAS starts up and runs setup routes
- Fixed this issue by wrapping the entire script in a "DO" block and thus turning it into an anonymous pl/pgsql function. This allows us to return early if no experiment data exists.
- While locally testing upgrade from 2022.4.x to this branch, found a few more breaking issues and fixed them. They were missing ddict types and kinds, a copy/paste typo where column name was put in instead of units, and some followthrough on switching to pl/pgsql (replacing lone "select" statements with "perform")

I'm sorry this is displaying as one big change, but you can look through the individual commits to get a sense of the individual changes that separate this from the earlier PR #394 

## How Has This Been Tested?
Tested two scenarios locally:
1. Start up local ACAS on latest 2022.4.x, load compounds and an experiment, shut down, switch to 2023.1.x + this Roo branch, and start up. Ensured migration ran successfully, and checked Protocol and Experiment browsers and ensured all the expected content was in the endpoints table in both.
2. Started up completely fresh system (`docker-compose down -v && docker-compose up`) on 2023.1.x + this roo branch, and ensured it started up smoothly and acasclient tests passed.