### PR TITLE
ACAS-596: Health endpoint to check database speed.  Better logging of bbchem process and fingerprint requests

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiHealthController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiHealthController.java
@@ -1,0 +1,68 @@
+package com.labsynch.labseer.api;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import com.fasterxml.jackson.annotation.JacksonInject.Value;
+import com.labsynch.labseer.domain.ValueType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("api/v1/health")
+@Transactional
+public class ApiHealthController {
+
+	private static final Logger logger = LoggerFactory.getLogger(ApiHealthController.class);
+
+	public long measureTimeForSingleRun(Boolean logData) {
+		long startTime = System.currentTimeMillis();
+		List<ValueType> valueTypes = ValueType.findAllValueTypes();
+		// Read through all value types to force a database read
+		for (ValueType valueType : valueTypes) {
+			String valueTypeString = valueType.toString();
+			if (logData) {
+				logger.info("Value type: " + valueTypeString);
+			}
+		}
+		long endTime = System.currentTimeMillis();
+		return endTime - startTime;
+	}
+
+	@Transactional
+	@RequestMapping(value = "/checkDatabaseSpeed", method = RequestMethod.GET, headers = "Accept=application/json")
+	public ResponseEntity<String> checkDatabaseSpeed(@RequestParam(value="testsToRun", required=false) Integer testsToRun, @RequestParam(value="logData", required=false) Boolean logData) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Content-Type", "application/json; charset=utf-8");
+
+		if(testsToRun == null) {
+			testsToRun = 1000;
+		}
+
+		if(logData == null) {
+			logData = false;
+		}
+		
+		final boolean finalLogData = logData;
+		long totalTime = IntStream.range(0, testsToRun)
+				.mapToLong(i -> measureTimeForSingleRun(finalLogData))
+				.sum();
+
+		double averageTime = (double) totalTime / testsToRun;
+		logger.info("Average time per run: " + averageTime + "ms");
+
+		// Return json response with {"averageMsTime": averageTime, "totalTime": totalTime, "testsToRun": testsToRun, "logData": logData}
+		return new ResponseEntity<String>("{\"averageMsTime\": " + averageTime + ", \"totalTime\": " + totalTime + ", \"testsToRun\": " + testsToRun + ", \"logData\": " + finalLogData + "}", headers, HttpStatus.OK);
+	}
+
+}

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
@@ -103,8 +103,10 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 		}
 
 		ForkJoinPool pool = new ForkJoinPool(Runtime.getRuntime().availableProcessors());
-		logger.info("Invoking " + tasks.size() + " fingerprint tasks");
+		logger.info("Invoking " + tasks.size() + " structure fingerprint tasks");
 		List<Future<Response>> results = pool.invokeAll(tasks);
+		logger.info("Got responses from all " + tasks.size() + " structure fingerprint tasks");
+		logger.info("Processing " + results.size() + " structure fingerprint responses");
 		HashMap<Integer, JsonNode> responseMap = new HashMap<Integer, JsonNode>();
 		for (Future<Response> response : results) {
 			String responseBody;
@@ -134,7 +136,7 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 			}
 			responseMap.put(responseId, responseNode);
 		}
-		logger.info("Got response for all " + tasks.size() + " fingerprint tasks");
+		logger.info("Finished processing " + results.size() + " structure fingerprint responses");
 
 		// The output array is guaranteed to be in the same order as its inputs
 		// Sort the response hashmap by the keys
@@ -254,8 +256,10 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 		}
 
 		ForkJoinPool pool = new ForkJoinPool(Runtime.getRuntime().availableProcessors());
-		logger.info("Invoking " + tasks.size() + " process tasks");
+		logger.info("Invoking " + tasks.size() + " structure process tasks");
 		List<Future<Response>> results = pool.invokeAll(tasks);
+		logger.info("Got responses from all " + tasks.size() + " structure process tasks");
+		logger.info("Processing " + results.size() + " structure process responses");
 		HashMap<Integer, JsonNode> responseMap = new HashMap<Integer, JsonNode>();
 		for (Future<Response> response : results) {
 			String responseBody;
@@ -280,7 +284,7 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 			JsonNode responseNode = responseMapper.readTree(responseBody);
 			responseMap.put(responseId, responseNode);
 		}
-		logger.info("Got response for all " + tasks.size() + " process tasks");
+		logger.info("Finished processing " + results.size() + " structure process responses");
 
 		// Sort the response hashmap by the keys
 		List<Integer> responseIds = new ArrayList<Integer>(responseMap.keySet());

--- a/src/main/java/com/labsynch/labseer/utils/Request.java
+++ b/src/main/java/com/labsynch/labseer/utils/Request.java
@@ -33,6 +33,8 @@ public class Request implements Callable<Response> {
     public Response call() {
         try {
             obj = new URL(url);
+            long startTime = System.currentTimeMillis();
+            logger.debug("Request " + id + " - Opening connection to " + url );
             con = (HttpURLConnection) obj.openConnection();
             String charset = "UTF-8";
             con.setRequestMethod("POST");
@@ -40,10 +42,12 @@ public class Request implements Callable<Response> {
             con.setRequestProperty("Accept", "application/json");
             con.setRequestProperty("Accept-Charset", charset);
             con.setRequestProperty("Content-Type", "application/json");
+            logger.debug("Request " + id + " - Sending request to " + url);
             OutputStream output = con.getOutputStream();
             output.write(json.getBytes());
 
             int responseCode = con.getResponseCode();
+            logger.debug("Request " + id + " - Response code: " + responseCode + " in " + (System.currentTimeMillis() - startTime) / 1000 + " seconds");
             InputStream inputStream = null;
             if (responseCode < HttpURLConnection.HTTP_BAD_REQUEST) {
                 inputStream = con.getInputStream();
@@ -51,9 +55,10 @@ public class Request implements Callable<Response> {
                 inputStream = con.getErrorStream();
             }
             String body = IOUtils.toString(inputStream);
+            logger.debug("Request " + id + " - Returning response body in " + (System.currentTimeMillis() - startTime) / 1000 + " seconds");
             return new Response(id, responseCode, body);
         } catch (IOException e) {
-            logger.error("Error in Request", e);
+            logger.error("Request " + id + " - Error in Request", e);
             response = "{\"output\":\"some error occurred\"}";
             return new Response(id, 404, response);
         }


### PR DESCRIPTION
## Description
 - Health endpoint queries all value types, which should be uniform on all systems of the same version. The idea is to have an endpoint tests the speed of querying the database which can be used to compare systems.

Curl example:

```
curl  "http://localhost:8080/acas/api/v1/health/checkDatabaseSpeed?testsToRun=100000&logData=False"
```

Output:
```
{"averageMsTime": 0.73629, "totalTime": 73629, "testsToRun": 100000, "logData": false}
```

## Related Issue
ACAS-596

## How Has This Been Tested?
Ran curl and verified results with up to 1 million tests with log data False and True.
