### PR TITLE
ACAS-413: look up ddict id sequence rather than assuming it

### DIFF
--- a/src/main/resources/db/migration/postgres/V2.4.1.0__data_column_order_states.sql
+++ b/src/main/resources/db/migration/postgres/V2.4.1.0__data_column_order_states.sql
@@ -63,7 +63,7 @@ create or replace function add_data_column_ddict_value(val varchar, ls_kind varc
 		select
 			nextval('ddict_value_pkseq') as id,
 			false as ignored,
-			'DDICT-' || lpad(nextval('labelseq_1_ddict_id_codename_document_datadictionary'):: text, 6, '0'::text) as code_name,
+			'DDICT-' || lpad((select nextval(db_sequence) from label_sequence where label_prefix = 'DDICT'):: text, 6, '0'::text) as code_name,
 			val as label_text,
 			'data column' as ls_type,
 			ls_kind as ls_kind,


### PR DESCRIPTION
## Description
- Some older servers seem to have a sequence named:
`labelseq_DDICT_id_codeName_document_datadictionary` instead of
`labelseq_1_ddict_id_codename_document_datadictionary`
- This change actually looks up the db_sequence name in the label_sequence table rather than assuming we know the name.

## Related Issue

## How Has This Been Tested?
- Tested the SQL command runs on an older and a newer ACAS server