### PR TITLE
ACAS-601: Fix for multiple calls to split service for already registered parents

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -980,7 +980,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 		}
 
 		// Only run mixture check if we have not identified an already existing parent
-		if(parent.getId() != null) {
+		if(parent.getId() == null) {
 			// check for multiple fragments, and if isMixture or not
 			Boolean hasMultipleFragments = parent.getMultipleFragments();
 			if (hasMultipleFragments == null){

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -868,7 +868,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 		if (dupeParentList.length > 0) {
 			// If we find a duplicate parent, we want to maintain the multiple fragments boolean we already have to save time since we have already checked for this
 			// and it is a transient property which wil be null on the found parent we may be overwriting with
-			boolean multipleFragments = parent.getMultipleFragments();
+			Boolean multipleFragments = parent.getMultipleFragments();
 			searchResultLoop: for (int foundParentCdId : dupeParentList) {
 				List<Parent> foundParents = Parent.findParentsByCdId(foundParentCdId).getResultList();
 

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -866,6 +866,9 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 			dupeParentList = chemStructureService.searchMolStructures(parent.getCmpdRegMolecule(), StructureType.PARENT, ChemStructureService.SearchType.DUPLICATE_TAUTOMER, -1F, -1);
 		}
 		if (dupeParentList.length > 0) {
+			// If we find a duplicate parent, we want to maintain the multiple fragments boolean we already have to save time since we have already checked for this
+			// and it is a transient property which wil be null on the found parent we may be overwriting with
+			boolean multipleFragments = parent.getMultipleFragments();
 			searchResultLoop: for (int foundParentCdId : dupeParentList) {
 				List<Parent> foundParents = Parent.findParentsByCdId(foundParentCdId).getResultList();
 
@@ -894,6 +897,9 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 							// No Changes or Modifications Needed; Can Break Loop
 							// Continue 
 							parent = foundParent;
+							// Add the multiple fragments boolean back to the parent
+							// from the transient property we calculated earlier
+							parent.setMultipleFragments(multipleFragments);
 							break searchResultLoop; 
 						} else { 
 							// Need to Update Aliases of Matching Parent to Be Union of Two Sets
@@ -972,25 +978,29 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 				}
 			}
 		}
-		// check for multiple fragments, and if isMixture or not
-		Boolean hasMultipleFragments = parent.getMultipleFragments();
-		if (hasMultipleFragments == null){
-			hasMultipleFragments = chemStructureService.checkForSalt(parent.getMolStructure());
-		}
-		if (hasMultipleFragments) {
-			// multiple fragments
-			if (parent.getIsMixture() != null) {
-				if (!parent.getIsMixture()) {
+
+		// Only run mixture check if we have not identified an already existing parent
+		if(parent.getId() != null) {
+			// check for multiple fragments, and if isMixture or not
+			Boolean hasMultipleFragments = parent.getMultipleFragments();
+			if (hasMultipleFragments == null){
+				hasMultipleFragments = chemStructureService.checkForSalt(parent.getMolStructure());
+			}
+			if (hasMultipleFragments) {
+				// multiple fragments
+				if (parent.getIsMixture() != null) {
+					if (!parent.getIsMixture()) {
+						logger.error("Multiple fragments detected. Please fix or mark \"Parent Is Mixture\" as true");
+						throw new SaltedCompoundException(
+								"Multiple fragments detected. Please fix or mark \"Parent Is Mixture\" as true");
+					} else {
+						// do nothing - structure is appropriately marked as a mixture
+					}
+				} else {
 					logger.error("Multiple fragments detected. Please fix or mark \"Parent Is Mixture\" as true");
 					throw new SaltedCompoundException(
 							"Multiple fragments detected. Please fix or mark \"Parent Is Mixture\" as true");
-				} else {
-					// do nothing - structure is appropriately marked as a mixture
 				}
-			} else {
-				logger.error("Multiple fragments detected. Please fix or mark \"Parent Is Mixture\" as true");
-				throw new SaltedCompoundException(
-						"Multiple fragments detected. Please fix or mark \"Parent Is Mixture\" as true");
 			}
 		}
 		// If parent has not already been identified, see if the corpName is provided


### PR DESCRIPTION
## Description
 - Maintain transient multipleFragments property when finding an already register compound
 - Don't do multiple fragment errors when finding an already registered parent

## Related Issue
ACAS-601

## How Has This Been Tested?
Not tested yet