### PR TITLE
ACAS-603: Fix standardization status on fresh system

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -165,6 +165,10 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 					mostRecentHistory.setStandardizationStatus("complete");
 					mostRecentHistory.setStandardizationUser("acas");
 					mostRecentHistory.setStandardizationReason("Initial standardization record");
+					// Get the applied standardizer settings
+					StandardizerSettingsConfigDTO appliedStandardizerSettings = chemStructureService.getStandardizerSettings(true);
+					mostRecentHistory.setSettings(appliedStandardizerSettings.toJson());
+					mostRecentHistory.setSettingsHash(appliedStandardizerSettings.hashCode());
 					mostRecentHistory.persist();
 
 				}


### PR DESCRIPTION
## Bug description
### To reproduce
- Start up a fresh instance of ACAS
- Bulk load some compounds
- Open up Bulk loader or CmpdReg
### Expectation
ACAS does not block you from registering compounds and requires a re-standardization
### Actual outcome
ACAS blocks you from registering compounds and requires re-standardization

## Description of fix
- Bug was caused by the fact our auto-created initial standardizer history had no settings / settings hash
- Getting the applied settings and saving them in that initial history entry solves this issue

## Related Issue

## How Has This Been Tested?
- Reproduced issue in k8s and in local dev (attached to remote bbchem)
- Confirmed on local dev (attached to remote bbchem) that this is fixed after the code changes