### PR TITLE
k8s: CmpdReg Salts module is not calculating "charges" from salt's structure while registering salts 

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/CmpdRegMolecule.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/CmpdRegMolecule.java
@@ -19,13 +19,13 @@ public interface CmpdRegMolecule {
 
 	public String getMolStructure() throws CmpdRegMolFormatException;
 
-	public String getFormula();
+	public String getFormula(boolean stopNeutralization);
 
 	public Double getExactMass();
 
-	public Double getMass();
+	public Double getMass(boolean stopNeutralization);
 
-	public int getTotalCharge();
+	public int getTotalCharge(boolean stopNeutralization);
 
 	public String getSmiles();
 

--- a/src/main/java/com/labsynch/labseer/chemclasses/CmpdRegMolecule.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/CmpdRegMolecule.java
@@ -19,13 +19,13 @@ public interface CmpdRegMolecule {
 
 	public String getMolStructure() throws CmpdRegMolFormatException;
 
-	public String getFormula(boolean stopNeutralization);
+	public String getFormula(boolean skipNeutralization);
 
 	public Double getExactMass();
 
-	public Double getMass(boolean stopNeutralization);
+	public Double getMass(boolean skipNeutralization);
 
-	public int getTotalCharge(boolean stopNeutralization);
+	public int getTotalCharge(boolean skipNeutralization);
 
 	public String getSmiles();
 

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureService.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureService.java
@@ -17,13 +17,13 @@ public interface BBChemStructureService {
 
     public JsonNode getPreprocessorSettings() throws IOException;
 
-    public JsonNode postToProcessService(String molfile) throws IOException;
+    public JsonNode postToProcessService(String molfile, Boolean stopNeutralization) throws IOException;
 
-    public BBChemParentStructure getProcessedStructure(String molfile, Boolean includeFingerprints)
+    public BBChemParentStructure getProcessedStructure(String molfile, Boolean includeFingerprints, Boolean stopNeutralization)
             throws CmpdRegMolFormatException;
 
     public HashMap<String, BBChemParentStructure> getProcessedStructures(HashMap<String, String> structures,
-            Boolean includeFingerprints) throws CmpdRegMolFormatException;
+            Boolean includeFingerprints, Boolean stopNeutralization) throws CmpdRegMolFormatException;
 
     public String getSDF(BBChemParentStructure structure) throws IOException;
 

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureService.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureService.java
@@ -17,13 +17,13 @@ public interface BBChemStructureService {
 
     public JsonNode getPreprocessorSettings() throws IOException;
 
-    public JsonNode postToProcessService(String molfile, Boolean stopNeutralization) throws IOException;
+    public JsonNode postToProcessService(String molfile, Boolean skipNeutralization) throws IOException;
 
-    public BBChemParentStructure getProcessedStructure(String molfile, Boolean includeFingerprints, Boolean stopNeutralization)
+    public BBChemParentStructure getProcessedStructure(String molfile, Boolean includeFingerprints, Boolean skipNeutralization)
             throws CmpdRegMolFormatException;
 
     public HashMap<String, BBChemParentStructure> getProcessedStructures(HashMap<String, String> structures,
-            Boolean includeFingerprints, Boolean stopNeutralization) throws CmpdRegMolFormatException;
+            Boolean includeFingerprints, Boolean skipNeutralization) throws CmpdRegMolFormatException;
 
     public String getSDF(BBChemParentStructure structure) throws IOException;
 

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
@@ -203,7 +203,7 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 		return groups;
 	}
 
-	private JsonNode postToProcessService(HashMap<String, String> structures, Boolean stopNeutralization) throws IOException {
+	private JsonNode postToProcessService(HashMap<String, String> structures, Boolean skipNeutralization) throws IOException {
 
 		String url = propertiesUtilService.getLDChemURL() + PROCESS_PATH;
 
@@ -219,7 +219,7 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 		// Get the standardizer actions
 		JsonNode standardizerActions = propertiesUtilService.getStandardizerActions();
 
-		if(stopNeutralization){
+		if(skipNeutralization){
 			((ObjectNode)standardizerActions).put("NEUTRALIZE", "false");
 		}
 
@@ -305,21 +305,21 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 	}
 
 	@Override
-	public JsonNode postToProcessService(String molfile, Boolean stopNeutralization) throws IOException {
+	public JsonNode postToProcessService(String molfile, Boolean skipNeutralization) throws IOException {
 
 		// New hashamp
 		HashMap<String, String> structures = new HashMap<String, String>();
 		// Add the molfile to the hashmap
 		structures.put("mol", molfile);
 		// Post to the service
-		JsonNode jsonNode = postToProcessService(structures, stopNeutralization);
+		JsonNode jsonNode = postToProcessService(structures, skipNeutralization);
 
 		return jsonNode;
 	}
 
 	@Override
 	public HashMap<String, BBChemParentStructure> getProcessedStructures(HashMap<String, String> structures,
-			Boolean includeFingerprints, Boolean stopNeutralization) throws CmpdRegMolFormatException {
+			Boolean includeFingerprints, Boolean skipNeutralization) throws CmpdRegMolFormatException {
 
 		// Return map
 		HashMap<String, BBChemParentStructure> processedStructures = new HashMap<String, BBChemParentStructure>();
@@ -328,7 +328,7 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 		try {
 			JsonNode responseNode;
 			try {
-				responseNode = postToProcessService(structures, stopNeutralization);
+				responseNode = postToProcessService(structures, skipNeutralization);
 			} catch (IOException e) {
 				throw new CmpdRegMolFormatException(e);
 			}
@@ -456,7 +456,7 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 	}
 
 	@Override
-	public BBChemParentStructure getProcessedStructure(String molfile, Boolean includeFingerprints, Boolean stopNeutralization)
+	public BBChemParentStructure getProcessedStructure(String molfile, Boolean includeFingerprints, Boolean skipNeutralization)
 			throws CmpdRegMolFormatException {
 		BBChemParentStructure bbChemStructure = new BBChemParentStructure();
 		// Post to the service and parse the response
@@ -466,7 +466,7 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 			structures.put("molstructure", molfile);
 
 			HashMap<String, BBChemParentStructure> processedStructuresHashMap = getProcessedStructures(structures,
-					includeFingerprints, stopNeutralization);
+					includeFingerprints, skipNeutralization);
 
 			// Get the first structure
 			bbChemStructure = processedStructuresHashMap.get("molstructure");

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemStructureServiceImpl.java
@@ -203,7 +203,7 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 		return groups;
 	}
 
-	private JsonNode postToProcessService(HashMap<String, String> structures) throws IOException {
+	private JsonNode postToProcessService(HashMap<String, String> structures, Boolean stopNeutralization) throws IOException {
 
 		String url = propertiesUtilService.getLDChemURL() + PROCESS_PATH;
 
@@ -218,6 +218,10 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 
 		// Get the standardizer actions
 		JsonNode standardizerActions = propertiesUtilService.getStandardizerActions();
+
+		if(stopNeutralization){
+			((ObjectNode)standardizerActions).put("NEUTRALIZE", "false");
+		}
 
 		options.replace("standardizer_actions", standardizerActions);
 		requestData.replace("options", options);
@@ -301,21 +305,21 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 	}
 
 	@Override
-	public JsonNode postToProcessService(String molfile) throws IOException {
+	public JsonNode postToProcessService(String molfile, Boolean stopNeutralization) throws IOException {
 
 		// New hashamp
 		HashMap<String, String> structures = new HashMap<String, String>();
 		// Add the molfile to the hashmap
 		structures.put("mol", molfile);
 		// Post to the service
-		JsonNode jsonNode = postToProcessService(structures);
+		JsonNode jsonNode = postToProcessService(structures, stopNeutralization);
 
 		return jsonNode;
 	}
 
 	@Override
 	public HashMap<String, BBChemParentStructure> getProcessedStructures(HashMap<String, String> structures,
-			Boolean includeFingerprints) throws CmpdRegMolFormatException {
+			Boolean includeFingerprints, Boolean stopNeutralization) throws CmpdRegMolFormatException {
 
 		// Return map
 		HashMap<String, BBChemParentStructure> processedStructures = new HashMap<String, BBChemParentStructure>();
@@ -324,7 +328,7 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 		try {
 			JsonNode responseNode;
 			try {
-				responseNode = postToProcessService(structures);
+				responseNode = postToProcessService(structures, stopNeutralization);
 			} catch (IOException e) {
 				throw new CmpdRegMolFormatException(e);
 			}
@@ -452,7 +456,7 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 	}
 
 	@Override
-	public BBChemParentStructure getProcessedStructure(String molfile, Boolean includeFingerprints)
+	public BBChemParentStructure getProcessedStructure(String molfile, Boolean includeFingerprints, Boolean stopNeutralization)
 			throws CmpdRegMolFormatException {
 		BBChemParentStructure bbChemStructure = new BBChemParentStructure();
 		// Post to the service and parse the response
@@ -462,7 +466,7 @@ public class BBChemStructureServiceImpl implements BBChemStructureService {
 			structures.put("molstructure", molfile);
 
 			HashMap<String, BBChemParentStructure> processedStructuresHashMap = getProcessedStructures(structures,
-					includeFingerprints);
+					includeFingerprints, stopNeutralization);
 
 			// Get the first structure
 			bbChemStructure = processedStructuresHashMap.get("molstructure");

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/ChemStructureServiceBBChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/ChemStructureServiceBBChemImpl.java
@@ -87,10 +87,10 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 				| searchType == SearchType.EXACT) {
 			// We don't need to do fingerprint matching for these searches so pass false
 			// here
-			serviceBBChemStructure = bbChemStructureService.getProcessedStructure(molfile, false);
+			serviceBBChemStructure = bbChemStructureService.getProcessedStructure(molfile, false, false);
 		} else {
 			// We need to do fingerprint matching for these searches so pass true here
-			serviceBBChemStructure = bbChemStructureService.getProcessedStructure(molfile, true);
+			serviceBBChemStructure = bbChemStructureService.getProcessedStructure(molfile, true, false);
 		}
 		if (serviceBBChemStructure.getRegistrationStatus() == RegistrationStatus.ERROR) {
 			throw new CmpdRegMolFormatException(serviceBBChemStructure.getRegistrationComment());
@@ -304,7 +304,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 					&& (bbChemStructure.getReg() == null || bbChemStructure.getSubstructure() == null)) {
 				logger.info(
 						"Reg or Substructure is null for bbchem structure so calling processStructure to generate them before saving");
-				bbChemStructure = bbChemStructureService.getProcessedStructure(bbChemStructure.getMol(), true);
+				bbChemStructure = bbChemStructureService.getProcessedStructure(bbChemStructure.getMol(), true, false);
 			}
 
 			if (structureType == StructureType.PARENT) {
@@ -404,7 +404,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 
 		try {
 			// Process the molfile and calculate fingerprints = true
-			BBChemParentStructure bbChemStructure = bbChemStructureService.getProcessedStructure(molfile, true);
+			BBChemParentStructure bbChemStructure = bbChemStructureService.getProcessedStructure(molfile, true, false);
 			// Save the structure
 			return saveStructure(bbChemStructure, structureType, checkForDupes);
 		} catch (CmpdRegMolFormatException e) {
@@ -416,7 +416,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 	@Override
 	public double getMolWeight(String molStructure) throws CmpdRegMolFormatException {
 		// Calculates the average molecular weight of a molecule
-		return bbChemStructureService.getProcessedStructure(molStructure, false).getAverageMolWeight();
+		return bbChemStructureService.getProcessedStructure(molStructure, false, false).getAverageMolWeight();
 	}
 
 	@Override
@@ -426,12 +426,12 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 
 	@Override
 	public String toMolfile(String molStructure) throws CmpdRegMolFormatException {
-		return bbChemStructureService.getProcessedStructure(molStructure, false).getMol();
+		return bbChemStructureService.getProcessedStructure(molStructure, false, false).getMol();
 	}
 
 	@Override
 	public String toSmiles(String molStructure) throws CmpdRegMolFormatException {
-		return bbChemStructureService.getProcessedStructure(molStructure, false).getSmiles();
+		return bbChemStructureService.getProcessedStructure(molStructure, false, false).getSmiles();
 	}
 
 	@Override
@@ -443,7 +443,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 	@Override
 	public String toInchi(String molStructure) {
 		try {
-			return bbChemStructureService.getProcessedStructure(molStructure, false).getInchi();
+			return bbChemStructureService.getProcessedStructure(molStructure, false, false).getInchi();
 		} catch (CmpdRegMolFormatException e) {
 			logger.error("Error calculating inchi: ", e);
 			return null;
@@ -453,7 +453,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 	@Override
 	public boolean updateStructure(String molStructure, StructureType structureType, int cdId) {
 		try {
-			BBChemParentStructure bbChemStructure = bbChemStructureService.getProcessedStructure(molStructure, true);
+			BBChemParentStructure bbChemStructure = bbChemStructureService.getProcessedStructure(molStructure, true, false);
 			return updateStructure(bbChemStructure, structureType, cdId);
 		} catch (CmpdRegMolFormatException e) {
 			logger.error("Error processing molfile: ");
@@ -468,7 +468,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 			logger.info(
 					"Reg or Substructure is null for bbchem structure so calling processStructure to generate them before saving");
 			try {
-				bbChemStructure = bbChemStructureService.getProcessedStructure(bbChemStructure.getMol(), true);
+				bbChemStructure = bbChemStructureService.getProcessedStructure(bbChemStructure.getMol(), true, false);
 			} catch (CmpdRegMolFormatException e) {
 				logger.error("Error processing molfile: " + e.getMessage());
 				return false;
@@ -517,7 +517,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 
 	@Override
 	public String getMolFormula(String molStructure) throws CmpdRegMolFormatException {
-		return bbChemStructureService.getProcessedStructure(molStructure, false).getMolecularFormula();
+		return bbChemStructureService.getProcessedStructure(molStructure, false, false).getMolecularFormula();
 	}
 
 	@Override
@@ -556,7 +556,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 	public double getExactMass(String molStructure) throws CmpdRegMolFormatException {
 		// Processor doesn't return exact mass so we need to populate it and then return
 		// it
-		BBChemParentStructure bbChemStructure = bbChemStructureService.getProcessedStructure(molStructure, false);
+		BBChemParentStructure bbChemStructure = bbChemStructureService.getProcessedStructure(molStructure, false, false);
 		return bbChemStructure.getExactMolWeight();
 	}
 
@@ -680,7 +680,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 
 		// Get processed structures (hashes and include fingerprints)
 		HashMap<String, BBChemParentStructure> standardizedStructures = bbChemStructureService
-				.getProcessedStructures(structures, true);
+				.getProcessedStructures(structures, true, false);
 
 		// Return hashmap
 		HashMap<String, CmpdRegMolecule> result = new HashMap<String, CmpdRegMolecule>();
@@ -717,8 +717,8 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 	@Override
 	public boolean standardizedMolCompare(String queryMol, String targetMol) throws CmpdRegMolFormatException {
 		try {
-			BBChemParentStructure queryStructure = bbChemStructureService.getProcessedStructure(queryMol, false);
-			BBChemParentStructure targetStructure = bbChemStructureService.getProcessedStructure(targetMol, false);
+			BBChemParentStructure queryStructure = bbChemStructureService.getProcessedStructure(queryMol, false, false);
+			BBChemParentStructure targetStructure = bbChemStructureService.getProcessedStructure(targetMol, false, false);
 			return queryStructure.getReg() == targetStructure.getReg();
 		} catch (Exception e) {
 			logger.error("Error in standardizedMolCompare: ", e);
@@ -736,7 +736,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 		// }
 		// ]
 		try {
-			JsonNode responseNode = bbChemStructureService.postToProcessService(molFile);
+			JsonNode responseNode = bbChemStructureService.postToProcessService(molFile, false);
 			JsonNode errorCodeNode = responseNode.get(0).get("error_code");
 			if (errorCodeNode != null && errorCodeNode.asText().equals("4004")) {
 				return true;
@@ -921,7 +921,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 		logger.info("Finished fetching " + group.size() + " " + StructureType.PARENT + " molstructures to save");
 		logger.info("Started processing " + structureIdParentMolStructureMap.size() + " parent structures");
 		HashMap<String, BBChemParentStructure> processedStructures = bbChemStructureService
-				.getProcessedStructures(structureIdParentMolStructureMap, true);
+				.getProcessedStructures(structureIdParentMolStructureMap, true, false);
 		logger.info("Finished processing " + structureIdParentMolStructureMap.size() + " " + StructureType.PARENT
 				+ " structures");
 		logger.info("Started saving " + processedStructures.size() + " " + StructureType.PARENT + " structures");
@@ -1000,7 +1000,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 		logger.info("Started processing " + structureIdSaltFormMolStructureMap.size() + " "
 				+ StructureType.SALT_FORM + " structures");
 		HashMap<String, BBChemParentStructure> processedStructures = bbChemStructureService
-				.getProcessedStructures(structureIdSaltFormMolStructureMap, true);
+				.getProcessedStructures(structureIdSaltFormMolStructureMap, true, false);
 		logger.info("Finished processing " + structureIdSaltFormMolStructureMap.size() + " "
 				+ StructureType.SALT_FORM + " structures");
 		logger.info("Started saving " + processedStructures.size() + " " + StructureType.SALT_FORM + " structures");
@@ -1081,7 +1081,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 		logger.info("Started processing " + structureIdSaltMolStructureMap.size() + " "
 				+ StructureType.SALT + " structures");
 		HashMap<String, BBChemParentStructure> processedStructures = bbChemStructureService
-				.getProcessedStructures(structureIdSaltMolStructureMap, true);
+				.getProcessedStructures(structureIdSaltMolStructureMap, true, false);
 		logger.info("Finished processing " + structureIdSaltMolStructureMap.size() + " "
 				+ StructureType.SALT + " structures");
 		logger.info("Started saving " + processedStructures.size() + " " + StructureType.SALT + " structures");

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/CmpdRegMoleculeBBChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/CmpdRegMoleculeBBChemImpl.java
@@ -63,14 +63,14 @@ public class CmpdRegMoleculeBBChemImpl implements CmpdRegMolecule {
 	}
 
 	@Override
-	public String getFormula() {
+	public String getFormula(boolean stopNeutralization) {
 		if (this.getRegistrationStatus() == RegistrationStatus.ERROR) {
 			return null;
 		} else if (this.molecule.getMolecularFormula() != null) {
 			return this.molecule.getMolecularFormula();
 		} else {
 			try {
-				this.molecule = bbChemStructureService.getProcessedStructure(this.molecule.getMol(), false);
+				this.molecule = bbChemStructureService.getProcessedStructure(this.molecule.getMol(), false, stopNeutralization);
 				return this.molecule.getMolecularFormula();
 			} catch (CmpdRegMolFormatException e) {
 				logger.error(e.getMessage());
@@ -87,7 +87,7 @@ public class CmpdRegMoleculeBBChemImpl implements CmpdRegMolecule {
 			return this.molecule.getExactMolWeight();
 		} else {
 			try {
-				this.molecule = bbChemStructureService.getProcessedStructure(this.molecule.getMol(), false);
+				this.molecule = bbChemStructureService.getProcessedStructure(this.molecule.getMol(), false, false);
 				return this.molecule.getExactMolWeight();
 			} catch (CmpdRegMolFormatException e) {
 				logger.error(e.getMessage());
@@ -97,14 +97,14 @@ public class CmpdRegMoleculeBBChemImpl implements CmpdRegMolecule {
 	}
 
 	@Override
-	public Double getMass() {
+	public Double getMass(boolean stopNeutralization) {
 		if (this.getRegistrationStatus() == RegistrationStatus.ERROR) {
 			return null;
 		} else if (this.molecule.getAverageMolWeight() != null) {
 			return this.molecule.getAverageMolWeight();
 		} else {
 			try {
-				this.molecule = bbChemStructureService.getProcessedStructure(this.molecule.getMol(), false);
+				this.molecule = bbChemStructureService.getProcessedStructure(this.molecule.getMol(), false, stopNeutralization);
 				return this.molecule.getAverageMolWeight();
 			} catch (CmpdRegMolFormatException e) {
 				logger.error(e.getMessage());
@@ -114,15 +114,15 @@ public class CmpdRegMoleculeBBChemImpl implements CmpdRegMolecule {
 	}
 
 	@Override
-	public int getTotalCharge() {
+	public int getTotalCharge(boolean stopNeutralization) {
 		if (this.getRegistrationStatus() == RegistrationStatus.ERROR) {
 			return -1;
-		} else if (this.molecule.getTotalCharge() != null) {
-			return this.molecule.getTotalCharge();
+		} else if (this.molecule.getTotalCharge(stopNeutralization) != null) {
+			return this.molecule.getTotalCharge(stopNeutralization);
 		} else {
 			try {
-				this.molecule = bbChemStructureService.getProcessedStructure(this.molecule.getMol(), false);
-				return this.molecule.getTotalCharge();
+				this.molecule = bbChemStructureService.getProcessedStructure(this.molecule.getMol(), false, stopNeutralization);
+				return this.molecule.getTotalCharge(stopNeutralization);
 			} catch (CmpdRegMolFormatException e) {
 				logger.error(e.getMessage());
 				return -1;
@@ -138,7 +138,7 @@ public class CmpdRegMoleculeBBChemImpl implements CmpdRegMolecule {
 			return this.molecule.getSmiles();
 		} else {
 			try {
-				this.molecule = bbChemStructureService.getProcessedStructure(this.molecule.getMol(), false);
+				this.molecule = bbChemStructureService.getProcessedStructure(this.molecule.getMol(), false, false);
 				return this.molecule.getSmiles();
 			} catch (CmpdRegMolFormatException e) {
 				logger.error(e.getMessage());

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/CmpdRegMoleculeBBChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/CmpdRegMoleculeBBChemImpl.java
@@ -63,14 +63,14 @@ public class CmpdRegMoleculeBBChemImpl implements CmpdRegMolecule {
 	}
 
 	@Override
-	public String getFormula(boolean stopNeutralization) {
+	public String getFormula(boolean skipNeutralization) {
 		if (this.getRegistrationStatus() == RegistrationStatus.ERROR) {
 			return null;
 		} else if (this.molecule.getMolecularFormula() != null) {
 			return this.molecule.getMolecularFormula();
 		} else {
 			try {
-				this.molecule = bbChemStructureService.getProcessedStructure(this.molecule.getMol(), false, stopNeutralization);
+				this.molecule = bbChemStructureService.getProcessedStructure(this.molecule.getMol(), false, skipNeutralization);
 				return this.molecule.getMolecularFormula();
 			} catch (CmpdRegMolFormatException e) {
 				logger.error(e.getMessage());
@@ -97,14 +97,14 @@ public class CmpdRegMoleculeBBChemImpl implements CmpdRegMolecule {
 	}
 
 	@Override
-	public Double getMass(boolean stopNeutralization) {
+	public Double getMass(boolean skipNeutralization) {
 		if (this.getRegistrationStatus() == RegistrationStatus.ERROR) {
 			return null;
 		} else if (this.molecule.getAverageMolWeight() != null) {
 			return this.molecule.getAverageMolWeight();
 		} else {
 			try {
-				this.molecule = bbChemStructureService.getProcessedStructure(this.molecule.getMol(), false, stopNeutralization);
+				this.molecule = bbChemStructureService.getProcessedStructure(this.molecule.getMol(), false, skipNeutralization);
 				return this.molecule.getAverageMolWeight();
 			} catch (CmpdRegMolFormatException e) {
 				logger.error(e.getMessage());
@@ -114,15 +114,15 @@ public class CmpdRegMoleculeBBChemImpl implements CmpdRegMolecule {
 	}
 
 	@Override
-	public int getTotalCharge(boolean stopNeutralization) {
+	public int getTotalCharge(boolean skipNeutralization) {
 		if (this.getRegistrationStatus() == RegistrationStatus.ERROR) {
 			return -1;
-		} else if (this.molecule.getTotalCharge(stopNeutralization) != null) {
-			return this.molecule.getTotalCharge(stopNeutralization);
+		} else if (this.molecule.getTotalCharge(skipNeutralization) != null) {
+			return this.molecule.getTotalCharge(skipNeutralization);
 		} else {
 			try {
-				this.molecule = bbChemStructureService.getProcessedStructure(this.molecule.getMol(), false, stopNeutralization);
-				return this.molecule.getTotalCharge(stopNeutralization);
+				this.molecule = bbChemStructureService.getProcessedStructure(this.molecule.getMol(), false, skipNeutralization);
+				return this.molecule.getTotalCharge(skipNeutralization);
 			} catch (CmpdRegMolFormatException e) {
 				logger.error(e.getMessage());
 				return -1;

--- a/src/main/java/com/labsynch/labseer/chemclasses/indigo/ChemStructureServiceIndigoImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/indigo/ChemStructureServiceIndigoImpl.java
@@ -653,7 +653,7 @@ public class ChemStructureServiceIndigoImpl implements ChemStructureService {
 	@Override
 	public double getMolWeight(String molStructure) throws CmpdRegMolFormatException {
 		CmpdRegMoleculeIndigoImpl mol = new CmpdRegMoleculeIndigoImpl(molStructure);
-		return mol.getMass();
+		return mol.getMass(false);
 	}
 
 	@Override
@@ -665,7 +665,7 @@ public class ChemStructureServiceIndigoImpl implements ChemStructureService {
 	@Override
 	public String getMolFormula(String molStructure) throws CmpdRegMolFormatException {
 		CmpdRegMoleculeIndigoImpl mol = new CmpdRegMoleculeIndigoImpl(molStructure);
-		return mol.getFormula();
+		return mol.getFormula(false);
 	}
 
 	@Override

--- a/src/main/java/com/labsynch/labseer/chemclasses/indigo/CmpdRegMoleculeIndigoImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/indigo/CmpdRegMoleculeIndigoImpl.java
@@ -83,7 +83,7 @@ public class CmpdRegMoleculeIndigoImpl implements CmpdRegMolecule {
 	};
 
 	@Override
-	public String getFormula(boolean stopNeutralization) {
+	public String getFormula(boolean skipNeutralization) {
 		return this.molecule.grossFormula();
 	}
 
@@ -93,12 +93,12 @@ public class CmpdRegMoleculeIndigoImpl implements CmpdRegMolecule {
 	}
 
 	@Override
-	public Double getMass(boolean stopNeutralization) {
+	public Double getMass(boolean skipNeutralization) {
 		return (double) this.molecule.molecularWeight();
 	}
 
 	@Override
-	public int getTotalCharge(boolean stopNeutralization) {
+	public int getTotalCharge(boolean skipNeutralization) {
 		int totalCharge = 0;
 		for (IndigoObject atom : this.molecule.iterateAtoms()) {
 			totalCharge += atom.charge();

--- a/src/main/java/com/labsynch/labseer/chemclasses/indigo/CmpdRegMoleculeIndigoImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/indigo/CmpdRegMoleculeIndigoImpl.java
@@ -83,7 +83,7 @@ public class CmpdRegMoleculeIndigoImpl implements CmpdRegMolecule {
 	};
 
 	@Override
-	public String getFormula() {
+	public String getFormula(boolean stopNeutralization) {
 		return this.molecule.grossFormula();
 	}
 
@@ -93,12 +93,12 @@ public class CmpdRegMoleculeIndigoImpl implements CmpdRegMolecule {
 	}
 
 	@Override
-	public Double getMass() {
+	public Double getMass(boolean stopNeutralization) {
 		return (double) this.molecule.molecularWeight();
 	}
 
 	@Override
-	public int getTotalCharge() {
+	public int getTotalCharge(boolean stopNeutralization) {
 		int totalCharge = 0;
 		for (IndigoObject atom : this.molecule.iterateAtoms()) {
 			totalCharge += atom.charge();

--- a/src/main/java/com/labsynch/labseer/chemclasses/jchem/ChemStructureServiceJChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/jchem/ChemStructureServiceJChemImpl.java
@@ -1303,7 +1303,7 @@ public class ChemStructureServiceJChemImpl implements ChemStructureService {
 		}
 
 		if (!badStructureFlag) {
-			return mol.getMass();
+			return mol.getMass(false);
 		} else {
 			return 0d;
 		}
@@ -1341,7 +1341,7 @@ public class ChemStructureServiceJChemImpl implements ChemStructureService {
 		}
 
 		if (!badStructureFlag) {
-			return mol.getFormula();
+			return mol.getFormula(false);
 		} else {
 			return null;
 		}

--- a/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegMoleculeJChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegMoleculeJChemImpl.java
@@ -90,8 +90,8 @@ public class CmpdRegMoleculeJChemImpl implements CmpdRegMolecule {
 	};
 
 	@Override
-	public String getFormula(boolean stopNeutralization) {
-		return this.molecule.getFormula(stopNeutralization);
+	public String getFormula(boolean skipNeutralization) {
+		return this.molecule.getFormula(skipNeutralization);
 	}
 
 	@Override
@@ -100,12 +100,12 @@ public class CmpdRegMoleculeJChemImpl implements CmpdRegMolecule {
 	}
 
 	@Override
-	public Double getMass(boolean stopNeutralization) {
+	public Double getMass(boolean skipNeutralization) {
 		return this.molecule.getMass();
 	}
 
 	@Override
-	public int getTotalCharge(boolean stopNeutralization) {
+	public int getTotalCharge(boolean skipNeutralization) {
 		return this.molecule.getTotalCharge();
 	}
 

--- a/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegMoleculeJChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegMoleculeJChemImpl.java
@@ -90,8 +90,8 @@ public class CmpdRegMoleculeJChemImpl implements CmpdRegMolecule {
 	};
 
 	@Override
-	public String getFormula() {
-		return this.molecule.getFormula();
+	public String getFormula(boolean stopNeutralization) {
+		return this.molecule.getFormula(stopNeutralization);
 	}
 
 	@Override
@@ -100,12 +100,12 @@ public class CmpdRegMoleculeJChemImpl implements CmpdRegMolecule {
 	}
 
 	@Override
-	public Double getMass() {
+	public Double getMass(boolean stopNeutralization) {
 		return this.molecule.getMass();
 	}
 
 	@Override
-	public int getTotalCharge() {
+	public int getTotalCharge(boolean stopNeutralization) {
 		return this.molecule.getTotalCharge();
 	}
 

--- a/src/main/java/com/labsynch/labseer/db/migration/postgres/V2_0_7_1__Recalculate_exact_mass.java
+++ b/src/main/java/com/labsynch/labseer/db/migration/postgres/V2_0_7_1__Recalculate_exact_mass.java
@@ -79,7 +79,7 @@ public class V2_0_7_1__Recalculate_exact_mass implements SpringJdbcMigration {
 	private double getMolWeight(String molStructure) {
 		try {
 			CmpdRegMolecule molecule = cmpdRegMoleculeFactory.getCmpdRegMolecule(molStructure);
-			return molecule.getMass();
+			return molecule.getMass(false);
 		} catch (Exception e) {
 			return 0d;
 		}

--- a/src/main/java/com/labsynch/labseer/domain/AbstractBBChemStructure.java
+++ b/src/main/java/com/labsynch/labseer/domain/AbstractBBChemStructure.java
@@ -323,7 +323,7 @@ public abstract class AbstractBBChemStructure {
         this.averageMolWeight = averageMolWeight;
     }
 
-    public Integer getTotalCharge(boolean stopNeutralization) {
+    public Integer getTotalCharge(boolean skipNeutralization) {
         return this.totalCharge;
     }
 

--- a/src/main/java/com/labsynch/labseer/domain/AbstractBBChemStructure.java
+++ b/src/main/java/com/labsynch/labseer/domain/AbstractBBChemStructure.java
@@ -112,7 +112,7 @@ public abstract class AbstractBBChemStructure {
         this.setSimilarity(updatedBbChemStructure.getSimilarity());
         this.setExactMolWeight(updatedBbChemStructure.getExactMolWeight());
         this.setAverageMolWeight(updatedBbChemStructure.getAverageMolWeight());
-        this.setTotalCharge(updatedBbChemStructure.getTotalCharge());
+        this.setTotalCharge(updatedBbChemStructure.getTotalCharge(false));
         this.setSmiles(updatedBbChemStructure.getSmiles());
         this.setMolecularFormula(updatedBbChemStructure.getMolecularFormula());
         this.setStandardizationStatus(updatedBbChemStructure.getStandardizationStatus());
@@ -323,7 +323,7 @@ public abstract class AbstractBBChemStructure {
         this.averageMolWeight = averageMolWeight;
     }
 
-    public Integer getTotalCharge() {
+    public Integer getTotalCharge(boolean stopNeutralization) {
         return this.totalCharge;
     }
 

--- a/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
@@ -369,9 +369,9 @@ public class MetalotServiceImpl implements MetalotService {
 							Double.valueOf(dExactMass.format(parent.getCmpdRegMolecule().getExactMass())));
 					DecimalFormat dMolWeight = new DecimalFormat("#.###");
 					parent.setMolWeight(
-							Double.valueOf(dMolWeight.format(parent.getCmpdRegMolecule().getMass())));
+							Double.valueOf(dMolWeight.format(parent.getCmpdRegMolecule().getMass(false))));
 
-					parent.setMolFormula(parent.getCmpdRegMolecule().getFormula());
+					parent.setMolFormula(parent.getCmpdRegMolecule().getFormula(false));
 					// add unique constraint to parent corp name as well (parent and lot)
 					boolean corpNameAlreadyExists = checkCorpNameAlreadyExists(parent.getCorpName());
 					while (corpNameAlreadyExists) {

--- a/src/main/java/com/labsynch/labseer/service/RegSearchServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/RegSearchServiceImpl.java
@@ -71,13 +71,13 @@ public class RegSearchServiceImpl implements RegSearchService {
 
 			regSearchDTO.setAsDrawnImage(convertToBase64(mol, format, hSize, wSize));
 			regSearchDTO.setAsDrawnStructure(mol.getMolStructure());
-			regSearchDTO.setAsDrawnMolFormula(mol.getFormula());
+			regSearchDTO.setAsDrawnMolFormula(mol.getFormula(false));
 			regSearchDTO.setAsDrawnExactMass(mol.getExactMass());
 			if (propertiesUtilService.getUseExactMass()) {
 				regSearchDTO.setAsDrawnMolWeight(mol.getExactMass());
 
 			} else {
-				regSearchDTO.setAsDrawnMolWeight(mol.getMass());
+				regSearchDTO.setAsDrawnMolWeight(mol.getMass(false));
 
 			}
 			int[] parentHits = chemStructureService.searchMolStructures(MoleculeUtil.exportMolAsText(mol, "mol"),

--- a/src/main/java/com/labsynch/labseer/service/SaltServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltServiceImpl.java
@@ -146,8 +146,8 @@ public class SaltServiceImpl implements SaltService {
 		salt.setOriginalStructure(MoleculeUtil.exportMolAsText(mol, "mol"));
 		salt.setAbbrev(MoleculeUtil.getMolProperty(mol, "code"));
 		salt.setName(MoleculeUtil.getMolProperty(mol, "Name"));
-		salt.setFormula(mol.getFormula());
-		salt.setMolWeight(mol.getMass());
+		salt.setFormula(mol.getFormula(true));
+		salt.setMolWeight(mol.getMass(true));
 
 		logger.debug("salt code: " + salt.getAbbrev());
 		logger.debug("salt name: " + salt.getName());

--- a/src/main/java/com/labsynch/labseer/service/SaltStructureServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltStructureServiceImpl.java
@@ -33,13 +33,9 @@ public class SaltStructureServiceImpl implements SaltStructureService {
 		CmpdRegMolecule mol = chemStructureService.toMolecule(salt.getMolStructure());
 		salt.setOriginalStructure(salt.getMolStructure());
 		salt.setMolStructure(mol.getMolStructure());
-		salt.setFormula(mol.getFormula());
-		if (propertiesUtilService.getUseExactMass()) {
-			salt.setMolWeight(mol.getExactMass());
-		} else {
-			salt.setMolWeight(mol.getMass());
-		}
-		salt.setCharge(mol.getTotalCharge());
+		salt.setFormula(mol.getFormula(true));
+		salt.setMolWeight(mol.getMass(true)); 
+		salt.setCharge(mol.getTotalCharge(true));
 
 		logger.debug("salt code: " + salt.getAbbrev());
 		logger.debug("salt name: " + salt.getName());
@@ -70,9 +66,9 @@ public class SaltStructureServiceImpl implements SaltStructureService {
 			CmpdRegMolecule mol = chemStructureService.toMolecule(salt.getMolStructure());
 			salt.setOriginalStructure(salt.getMolStructure());
 			salt.setMolStructure(mol.getMolStructure());
-			salt.setFormula(mol.getFormula());
-			salt.setMolWeight(mol.getMass());
-			salt.setCharge(mol.getTotalCharge());
+			salt.setFormula(mol.getFormula(true)); // stopNeutralization == true for the 3 methods here
+			salt.setMolWeight(mol.getMass(true));
+			salt.setCharge(mol.getTotalCharge(true));
 
 			logger.debug("salt code: " + salt.getAbbrev());
 			logger.debug("salt name: " + salt.getName());
@@ -116,7 +112,7 @@ public class SaltStructureServiceImpl implements SaltStructureService {
         try
         {
             CmpdRegMolecule mol = chemStructureService.toMolecule(salt.getMolStructure());
-		    weight = mol.getMass();
+		    weight = mol.getMass(true); // stopNeutralization == true
             return weight;
         }
         catch (CmpdRegMolFormatException e)
@@ -131,7 +127,7 @@ public class SaltStructureServiceImpl implements SaltStructureService {
         try
         {
             CmpdRegMolecule mol = chemStructureService.toMolecule(salt.getMolStructure());
-		    formula = mol.getFormula();
+		    formula = mol.getFormula(true); // stopNeutralization == true
             return formula;
         }
         catch (CmpdRegMolFormatException e)
@@ -146,7 +142,7 @@ public class SaltStructureServiceImpl implements SaltStructureService {
         try
         {
             CmpdRegMolecule mol = chemStructureService.toMolecule(salt.getMolStructure());
-		    charge = mol.getTotalCharge();
+		    charge = mol.getTotalCharge(true); // stopNeutralization == true
             return charge;
         }
         catch (CmpdRegMolFormatException e)

--- a/src/main/java/com/labsynch/labseer/service/SaltStructureServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltStructureServiceImpl.java
@@ -66,7 +66,7 @@ public class SaltStructureServiceImpl implements SaltStructureService {
 			CmpdRegMolecule mol = chemStructureService.toMolecule(salt.getMolStructure());
 			salt.setOriginalStructure(salt.getMolStructure());
 			salt.setMolStructure(mol.getMolStructure());
-			salt.setFormula(mol.getFormula(true)); // stopNeutralization == true for the 3 methods here
+			salt.setFormula(mol.getFormula(true)); // skipNeutralization == true for the 3 methods here
 			salt.setMolWeight(mol.getMass(true));
 			salt.setCharge(mol.getTotalCharge(true));
 
@@ -112,7 +112,7 @@ public class SaltStructureServiceImpl implements SaltStructureService {
         try
         {
             CmpdRegMolecule mol = chemStructureService.toMolecule(salt.getMolStructure());
-		    weight = mol.getMass(true); // stopNeutralization == true
+		    weight = mol.getMass(true); // skipNeutralization == true
             return weight;
         }
         catch (CmpdRegMolFormatException e)
@@ -127,7 +127,7 @@ public class SaltStructureServiceImpl implements SaltStructureService {
         try
         {
             CmpdRegMolecule mol = chemStructureService.toMolecule(salt.getMolStructure());
-		    formula = mol.getFormula(true); // stopNeutralization == true
+		    formula = mol.getFormula(true); // skipNeutralization == true
             return formula;
         }
         catch (CmpdRegMolFormatException e)
@@ -142,7 +142,7 @@ public class SaltStructureServiceImpl implements SaltStructureService {
         try
         {
             CmpdRegMolecule mol = chemStructureService.toMolecule(salt.getMolStructure());
-		    charge = mol.getTotalCharge(true); // stopNeutralization == true
+		    charge = mol.getTotalCharge(true); // skipNeutralization == true
             return charge;
         }
         catch (CmpdRegMolFormatException e)

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -329,7 +329,7 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			stndznCompound.setRegistrationStatus(cmpdRegMolecule.getRegistrationStatus());
 			stndznCompound.setRegistrationComment(cmpdRegMolecule.getRegistrationComment());
 
-			Double newMolWeight = cmpdRegMolecule.getMass();
+			Double newMolWeight = cmpdRegMolecule.getMass(false);
 			if (newMolWeight != null) {
 				DecimalFormat dMolWeight = new DecimalFormat("#.###");
 				stndznCompound.setNewMolWeight(Double.valueOf(dMolWeight.format(newMolWeight)));
@@ -771,14 +771,14 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 				parent.setExactMass(null);
 			}
 
-			if (cmpdRegMolecule.getMass() != null) {
+			if (cmpdRegMolecule.getMass(false) != null) {
 				DecimalFormat dMolWeight = new DecimalFormat("#.###");
-				parent.setMolWeight(Double.valueOf(dMolWeight.format(cmpdRegMolecule.getMass())));
+				parent.setMolWeight(Double.valueOf(dMolWeight.format(cmpdRegMolecule.getMass(false))));
 			} else {
 				parent.setMolWeight(null);
 			}
 
-			parent.setMolFormula(cmpdRegMolecule.getFormula());
+			parent.setMolFormula(cmpdRegMolecule.getFormula(false));
 
 			pIds.add(parent.getId());
 

--- a/src/main/java/com/labsynch/labseer/utils/LoadFullCompoundsUtil.java
+++ b/src/main/java/com/labsynch/labseer/utils/LoadFullCompoundsUtil.java
@@ -168,7 +168,7 @@ public class LoadFullCompoundsUtil {
 		lot.setSynthesisDate(new Date());
 		lot.setChemist(lotChemist.getUserName());
 		lot.setSaltForm(saltForm);
-		lot.setLotMolWeight(mol.getMass());
+		lot.setLotMolWeight(mol.getMass(false));
 		lot.setIsVirtual(false);
 
 		String supplierCode;

--- a/src/main/java/com/labsynch/labseer/utils/MoleculeUtil.java
+++ b/src/main/java/com/labsynch/labseer/utils/MoleculeUtil.java
@@ -79,7 +79,7 @@ public class MoleculeUtil {
 
 	public static String getMolFormula(String molStructure) throws CmpdRegMolFormatException {
 		CmpdRegMolecule mol = cmpdRegMoleculeFactory.getCmpdRegMolecule(molStructure);
-		return mol.getFormula();
+		return mol.getFormula(false);
 	}
 
 }


### PR DESCRIPTION
**Steps to Reproduce:**

1. Be using an ACAS on k8s instance
2. Log in to ACAS as CmpdReg Admin
3. Open "CmpdReg Salts" module >> Click 'Create New Salt'
4. Draw a salt structure with '+' or '-' charges (e.g. sulphate) >> add Abbreviation & Name
5. Click on "Next"
6. Observe the Salt Charge & Salt Molecular Weight calculated on next page

**Expected Results:**

- The molecular weight is calculated for "charged" form of the salt & not the neutral one
- The "Salt Charge" is generated as per the drawn structure

**Previous Bug Results:**

- Molecular weight is generating for neutral form
- Salt charge is not computed (showing '0')