### PR TITLE
ACAS-600: Reparent lot behavior with maxAutoLotNumber

### DIFF
--- a/src/main/java/com/labsynch/labseer/domain/Lot.java
+++ b/src/main/java/com/labsynch/labseer/domain/Lot.java
@@ -405,7 +405,11 @@ public class Lot {
         }
 		criteria.where(criteriaBuilder.and(predicateList.toArray( new Predicate[0])));
         TypedQuery<Integer> q = em.createQuery(criteria);
-        return q.getSingleResult();
+        Integer result = q.getSingleResult();
+        if(result == null) {
+            result = 0;
+        }
+        return result;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION


Catch case when there are no lots below maxAutoLotNumber and return 0…… as the max Lot Number. This prevents upstream NullPointerExceptions.

<!--- Provide a general summary of your changes in the Title above -->

## Description
- The scenario for this bug is when a user is trying to reparent a lot (i.e. lot 1) of a Parent A onto another Parent B which only has a huge lot number (i.e. lot 4000). When the `maxAutoLotNumber` config is set (i.e. to 1000) the expected behavior is that Parent A Lot 1 will become Parent B Lot 1.
- On ACAS 2022.1.0 the actual behavior is that Parent A Lot 1 will be made into Parent B Lot 4001
- On ACAS 2022.4.3 the actual behavior is that the reparent check fails in the UI, and on the Roo layer there is a NullPointerException.
- This PR contains the fix for the NullPointerException. After that fix, we see the expected behavior.

## Related Issue

## How Has This Been Tested?
- Tested in local dev environment.