### PR TITLE
Pcheung/2023.1.x  j chem 22.22.0 upgrade  patched

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.]]>
 		<querydsl.version>3.4.3</querydsl.version>
 		<spring-security.version>5.6.3</spring-security.version>
 		<cdk.version>1.5.13</cdk.version>
-		<jchem.version>22.22.0</jchem.version>
+		<jchem.version>23.4.0</jchem.version>
 		<rdkit.version>2021.03.5-release</rdkit.version>
 		<indigo.version>1.6.1</indigo.version>
 		<git-sha-1>${buildNumber}</git-sha-1>
@@ -122,14 +122,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.]]>
 					<groupId>com.google.guava</groupId>
 					<artifactId>guava</artifactId>
 					<version>23.0</version>
-				</dependency>
-				<!-- org.apache.commons was added to fix CVE-2022-42889 in jchem 22.12.0
-				it can be removed when upgrading to October 27th, 2022: JChem Base 22.19.0
-				which addresesed CVE-2022-42889 -->
-				<dependency>
-					<groupId>org.apache.commons</groupId>
-					<artifactId>commons-text</artifactId>
-					<version>1.10.0</version>
 				</dependency>
 			</dependencies>
 			<properties>
@@ -253,11 +245,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.]]>
 			<artifactId>jackson-databind</artifactId>
 			<version>2.13.4.1</version>
 		</dependency>
-		<dependency>
+		<!-- <dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<version>3.1</version>
-		</dependency>
+		</dependency> -->
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.]]>
 		<querydsl.version>3.4.3</querydsl.version>
 		<spring-security.version>5.6.3</spring-security.version>
 		<cdk.version>1.5.13</cdk.version>
-		<jchem.version>22.12.0</jchem.version>
+		<jchem.version>22.22.0</jchem.version>
 		<rdkit.version>2021.03.5-release</rdkit.version>
 		<indigo.version>1.6.1</indigo.version>
 		<git-sha-1>${buildNumber}</git-sha-1>

--- a/pom.xml
+++ b/pom.xml
@@ -245,11 +245,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.]]>
 			<artifactId>jackson-databind</artifactId>
 			<version>2.13.4.1</version>
 		</dependency>
-		<!-- <dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.1</version>
-		</dependency> -->
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>

--- a/src/main/java/com/labsynch/labseer/chemclasses/jchem/ChemStructureServiceJChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/jchem/ChemStructureServiceJChemImpl.java
@@ -1302,8 +1302,8 @@ public class ChemStructureServiceJChemImpl implements ChemStructureService {
 			badStructureFlag = true;
 		}
 
