### PR TITLE
ACAS-564: fix bbchem urls that no longer tolerate trailing slash

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
@@ -48,16 +48,16 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 	private static final String ERROR_STRUCTURE = "ERROR_STRUCTURE";
 
 
-	private final String CONVERTER_PATH = "/converter/api/v0/convert/";
+	private final String CONVERTER_PATH = "/converter/api/v0/convert";
 	private final String EXPORTSDF_PATH = "/sdf_export/api/v0/";
 	private final String FINGERPRINT_PATH = "/fingerprint/api/v0/";
 	private final String IMAGE_PATH = "/image/api/v0/";	
 	private final String PARSESDF_PATH =  "/parse/api/v0/";	
-	private final String PROCESS_PATH = "/preprocessor/api/v0/process/";
+	private final String PROCESS_PATH = "/preprocessor/api/v0/process";
 	private final String SPLIT_PATH = "/split/api/v0/";
 	private final String SUBSTRUCTURE_PATH = "/substructure/match/api/v0/";
 	private final String CONFIG_CHECK_PATH = "/preprocessor/api/v0/config/check";
-	private final String CONFIG_FIX_PATH = "/preprocessor/api/v0/config/fix/";
+	private final String CONFIG_FIX_PATH = "/preprocessor/api/v0/config/fix";
 	private final String HEALTH_PATH = "/preprocessor/api/v0/health";
 
 	@Override


### PR DESCRIPTION
## Description
- Some bbchem endpoints seem to have stopped accepting trailing slashes
- Tested each endpoint on my 2023.1.x k8s dev environment, and changed the ones that no longer work

## Related Issue

## How Has This Been Tested?
- Has not yet been tested through Roo, but I've checked the edited endpoints. Will confirm this in k8s after it builds & pushes