### PR TITLE
Add label prefix to the unique index

### DIFF
--- a/src/main/resources/db/migration/postgres/V2.4.2.1__add_label_sequence_ddict_value_partial_unique_indexes.sql
+++ b/src/main/resources/db/migration/postgres/V2.4.2.1__add_label_sequence_ddict_value_partial_unique_indexes.sql
@@ -1,5 +1,5 @@
 CREATE UNIQUE INDEX IF NOT EXISTS label_sequence_thing_label_prefix_key
- ON label_sequence (thing_type_and_kind, label_type_and_kind)
+ ON label_sequence (thing_type_and_kind, label_type_and_kind, label_prefix)
  WHERE ignored IS FALSE;
 CREATE UNIQUE INDEX IF NOT EXISTS ddict_value_code_type_kind_short_name_key
  ON ddict_value (ls_type, ls_kind, short_name)


### PR DESCRIPTION
## Description
 - Adding label prefix to partial unique index for label sequences as corporate ID prefixes have the same thing and label type and kinds.

## Related Issue
ACAS-644

## How Has This Been Tested?
Ran tests on local dev system