### PR TITLE
ACAS-598: Ignore corporate name prefix match in cmpdreg search.

### DIFF
--- a/src/main/java/com/labsynch/labseer/domain/SaltForm.java
+++ b/src/main/java/com/labsynch/labseer/domain/SaltForm.java
@@ -279,8 +279,14 @@ public class SaltForm implements Comparable {
 			predicateList.add(predicate);
 		}
 		if (searchParams.getFormattedCorpNameList() != null) {
-			logger.debug("incoming corpNameList :" + searchParams.getFormattedCorpNameList().toString());
-			Predicate predicate = saltFormParent.get("corpName").in(searchParams.getFormattedCorpNameList());
+			List<String> corpNames = searchParams.getFormattedCorpNameList();
+			logger.debug("incoming corpNameList :" + corpNames.toString());
+			ArrayList<Predicate> corpNameLikePredicates = new ArrayList<Predicate>();
+			for (String corpName : corpNames) {
+				Predicate predicate = criteriaBuilder.like(saltFormParent.get("corpName"), '%' + corpName);
+				corpNameLikePredicates.add(predicate);
+			}
+			Predicate predicate = criteriaBuilder.or(corpNameLikePredicates.toArray(new Predicate[0]));
 			predicateList.add(predicate);
 		}
 		if (searchParams.getAlias() != null && !searchParams.getAlias().equals("")) {

--- a/src/main/java/com/labsynch/labseer/service/SearchFormServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SearchFormServiceImpl.java
@@ -186,15 +186,16 @@ public class SearchFormServiceImpl implements SearchFormService {
 		if (!searchParams.getCorpNameList().equals("")) {
 			logger.info("got a corp name list search!");
 			String[] inputListArray = searchParams.getCorpNameList().split("[\\s,;\\n\\r]+");
-			List<String> formattedCorpNameList = new ArrayList<String>();
+			HashSet<String> uniqueCorpNames = new HashSet<>();
 			for (String corpName : inputListArray) {
-				logger.info(corpNameService.formatCorpName(corpNameService.parseParentNumber(corpName)));
-				formattedCorpNameList.add(corpName);
-				formattedCorpNameList.add(corpNameService.formatCorpName(corpNameService.parseParentNumber(corpName)));
-
+				uniqueCorpNames.add(corpName);
+				// Remove the prefix, lot.
+				String parentNumber = corpNameService.parseParentNumber(corpName).toString();
+				uniqueCorpNames.add(parentNumber);
 			}
-			searchParams.setFormattedCorpNameList(formattedCorpNameList);
-			logger.info(formattedCorpNameList.toString());
+			List<String> corpNames = new ArrayList<String>(uniqueCorpNames);
+			logger.info(corpNames.toString());
+			searchParams.setFormattedCorpNameList(corpNames);
 		}
 		// Check if corpNameFrom and corpNameTo are both set -- will search for a range
 		// of parents if both set


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Compound search via the corporate name uses the corporate prefix in the configuration to do matches. E.g
```
client.cmpdreg.serverSettings.corpPrefix=CMD

Available compounds: CMPD-0000001, MYCMPD-0000001

Search criteria: 1

Output: CMPD-0000001
# MYCMPD-0000001 is ignored in the output
```

Service attempts to do an actual match on `1` and `CMPD-0000001`. I have now updated the logic to only do matches on the unique identifier of the label and do matching based on `%id`.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACAS-598](https://jira.schrodinger.com/browse/ACAS-598)
## How Has This Been Tested?
<!--- Describe how this has been tested -->

I did some manual testing,

```
Available Compounds:
CMPD-0000001-001, CMPD-0000001-002, CMPD-0000002-001, ..., CMPD-0000010-001
MYCMPD-0000001-001
```

|Search Parameter|Matches                                                                               |
|---------------------|------------------------------------------------------|
|1                                 |CMPD-000001, MYCMPD-0000001                             |
|2                                |CMPD-0000002                                                             |
|1,2                              |CMPD-0000001, MYCMPD-0000001, CMPD-000002|
|CMPD-0000001        |CMPD-0000001, MYCMPD-0000001                           |
|CMPD-0000001-002|CMPD-0000001, MYCMPD-0000001                           |
|CMPD-0000001-500|CMPD-0000001, MYCMPD-0000001                           |
|CM-0000001-002     |CMPD-0000001, MYCMPD-0000001                           |
|CM-001-002              |CMPD-0000001, MYCMPD-0000001                           |
|10                                |CMPD-0000010                                                             |

## TODO
Add acasclient tests.