-		if (!badStructureFlag) {
-			return mol.getMass(false);
+		if ((!badStructureFlag) && (mol != null)) {
+			return mol.getMass();
 		} else {
 			return 0d;
 		}
@@ -1340,8 +1340,8 @@ public class ChemStructureServiceJChemImpl implements ChemStructureService {
 			badStructureFlag = true;
 		}
 
-		if (!badStructureFlag) {
-			return mol.getFormula(false);
+		if ((!badStructureFlag) && (mol != null)) {
+			return mol.getFormula();
 		} else {
 			return null;
 		}

--- a/src/main/java/com/labsynch/labseer/chemclasses/jchem/ChemStructureServiceJChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/jchem/ChemStructureServiceJChemImpl.java
@@ -736,12 +736,12 @@ public class ChemStructureServiceJChemImpl implements ChemStructureService {
 				boolean coloringEnabled = true;
 				Color hitColor = Color.blue;
 				Color nonHitColor = Color.black;
-				hitColorOptions.coloring = true;
-				hitColorOptions.hitColor = hitColor;
-				hitColorOptions.nonHitColor = nonHitColor;
-				// hitColorOptions.setColoringEnabled(coloringEnabled);
-				// hitColorOptions.setHitColor(hitColor);
-				// hitColorOptions.setNonHitColor(nonHitColor);
+				// hitColorOptions.coloring = true;
+				// hitColorOptions.hitColor = hitColor;
+				// hitColorOptions.nonHitColor = nonHitColor;
+				hitColorOptions.setColoringEnabled(coloringEnabled);
+				hitColorOptions.setHitColor(hitColor);
+				hitColorOptions.setNonHitColor(nonHitColor);
 
 			} else if (searchType == SearchType.SIMILARITY) {
 				searchOptions = new JChemSearchOptions(SearchConstants.SIMILARITY);
@@ -983,12 +983,12 @@ public class ChemStructureServiceJChemImpl implements ChemStructureService {
 				boolean coloringEnabled = true;
 				Color hitColor = Color.blue;
 				Color nonHitColor = Color.black;
-				hitColorOptions.coloring = true;
-				hitColorOptions.hitColor = hitColor;
-				hitColorOptions.nonHitColor = nonHitColor;
-				// hitColorOptions.setColoringEnabled(coloringEnabled);
-				// hitColorOptions.setHitColor(hitColor);
-				// hitColorOptions.setNonHitColor(nonHitColor);
+				// hitColorOptions.coloring = true;
+				// hitColorOptions.hitColor = hitColor;
+				// hitColorOptions.nonHitColor = nonHitColor;
+				hitColorOptions.setColoringEnabled(coloringEnabled);
+				hitColorOptions.setHitColor(hitColor);
+				hitColorOptions.setNonHitColor(nonHitColor);
 
 			} else if (searchType == SearchType.SIMILARITY) {
 				searchOptions = new JChemSearchOptions(SearchConstants.SIMILARITY);

--- a/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegMoleculeJChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/jchem/CmpdRegMoleculeJChemImpl.java
@@ -91,7 +91,7 @@ public class CmpdRegMoleculeJChemImpl implements CmpdRegMolecule {
 
 	@Override
 	public String getFormula(boolean skipNeutralization) {
-		return this.molecule.getFormula(skipNeutralization);
+		return this.molecule.getFormula();
 	}
 
 	@Override

--- a/src/main/java/com/labsynch/labseer/db/migration/postgres/jchem/R__Upgrade_Jchem_Tables.java
+++ b/src/main/java/com/labsynch/labseer/db/migration/postgres/jchem/R__Upgrade_Jchem_Tables.java
@@ -1,0 +1,84 @@
+package com.labsynch.labseer.db.migration.postgres.jchem;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.migration.MigrationChecksumProvider;
+import org.flywaydb.core.api.migration.MigrationInfoProvider;
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.chemaxon.version.VersionInfo;
+
+import chemaxon.jchem.db.UpdateHandlerException;
+import chemaxon.jchem.db.Updater;
+import chemaxon.util.ConnectionHandler;
+
+public class R__Upgrade_Jchem_Tables implements JdbcMigration, MigrationInfoProvider, MigrationChecksumProvider {
+
+	private static int count;
+
+	Logger logger = LoggerFactory.getLogger(V2_4_0_8__Upgrade_Jchem_Tables.class);
+
+	public void migrate(Connection conn) throws Exception {
+		logger.info("ATTEMPTING TO UPGRADE JCHEM TABLES");
+		conn.setAutoCommit(true);
+		logger.info("connection autocommit mode: " + conn.getAutoCommit());
+		logger.info("getTransactionIsolation  " + conn.getTransactionIsolation());
+
+		recalculateJChemTable(conn);
+
+		conn.setAutoCommit(false);
+		logger.info("connection autocommit mode: " + conn.getAutoCommit());
+
+	}
+
+	// Example of implementation used for Repeated Migrations
+	// https://github.com/flyway/flyway/issues/1814
+
+    @Override
+    public MigrationVersion getVersion() {
+        return null;
+    }
+
+    @Override
+    public String getDescription() {
+        return "R__Upgrade_Jchem_Tables";
+    }
+
+	// 	Add a public Integer getChecksum() method which gets the jchem version as a string and runs:
+	// jchemVersion.hashCode() to generate an integer
+	// 
+	// 	https://apidocs.chemaxon.com/jchem/doc/dev/java/api/com/chemaxon/version/VersionInfo.html
+	//
+	//  static String	getVersion()	Returns the product version.
+
+    @Override
+    public Integer getChecksum() {
+		String jchemVersion = VersionInfo.getVersion();
+		System.out.println("R__Upgrade_Jchem_Tables is checking jChem Version:" + jchemVersion);
+        return jchemVersion.hashCode();
+    }	
+
+	private boolean recalculateJChemTable(Connection conn) throws UpdateHandlerException, SQLException {
+		ConnectionHandler ch = new ConnectionHandler();
+		ch.setConnection(conn);
+
+		String message = "";
+		Updater ud = new Updater(ch);
+		Updater.UpdateInfo ui = null;
+		while ((ui = ud.getNextUpdateInfo()) != null) {
+			logger.info("\n" + ui.processingMessage + "\n");
+			logger.info("Is structure change required: " + ui.isStructuralChange);
+			message = ud.performCurrentUpdate();
+			logger.info(message);
+		}
+
+		logger.info("updated the Jchem structure tables ");
+
+		return false;
+	}
+
+}

--- a/src/main/java/com/labsynch/labseer/db/migration/postgres/jchem/R__Upgrade_Jchem_Tables.java
+++ b/src/main/java/com/labsynch/labseer/db/migration/postgres/jchem/R__Upgrade_Jchem_Tables.java
@@ -58,7 +58,7 @@ public class R__Upgrade_Jchem_Tables implements JdbcMigration, MigrationInfoProv
     @Override
     public Integer getChecksum() {
 		String jchemVersion = VersionInfo.getVersion();
-		System.out.println("R__Upgrade_Jchem_Tables is checking jChem Version:" + jchemVersion);
+		logger.info("R__Upgrade_Jchem_Tables is checking jChem Version:" + jchemVersion);
         return jchemVersion.hashCode();
     }	
 


### PR DESCRIPTION
Provided JChem specific fixes to 2023.1.x  
Changed pom.xml to remove dependency on older commons.lang package.
Added JChem automigration every time JChem version changes.