### PR TITLE
Add back org.apache.commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.]]>
 			<version>2.13.4.1</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.1</version>
+		</dependency>
+		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>2.11.0</version>


### PR DESCRIPTION
## Description
 - https://github.com/mcneilco/acas-roo-server/pull/431 Removed org.apache.commons.lang3 this adds it back
 - org.apache.commons.lang3 is used through out the code and is therefore a direct decency which should be included in the pom.xml
 - It was removed because jchem itself in newer versions includes this dependency

## Related Issue
None

## How Has This Been Tested?
 - Performed a build with jchem
 - Will let CI/CD tests run