### PR TITLE
ACAS-413: Add a new migration to catch any "missed" ddict values.

### DIFF
--- a/src/main/resources/db/migration/postgres/V2.4.1.1__missing_column_ddict_values.sql
+++ b/src/main/resources/db/migration/postgres/V2.4.1.1__missing_column_ddict_values.sql
@@ -1,0 +1,116 @@
+do $script$
+begin
+-- As part of ACAS-413, followup from previous migration
+-- Exit early if there is no expt data as this indicates a fresh system
+if not exists (select * from experiment)
+then
+	return;
+end if;
+
+-- Fill in missing 'data column' DDict Values based on saved data
+-- Create a reusable function to insert missing ddict values
+create or replace function add_data_column_ddict_value(val varchar, ls_kind varchar) returns bigint as $$
+	--create ddict type if not exists
+	insert into ddict_type (id, ignored, name, version)
+		select nextval('ddict_type_pkseq') as id, false as ignored, 'data column', 0
+		where not exists (select * from ddict_type where name = 'data column');
+	--create ddict kind if not exists
+	insert into ddict_kind (id, ignored, ls_type, ls_type_and_kind, name, version)
+		select
+			nextval('ddict_kind_pkseq') as id,
+			false as ignored,
+			'data column' as ls_type,
+			'data column_'||ls_kind as ls_type_and_kind,
+			ls_kind as name,
+			0 as version
+			where not exists (
+				select * from ddict_kind where ls_type = 'data column' and name = ls_kind
+			);
+
+	--create ddict value if not exists
+	insert into ddict_value (id, ignored, code_name, label_text, ls_type, ls_kind, ls_type_and_kind, short_name, version)
+		select
+			nextval('ddict_value_pkseq') as id,
+			false as ignored,
+			'DDICT-' || lpad((select nextval(db_sequence) from label_sequence where label_prefix = 'DDICT'):: text, 6, '0'::text) as code_name,
+			val as label_text,
+			'data column' as ls_type,
+			ls_kind as ls_kind,
+			'data column_'||ls_kind as ls_type_and_kind,
+			val as short_name,
+			0 as version
+		where not exists (
+			select * from ddict_value dv 
+				where dv.ls_type = 'data column' 
+					and dv.ls_kind = ls_kind 
+					and dv.ignored = false 
+					and dv.short_name = val
+			)
+		returning id
+	$$ language sql;
+
+--Add missing column name ddicts
+perform add_data_column_ddict_value(code_value, 'column name'::varchar) from
+(SELECT DISTINCT ev.code_value
+	FROM experiment e
+	JOIN experiment_state es ON e.id = es.experiment_id
+	JOIN experiment_value ev ON es.id = ev.experiment_state_id
+	WHERE e.ignored = FALSE
+	AND es.ignored = FALSE
+	AND ev.ignored = FALSE
+	AND es.ls_kind = 'data column order'
+	AND ev.ls_kind = 'column name'
+	AND ev.code_value IS NOT NULL
+	AND NOT exists(
+		SELECT 1 FROM ddict_value dv WHERE dv.ls_type = ev.code_type AND dv.ls_kind = ev.code_kind AND dv.short_name = ev.code_value
+)) a;
+
+--units
+perform add_data_column_ddict_value(code_value, 'column units'::varchar) from
+(SELECT DISTINCT ev.code_value
+	FROM experiment e
+	JOIN experiment_state es ON e.id = es.experiment_id
+	JOIN experiment_value ev ON es.id = ev.experiment_state_id
+	WHERE e.ignored = FALSE
+	AND es.ignored = FALSE
+	AND ev.ignored = FALSE
+	AND es.ls_kind = 'data column order'
+	AND ev.ls_kind = 'column units'
+	AND ev.code_value IS NOT NULL
+	AND NOT exists(
+		SELECT 1 FROM ddict_value dv WHERE dv.ls_type = ev.code_type AND dv.ls_kind = ev.code_kind AND dv.short_name = ev.code_value
+)) a;
+
+--conc units
+perform add_data_column_ddict_value(code_value, 'column conc units'::varchar) from
+(SELECT DISTINCT ev.code_value
+	FROM experiment e
+	JOIN experiment_state es ON e.id = es.experiment_id
+	JOIN experiment_value ev ON es.id = ev.experiment_state_id
+	WHERE e.ignored = FALSE
+	AND es.ignored = FALSE
+	AND ev.ignored = FALSE
+	AND es.ls_kind = 'data column order'
+	AND ev.ls_kind = 'column conc units'
+	AND ev.code_value IS NOT NULL
+	AND NOT exists(
+		SELECT 1 FROM ddict_value dv WHERE dv.ls_type = ev.code_type AND dv.ls_kind = ev.code_kind AND dv.short_name = ev.code_value
+)) a;
+
+--time units
+perform add_data_column_ddict_value(code_value, 'column time units'::varchar) from
+(SELECT DISTINCT ev.code_value
+	FROM experiment e
+	JOIN experiment_state es ON e.id = es.experiment_id
+	JOIN experiment_value ev ON es.id = ev.experiment_state_id
+	WHERE e.ignored = FALSE
+	AND es.ignored = FALSE
+	AND ev.ignored = FALSE
+	AND es.ls_kind = 'data column order'
+	AND ev.ls_kind = 'column time units'
+	AND ev.code_value IS NOT NULL
+	AND NOT exists(
+		SELECT 1 FROM ddict_value dv WHERE dv.ls_type = ev.code_type AND dv.ls_kind = ev.code_kind AND dv.short_name = ev.code_value
+)) a;
+
+end $script$

