### PR TITLE
ACAS-575: Search experiment project in experiment browser search

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
@@ -1194,6 +1194,7 @@ public class ExperimentServiceImpl implements ExperimentService {
 			experimentIdList.addAll(findExperimentIdsByMetadata(term, "CELL LINE"));
 			experimentIdList.addAll(findExperimentIdsByMetadata(term, "TARGET ORIGIN"));
 			experimentIdList.addAll(findExperimentIdsByMetadata(term, "ASSAY STAGE"));
+			experimentIdList.addAll(findExperimentIdsByMetadata(term, "PROJECT"));
 
 			resultsByTerm.put(term, new HashSet<Long>(experimentIdList));
 			experimentAllIdList.addAll(experimentIdList);
@@ -1391,6 +1392,16 @@ public class ExperimentServiceImpl implements ExperimentService {
 		if (searchBy == "NOTEBOOK") {
 			Collection<ExperimentValue> experimentValues = ExperimentValue
 					.findExperimentValuesByLsKindEqualsAndStringValueLike("notebook", queryString).getResultList();
+			if (!experimentValues.isEmpty()) {
+				for (ExperimentValue experimentValue : experimentValues) {
+					experimentIdList.add(experimentValue.getLsState().getExperiment().getId());
+				}
+			}
+			experimentValues.clear();
+		}
+		if (searchBy == "PROJECT") {
+			Collection<ExperimentValue> experimentValues = ExperimentValue
+					.findExperimentValuesByLsKindEqualsAndCodeValueLike("project", queryString).getResultList();
 			if (!experimentValues.isEmpty()) {
 				for (ExperimentValue experimentValue : experimentValues) {
 					experimentIdList.add(experimentValue.getLsState().getExperiment().getId());


### PR DESCRIPTION
## Description
Search the project field when doing a query terms search (experiment browser)

## Related Issue
ACAS-575

## How Has This Been Tested?
Ran acasclient tests