### PR TITLE
Salt Browser Bug: Charged and Uncharged Salts Being Treated as Duplicates 

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiSaltController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiSaltController.java
@@ -283,7 +283,7 @@ public class ApiSaltController {
 		}
 		if (validSalt & !dryrun) {
 			try {
-				salt = saltStructureService.saveStructureNoDupeCheck(salt);
+				salt = saltStructureService.saveStructure(salt, false);
 			} catch (CmpdRegMolFormatException e) {
 				logger.error("Error saving salt: " + e.getMessage());
 				validSalt = false;

--- a/src/main/java/com/labsynch/labseer/api/ApiSaltController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiSaltController.java
@@ -283,7 +283,7 @@ public class ApiSaltController {
 		}
 		if (validSalt & !dryrun) {
 			try {
-				salt = saltStructureService.saveStructure(salt);
+				salt = saltStructureService.saveStructureNoDupeCheck(salt);
 			} catch (CmpdRegMolFormatException e) {
 				logger.error("Error saving salt: " + e.getMessage());
 				validSalt = false;
@@ -304,7 +304,16 @@ public class ApiSaltController {
 			errors.add(error);
 
 			return new ResponseEntity<String>(ErrorMessage.toJsonArray(errors), headers, HttpStatus.BAD_REQUEST);
-		} else if (salt.getCdId() > 0 || (validSalt & dryrun)) { // Continue If Valid Registered or Valid Salt in Dryrun
+		} 
+		else if (salt.getCdId() == 0 & !dryrun)
+		{
+			ErrorMessage error = new ErrorMessage();
+			error.setLevel("error");
+			error.setMessage("Duplicate salt found in system.");
+			errors.add(error);
+			return new ResponseEntity<String>(ErrorMessage.toJsonArray(errors), headers, HttpStatus.CONFLICT);
+		}
+		else if (salt.getCdId() > 0 || (validSalt & dryrun)) { // Continue If Valid Registered or Valid Salt in Dryrun
 			if(!dryrun) {
 				salt.persist();
 			}

--- a/src/main/java/com/labsynch/labseer/service/SaltStructureService.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltStructureService.java
@@ -12,6 +12,8 @@ public interface SaltStructureService {
 
 	public Salt update(Salt salt) throws CmpdRegMolFormatException;
 
+	public Salt saveStructureNoDupeCheck(Salt salt) throws CmpdRegMolFormatException;
+
 	public Salt edit(Salt oldSalt, Salt newSalt);
 
 	List<Salt> saveMissingStructures() throws StructureSaveException;

--- a/src/main/java/com/labsynch/labseer/service/SaltStructureService.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltStructureService.java
@@ -8,11 +8,9 @@ import com.labsynch.labseer.exceptions.StructureSaveException;
 
 public interface SaltStructureService {
 
-	public Salt saveStructure(Salt salt) throws CmpdRegMolFormatException;
+	public Salt saveStructure(Salt salt, boolean checkForDupes) throws CmpdRegMolFormatException;
 
 	public Salt update(Salt salt) throws CmpdRegMolFormatException;
-
-	public Salt saveStructureNoDupeCheck(Salt salt) throws CmpdRegMolFormatException;
 
 	public Salt edit(Salt oldSalt, Salt newSalt);
 

--- a/src/main/java/com/labsynch/labseer/service/SaltStructureServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltStructureServiceImpl.java
@@ -60,7 +60,6 @@ public class SaltStructureServiceImpl implements SaltStructureService {
 		}
 
 		return salt;
-
 	}
 
 	@Override
@@ -93,6 +92,29 @@ public class SaltStructureServiceImpl implements SaltStructureService {
 			return null;
         }
 
+	}
+
+	public Salt saveStructureNoDupeCheck(Salt salt) throws CmpdRegMolFormatException {
+		CmpdRegMolecule mol = chemStructureService.toMolecule(salt.getMolStructure());
+		salt.setOriginalStructure(salt.getMolStructure());
+		salt.setMolStructure(mol.getMolStructure());
+		salt.setFormula(mol.getFormula());
+		if (propertiesUtilService.getUseExactMass()) {
+			salt.setMolWeight(mol.getExactMass());
+		} else {
+			salt.setMolWeight(mol.getMass());
+		}
+		salt.setCharge(mol.getTotalCharge());
+
+		logger.debug("salt code: " + salt.getAbbrev());
+		logger.debug("salt name: " + salt.getName());
+		logger.debug("salt structure: " + salt.getMolStructure());
+
+		boolean checkForDupes = false;
+		int cdId = chemStructureService.saveStructure(salt.getMolStructure(), StructureType.SALT, checkForDupes);
+		salt.setCdId(cdId);
+
+		return salt;
 	}
 
     public Salt edit(Salt oldSalt, Salt newSalt){

--- a/src/main/java/com/labsynch/labseer/service/SaltStructureServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltStructureServiceImpl.java
@@ -28,7 +28,7 @@ public class SaltStructureServiceImpl implements SaltStructureService {
 	Logger logger = LoggerFactory.getLogger(SaltStructureService.class);
 
 	@Override
-	public Salt saveStructure(Salt salt) throws CmpdRegMolFormatException {
+	public Salt saveStructure(Salt salt, boolean checkForDupes) throws CmpdRegMolFormatException {
 
 		CmpdRegMolecule mol = chemStructureService.toMolecule(salt.getMolStructure());
 		salt.setOriginalStructure(salt.getMolStructure());
@@ -54,7 +54,6 @@ public class SaltStructureServiceImpl implements SaltStructureService {
 			int[] dupeMols = chemStructureService.checkDupeMol(salt.getMolStructure(), StructureType.SALT);
 			logger.debug("number of matching salt structures: " + dupeMols.length);
 		} else {
-			boolean checkForDupes = true;
 			int cdId = chemStructureService.saveStructure(salt.getMolStructure(), StructureType.SALT, checkForDupes);
 			salt.setCdId(cdId);
 		}
@@ -92,29 +91,6 @@ public class SaltStructureServiceImpl implements SaltStructureService {
 			return null;
         }
 
-	}
-
-	public Salt saveStructureNoDupeCheck(Salt salt) throws CmpdRegMolFormatException {
-		CmpdRegMolecule mol = chemStructureService.toMolecule(salt.getMolStructure());
-		salt.setOriginalStructure(salt.getMolStructure());
-		salt.setMolStructure(mol.getMolStructure());
-		salt.setFormula(mol.getFormula());
-		if (propertiesUtilService.getUseExactMass()) {
-			salt.setMolWeight(mol.getExactMass());
-		} else {
-			salt.setMolWeight(mol.getMass());
-		}
-		salt.setCharge(mol.getTotalCharge());
-
-		logger.debug("salt code: " + salt.getAbbrev());
-		logger.debug("salt name: " + salt.getName());
-		logger.debug("salt structure: " + salt.getMolStructure());
-
-		boolean checkForDupes = false;
-		int cdId = chemStructureService.saveStructure(salt.getMolStructure(), StructureType.SALT, checkForDupes);
-		salt.setCdId(cdId);
-
-		return salt;
 	}
 
     public Salt edit(Salt oldSalt, Salt newSalt){


### PR DESCRIPTION
**Bug:** CmpdReg Salt Module: Different forms of same salt (e.g. charged & neutral) are being treated as duplicates

Steps to Reproduce:

- Log in to ACAS as CmpdReg admin >> Open CmpdReg Salts module
- Register a salt in it's neutral form (e.g. Dihydrogen Sulphate - H2SO4)
- Now register a charged form of the same salt (i.e. Sulphate ion - O4S-2)
- Provide different salt name & abbreviation for both entries

Previous Bug Results:

- The neutral form & charged form of same salt is getting treated as duplicates of each other
- CReg is generating '0' Compound ID for the later entry

Fixed Results:

- Both entries should get registered as different entries
- Both entries should receive unique Compound ID

Extra Information: 

- Added `saveStructureNoDupeCheck(salt)` in `saltStructureService` 

Logic and Reasoning for Solution: 

- When first implementing the Salt Browser, it was decided that we would not be checking for duplicate structures and it would the responsibility of the data administrators to retain the integrity of the data in this area. This work uncovered a prior section of code salts would be run through when saved: 

```
boolean checkForDupes = true;
int cdId = chemStructureService.saveStructure(salt.getMolStructure(), StructureType.SALT, checkForDupes);
```

- Different chemistry engines slightly vary the way in which duplicates are checked and since the original design of the Salt Browser purposefully did not involve duplicate checking, I have added `saveStructureNoDupeCheck(salt)` to bypass this problem. 