--- a/src/main/resources/db/migration/postgres/V2.4.1.1__missing_column_ddict_values.sql
+++ b/src/main/resources/db/migration/postgres/V2.4.1.1__missing_column_ddict_values.sql
@@ -61,6 +61,7 @@ perform add_data_column_ddict_value(code_value, 'column name'::varchar) from
 	AND es.ls_kind = 'data column order'
 	AND ev.ls_kind = 'column name'
 	AND ev.code_value IS NOT NULL
+	AND LENGTH(ev.code_value) > 0
 	AND NOT exists(
 		SELECT 1 FROM ddict_value dv WHERE dv.ls_type = ev.code_type AND dv.ls_kind = ev.code_kind AND dv.short_name = ev.code_value
 )) a;
@@ -77,6 +78,7 @@ perform add_data_column_ddict_value(code_value, 'column units'::varchar) from
 	AND es.ls_kind = 'data column order'
 	AND ev.ls_kind = 'column units'
 	AND ev.code_value IS NOT NULL
+	AND LENGTH(ev.code_value) > 0
 	AND NOT exists(
 		SELECT 1 FROM ddict_value dv WHERE dv.ls_type = ev.code_type AND dv.ls_kind = ev.code_kind AND dv.short_name = ev.code_value
 )) a;
@@ -93,6 +95,7 @@ perform add_data_column_ddict_value(code_value, 'column conc units'::varchar) fr
 	AND es.ls_kind = 'data column order'
 	AND ev.ls_kind = 'column conc units'
 	AND ev.code_value IS NOT NULL
+	AND LENGTH(ev.code_value) > 0
 	AND NOT exists(
 		SELECT 1 FROM ddict_value dv WHERE dv.ls_type = ev.code_type AND dv.ls_kind = ev.code_kind AND dv.short_name = ev.code_value
 )) a;
@@ -109,6 +112,7 @@ perform add_data_column_ddict_value(code_value, 'column time units'::varchar) fr
 	AND es.ls_kind = 'data column order'
 	AND ev.ls_kind = 'column time units'
 	AND ev.code_value IS NOT NULL
+	AND LENGTH(ev.code_value) > 0
 	AND NOT exists(
 		SELECT 1 FROM ddict_value dv WHERE dv.ls_type = ev.code_type AND dv.ls_kind = ev.code_kind AND dv.short_name = ev.code_value
 )) a;


### PR DESCRIPTION
## Description
- Testing showed that some "Dose Response" columns (Slope, Min, Max) present in SEL files were being saved in Experiment "data column order" states by SEL, but the necessary DDict values to display their column names in the Protocol Endpoint Manager GUI were not getting created
- Simplest fix is to add a new migration that looks for any missing ddict values and adds them

## Related Issue

## How Has This Been Tested?
Tested locally by:
- Starting up ACAS on release/2022.4.x
- Loading a Dose Response Experiment
- Switching ACAS to release/2023.1.x and starting up, which applies the previous migration V2.4.1.0
- Logging in, navigating to Protocol Browser and confirming there are endpoints whose names are not displaying
- Switch Roo image to locally-built one with these changes, start up, which applies the new migration V2.4.1.1
- Login again and check the Protocol UI, and confirm all endpoints are now showing their column names properly.