### PR TITLE
Improve Reporting of Overwritten Experiments and Migration of Old Experiment Statuses to "Overwritten"

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/ExperimentService.java
+++ b/src/main/java/com/labsynch/labseer/service/ExperimentService.java
@@ -51,13 +51,13 @@ public interface ExperimentService {
 	public Collection<Experiment> findExperimentsByMetadataJson(
 			List<StringCollectionDTO> metaDataList);
 
-	public Collection<Experiment> findExperimentsByGenericMetaDataSearch(String query, String userName)
+	public Collection<Experiment> findExperimentsByGenericMetaDataSearch(String query, String userName, Boolean includeDeleted)
 			throws TooManyResultsException;
 
-	public Collection<Experiment> findExperimentsByGenericMetaDataSearch(String query, List<String> projects)
+	public Collection<Experiment> findExperimentsByGenericMetaDataSearch(String query, List<String> projects, Boolean includeDeleted)
 			throws TooManyResultsException;
 
-	public Collection<Experiment> findExperimentsByGenericMetaDataSearch(String query) throws TooManyResultsException;
+	public Collection<Experiment> findExperimentsByGenericMetaDataSearch(String query, Boolean includeDeleted) throws TooManyResultsException;
 
 	public Collection<Experiment> findExperimentsByMetadata(String queryString, String searchBy);
 

--- a/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
@@ -1086,9 +1086,9 @@ public class ExperimentServiceImpl implements ExperimentService {
 	}
 
 	@Override
-	public Collection<Experiment> findExperimentsByGenericMetaDataSearch(String queryString, String userName)
+	public Collection<Experiment> findExperimentsByGenericMetaDataSearch(String queryString, String userName, Boolean includeDeleted)
 			throws TooManyResultsException {
-		Collection<Experiment> rawResults = findExperimentsByGenericMetaDataSearch(queryString);
+		Collection<Experiment> rawResults = findExperimentsByGenericMetaDataSearch(queryString, includeDeleted);
 		if (propertiesUtilService.getRestrictExperiments()) {
 			Collection<LsThing> projects = authorService.getUserProjects(userName);
 			List<String> allowedProjectCodeNames = new ArrayList<String>();
@@ -1119,9 +1119,9 @@ public class ExperimentServiceImpl implements ExperimentService {
 	}
 
 	@Override
-	public Collection<Experiment> findExperimentsByGenericMetaDataSearch(String queryString, List<String> projects)
+	public Collection<Experiment> findExperimentsByGenericMetaDataSearch(String queryString, List<String> projects, Boolean includeDeleted)
 			throws TooManyResultsException {
-		Collection<Experiment> rawResults = findExperimentsByGenericMetaDataSearch(queryString);
+		Collection<Experiment> rawResults = findExperimentsByGenericMetaDataSearch(queryString, includeDeleted);
 		if (propertiesUtilService.getRestrictExperiments()) {
 			projects.add("unassigned");
 			Collection<Experiment> results = new HashSet<Experiment>();
@@ -1147,7 +1147,7 @@ public class ExperimentServiceImpl implements ExperimentService {
 		}
 	}
 
-	public Collection<Experiment> findExperimentsByGenericMetaDataSearch(String queryString)
+	public Collection<Experiment> findExperimentsByGenericMetaDataSearch(String queryString, Boolean includeDeleted)
 			throws TooManyResultsException {
 		// make our HashSets: experimentIdList will be filled/cleared/refilled for each
 		// term
@@ -1210,12 +1210,13 @@ public class ExperimentServiceImpl implements ExperimentService {
 		// ignored or deleted
 		Collection<Experiment> result = new HashSet<Experiment>();
 		for (Experiment experiment : experimentList) {
-			// For Experiment Browser, we want to see soft deleted (ignored=true,
+			// For Experiment Browser, we generally want to see soft deleted (ignored=true,
 			// deleted=false), but not hard deleted (ignored=deleted=true)
-			if (experiment.isDeleted()) {
-				logger.debug("removing a deleted experiment from the results");
-			} else {
+			// But the includeDeleted flag will include hard deleted experiments too
+			if (!experiment.isDeleted() || includeDeleted){
 				result.add(experiment);
+			} else {
+				logger.debug("removing a deleted experiment from the results");
 			}
 		}
 		return result;

--- a/src/main/resources/db/migration/postgres/V2.4.2.0__overwritten_experiment_status.sql
+++ b/src/main/resources/db/migration/postgres/V2.4.2.0__overwritten_experiment_status.sql
@@ -1,0 +1,73 @@
+-- Goal Of This Migration - To Introduce to the Notion of an "Overwritten" Experiment to ACAS
+
+-- 		1. SELECT ALL EXPERIMENTS WHERE "ignored=true" AND "deleted=true" 
+-- 		2. From the Filtered Experiments -> Set Old Experiment Status to Ignore 
+--    3. From the Filtered Experiments -> Set New Experiment Status of Being Overwritten 
+
+--Create an ls_transaction to tie all our states and values to
+insert into ls_transaction (id, comments, recorded_date, version, recorded_by)
+	select nextval('ls_transaction_pkseq'), 'V2.4.2.0 overwritten experiment status', now(), 0, 'ACAS';
+
+
+UPDATE
+    experiment_value
+SET
+    ignored = '1'  -- Ignoring Any Experiment Status Where Experiment is "Deleted" and "Ignored" (i.e. Our new definition of "Overwritten")
+FROM
+    (SELECT e.id AS id,
+    e.code_name || '::' || el.label_text as experiment_name,
+    e.code_name,
+    el.label_text,
+    e.Ls_Type_And_Kind as kind,
+    e.recorded_by,
+    e.recorded_date,
+    e.short_description,
+    e.protocol_id,
+    MAX( CASE ev.ls_kind WHEN 'experiment status' THEN ev.code_value ELSE null END ) AS status,
+    es.id as exp_state_id
+	FROM experiment e
+	JOIN experiment_label el
+	ON e.id=el.experiment_id
+	JOIN experiment_state es
+	ON e.id=es.experiment_id
+	JOIN experiment_value ev
+	ON Es.Id=Ev.Experiment_State_Id
+	WHERE e.ignored ='1' and e.deleted = '1' -- Criteria for Experiment Being Overwritten 
+	AND es.ls_kind='experiment metadata' Group By E.Id, E.Code_Name, E.Ls_Type_And_Kind, E.Recorded_By, E.Recorded_Date, E.Short_Description, E.Protocol_Id, El.Label_Text, exp_state_id)
+	AS subquery
+WHERE 
+	experiment_value.ls_kind = 'experiment status' and experiment_value.experiment_state_id = subquery.exp_state_id;
+
+
+-- Add New Ignore Status Set to "Overwritten"
+
+
+-- Inserting "Overwritten Status" Into Experiment Values w/ Associated Experiemnt State IDs From Same Filtering Criteria Above
+INSERT INTO experiment_value (id, deleted, ignored, code_kind, code_origin, code_type, code_type_and_kind, code_value, 
+								ls_kind, ls_transaction, 
+                ls_type, ls_type_and_kind, public_data, recorded_by, recorded_date, 
+								version, experiment_state_id)
+SELECT nextval('value_pkseq'), false, false, 'status', 'ACAS DDICT', 'experiment', 'experiment_status', 'overwritten',
+								'experiment status', (select id from ls_transaction where comments = 'V2.4.2.0 overwritten experiment status'), 
+                'codeValue', 'codeValue_experiment status', true, 'ACAS', now(),
+								0, subquery.exp_state_id
+FROM 
+    (SELECT e.id AS exp_id,
+    e.code_name || '::' || el.label_text as experiment_name,
+    e.code_name,
+    el.label_text,
+    es.id as exp_state_id
+    FROM experiment e
+    JOIN experiment_label el
+    ON e.id=el.experiment_id
+    JOIN experiment_state es
+    ON e.id=es.experiment_id
+    JOIN experiment_value ev
+    ON Es.Id=Ev.Experiment_State_Id
+    WHERE e.ignored ='1' and e.deleted = '1'
+    AND es.ls_kind='experiment metadata' Group By E.Id, E.Code_Name, El.Label_Text, es.id)
+    AS subquery
+ ;
+
+
+--- Check w/ select * from experiment_value WHERE experiment_value.ls_kind = 'experiment status';

--- a/src/main/resources/db/migration/postgres/V2.4.2.0__overwritten_experiment_status.sql
+++ b/src/main/resources/db/migration/postgres/V2.4.2.0__overwritten_experiment_status.sql
@@ -9,36 +9,6 @@ insert into ls_transaction (id, comments, recorded_date, version, recorded_by)
 	select nextval('ls_transaction_pkseq'), 'V2.4.2.0 overwritten experiment status', now(), 0, 'ACAS';
 
 
-UPDATE
-    experiment_value
-SET
-    ignored = '1'  -- Ignoring Any Experiment Status Where Experiment is "Deleted" and "Ignored" (i.e. Our new definition of "Overwritten")
-FROM
-    (SELECT e.id AS id,
-    e.code_name || '::' || el.label_text as experiment_name,
-    e.code_name,
-    el.label_text,
-    e.Ls_Type_And_Kind as kind,
-    e.recorded_by,
-    e.recorded_date,
-    e.short_description,
-    e.protocol_id,
-    MAX( CASE ev.ls_kind WHEN 'experiment status' THEN ev.code_value ELSE null END ) AS status,
-    es.id as exp_state_id
-	FROM experiment e
-	JOIN experiment_label el
-	ON e.id=el.experiment_id
-	JOIN experiment_state es
-	ON e.id=es.experiment_id
-	JOIN experiment_value ev
-	ON Es.Id=Ev.Experiment_State_Id
-	WHERE e.ignored ='1' and e.deleted = '1' -- Criteria for Experiment Being Overwritten 
-	AND es.ls_kind='experiment metadata' Group By E.Id, E.Code_Name, E.Ls_Type_And_Kind, E.Recorded_By, E.Recorded_Date, E.Short_Description, E.Protocol_Id, El.Label_Text, exp_state_id)
-	AS subquery
-WHERE 
-	experiment_value.ls_kind = 'experiment status' and experiment_value.experiment_state_id = subquery.exp_state_id;
-
-
 -- Add New Ignore Status Set to "Overwritten"
 
 
@@ -66,8 +36,39 @@ FROM
     ON Es.Id=Ev.Experiment_State_Id
     WHERE e.ignored ='1' and e.deleted = '1'
     AND es.ls_kind='experiment metadata' Group By E.Id, E.Code_Name, El.Label_Text, es.id)
-    AS subquery
- ;
+    AS subquery;
+
+
+
+
+UPDATE
+    experiment_value
+SET
+    ignored = '1'  -- Ignoring Any Experiment Status Where Experiment is "Deleted" and "Ignored" (i.e. Our new definition of "Overwritten")
+FROM
+    (SELECT e.id AS id,
+    e.code_name || '::' || el.label_text as experiment_name,
+    e.code_name,
+    el.label_text,
+    e.Ls_Type_And_Kind as kind,
+    e.recorded_by,
+    e.recorded_date,
+    e.short_description,
+    e.protocol_id,
+    MAX( CASE ev.ls_kind WHEN 'experiment status' THEN ev.code_value ELSE null END ) AS status,
+    es.id as exp_state_id
+	FROM experiment e
+	JOIN experiment_label el
+	ON e.id=el.experiment_id
+	JOIN experiment_state es
+	ON e.id=es.experiment_id
+	JOIN experiment_value ev
+	ON Es.Id=Ev.Experiment_State_Id
+	WHERE e.ignored ='1' and e.deleted = '1' -- Criteria for Experiment Being Overwritten 
+	AND es.ls_kind='experiment metadata' Group By E.Id, E.Code_Name, E.Ls_Type_And_Kind, E.Recorded_By, E.Recorded_Date, E.Short_Description, E.Protocol_Id, El.Label_Text, exp_state_id)
+	AS subquery
+WHERE 
+	experiment_value.ls_kind = 'experiment status' and experiment_value.code_value != 'overwritten' and experiment_value.experiment_state_id = subquery.exp_state_id;
 
 
 --- Check w/ select * from experiment_value WHERE experiment_value.ls_kind = 'experiment status';

--- a/src/test/java/com/labsynch/labseer/service/ExperimentServiceTests.java
+++ b/src/test/java/com/labsynch/labseer/service/ExperimentServiceTests.java
@@ -647,7 +647,7 @@ public class ExperimentServiceTests {
 		Long id = 2123L;
 		String query = "EXPERIMENT 4 EXPT-00000006";
 		Experiment experiment = Experiment.findExperiment(id);
-		Collection<Experiment> experiments = experimentService.findExperimentsByGenericMetaDataSearch(query);
+		Collection<Experiment> experiments = experimentService.findExperimentsByGenericMetaDataSearch(query, false);
 		Assert.assertEquals(1, experiments.size());
 		Assert.assertEquals(experiment.getId(), experiments.iterator().next().getId());
 		experiments.clear();
@@ -657,7 +657,7 @@ public class ExperimentServiceTests {
 		experiment.setIgnored(true);
 		experiment.merge();
 		experiment.flush();
-		experiments = experimentService.findExperimentsByGenericMetaDataSearch(query);
+		experiments = experimentService.findExperimentsByGenericMetaDataSearch(query, false);
 		Assert.assertEquals(1, experiments.size());
 		Assert.assertEquals(experiment.getId(), experiments.iterator().next().getId());
 		experiments.clear();
@@ -674,7 +674,7 @@ public class ExperimentServiceTests {
 		experiment.setIgnored(true);
 		experiment.merge();
 		experiment.flush();
-		Collection<Experiment> experiments = experimentService.findExperimentsByGenericMetaDataSearch(query);
+		Collection<Experiment> experiments = experimentService.findExperimentsByGenericMetaDataSearch(query, false);
 		Assert.assertEquals(0, experiments.size());
 
 	}
@@ -706,7 +706,7 @@ public class ExperimentServiceTests {
 	@Test
 	public void searchTest2() throws TooManyResultsException {
 		String query = "EXPT-00000012";
-		Collection<Experiment> experiments = experimentService.findExperimentsByGenericMetaDataSearch(query);
+		Collection<Experiment> experiments = experimentService.findExperimentsByGenericMetaDataSearch(query, false);
 		logger.debug("RESULTS: " + "NUMBER OF EXPERIMENTS: " + experiments.size() + experiments.toString());
 	}
 
@@ -779,24 +779,24 @@ public class ExperimentServiceTests {
 	public void experimentBrowserSearchTest2() throws Exception {
 		String query = "EXPERIMENT 5";
 		logger.info("Searching with the query: " + query);
-		Collection<Experiment> resultExperiments = experimentService.findExperimentsByGenericMetaDataSearch(query);
+		Collection<Experiment> resultExperiments = experimentService.findExperimentsByGenericMetaDataSearch(query, false);
 		logger.info("Found: " + resultExperiments.toString());
 		Assert.assertTrue(resultExperiments.size() > 0);
 		query = "\"EXPERIMENT 5\"";
 		logger.info("Searching with the query: " + query);
-		Collection<Experiment> resultExperiments2 = experimentService.findExperimentsByGenericMetaDataSearch(query);
+		Collection<Experiment> resultExperiments2 = experimentService.findExperimentsByGenericMetaDataSearch(query, false);
 		logger.info("Found: " + resultExperiments2.toString());
 		Assert.assertTrue(resultExperiments2.size() > 0);
 		Assert.assertTrue(resultExperiments.size() != resultExperiments2.size());
 
 		query = "EXPERIMENT 50";
 		logger.info("Searching with the query: " + query);
-		resultExperiments = experimentService.findExperimentsByGenericMetaDataSearch(query);
+		resultExperiments = experimentService.findExperimentsByGenericMetaDataSearch(query, false);
 		logger.info("Found: " + resultExperiments.toString());
 		Assert.assertTrue(resultExperiments.size() > 0);
 		query = "\"EXPERIMENT 50\"";
 		logger.info("Searching with the query: " + query);
-		resultExperiments2 = experimentService.findExperimentsByGenericMetaDataSearch(query);
+		resultExperiments2 = experimentService.findExperimentsByGenericMetaDataSearch(query, false);
 		logger.info("Found: " + resultExperiments2.toString());
 		Assert.assertTrue(resultExperiments2.size() > 0);
 		Assert.assertEquals(resultExperiments.iterator().next().getCodeName(),
@@ -808,7 +808,7 @@ public class ExperimentServiceTests {
 	public void experimentBrowser_dateSearch() throws Exception {
 		String query = "2015-05-08";
 		logger.info("Searching with the query: " + query);
-		Collection<Experiment> resultExperiments = experimentService.findExperimentsByGenericMetaDataSearch(query);
+		Collection<Experiment> resultExperiments = experimentService.findExperimentsByGenericMetaDataSearch(query, false);
 		logger.info("Found: " + resultExperiments.toString());
 		Assert.assertTrue(resultExperiments.size() > 0);
 


### PR DESCRIPTION
## Description
Users often are hampered by apparent 'missing data' when a registrar fails to update the experiment name field. A new experiment code is generated and the previous ACAS file-data is replaced (overwritten). In most cases, the current behavior is desired, since it allows trivial adjustments to units, endpoint labels, etc. But in wrong hands it leads to a confusing state. Moreover, as registrars it is difficult to even discover such cases and troubleshoot. Here we want to enhance the Experiment Browser table such that it can be used to recover from such registration failures.

**Scope of This Work**

- Backend Work Supporting the Adding of "Overwritten" as an "Experiment Status"
- Adding a route in the delete experiment logic that changes the status field
- DB migration to change the "experiment status" for "ignored=true, deleted=true" experiments to "overwritten". This creates a new "experiment status" experiment value and ignore the old status experiment value.

**Contribution Notes**

- @bffrost Added to the experiment routes and services 
- @dalejerikson Wrote SQL for the migration of "deleted" and "ignored" experiments to the "overwritten" status 