### PR TITLE
ACAS-654

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemParentStructure.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemParentStructure.java
@@ -32,7 +32,7 @@ public class BBChemParentStructure extends AbstractBBChemStructure {
         EntityManager em = BBChemParentStructure.entityManager();
         String fingerprintString = SimpleUtil.bitSetToString(substructure);
         Query q = em.createNativeQuery(
-                "SELECT o.* FROM bbchem_parent_structure AS o WHERE (o.substructure \\& CAST(:fingerprintString AS bit(2048))) = CAST(:fingerprintString AS bit(2048))  ",
+                "SELECT o.* FROM bbchem_parent_structure AS o WHERE (o.substructure \\& CAST(:fingerprintString AS bit(2112))) = CAST(:fingerprintString AS bit(2112))  ",
                 BBChemParentStructure.class);
         q.setParameter("fingerprintString", fingerprintString);
         if (maxResults > -1) {

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemSaltFormStructure.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemSaltFormStructure.java
@@ -32,7 +32,7 @@ public class BBChemSaltFormStructure extends AbstractBBChemStructure {
         EntityManager em = BBChemSaltFormStructure.entityManager();
         String fingerprintString = SimpleUtil.bitSetToString(substructure);
         Query q = em.createNativeQuery(
-                "SELECT o.* FROM bbchem_salt_form_structure AS o WHERE (o.substructure \\& CAST(:fingerprintString AS bit(2048))) = CAST(:fingerprintString AS bit(2048)) ",
+                "SELECT o.* FROM bbchem_salt_form_structure AS o WHERE (o.substructure \\& CAST(:fingerprintString AS bit(2112))) = CAST(:fingerprintString AS bit(2112)) ",
                 BBChemSaltFormStructure.class);
         q.setParameter("fingerprintString", fingerprintString);
         if (maxResults > -1) {

--- a/src/main/resources/db/migration/bbchem/postgres/V2.4.2.2__bbchem_small_vs_bio_molecule_fingerprint_bit.sql
+++ b/src/main/resources/db/migration/bbchem/postgres/V2.4.2.2__bbchem_small_vs_bio_molecule_fingerprint_bit.sql
@@ -13,6 +13,8 @@ DECLARE
 BEGIN
     FOREACH table_name IN ARRAY table_names
     LOOP 
-        EXECUTE 'ALTER TABLE ' || table_name || ' ALTER COLUMN substructure TYPE bit(2112) USING substructure || B''1''::bit(64);';
+        -- Truncate the table to avoid any issues with the new column length acas will fill it back on startup.
+        EXECUTE 'TRUNCATE TABLE ' || table_name;
+        EXECUTE 'ALTER TABLE ' || table_name || ' ALTER COLUMN substructure TYPE bit(2112)';
     END LOOP;
 END $$;

--- a/src/main/resources/db/migration/bbchem/postgres/V2.4.2.2__bbchem_small_vs_bio_molecule_fingerprint_bit.sql
+++ b/src/main/resources/db/migration/bbchem/postgres/V2.4.2.2__bbchem_small_vs_bio_molecule_fingerprint_bit.sql
@@ -1,0 +1,18 @@
+-- Alter each of the bbchem structure.substructure columns to be of type bit(2112) from bit(2048) by adding 1 to the length.
+-- This is because the new substructure column is 64 bits longer than the old one with an additional 1 for the small vs bio molecule fingerprint.
+DO $$ 
+DECLARE
+	table_names text[] := array[ 
+        'bbchem_standardization_dry_run_structure',
+        'bbchem_dry_run_structure',
+        'bbchem_parent_structure',
+        'bbchem_salt_form_structure',
+        'bbchem_salt_structure'
+    ];
+    table_name text;
+BEGIN
+    FOREACH table_name IN ARRAY table_names
+    LOOP 
+        EXECUTE 'ALTER TABLE ' || table_name || ' ALTER COLUMN substructure TYPE bit(2112) USING substructure || B''1''::bit(64);';
+    END LOOP;
+END $$;


### PR DESCRIPTION
## Description
 - BBChem in 2023-2 introduced a new small molecule vs. bio molecule flag to the substructure type fingerprints which is breaking ACAS from storing new fingerprints and also from re-standardizing on upgrades to 2023-2.  
 - This PR truncates the ACAS bbchem tables (which are re-populated on ACAS start) and increases the fingerprint size from `2048` -> to `2112` (64 bit) to account for the additional 1/0 flag.
 
Not in this PR but as a followup we should explore if we can get rid of fingerprint hashing all together with ACAS and just use the substructure service if its feasible.

## Related Issue
ACAS-654

## How Has This Been Tested?
 - Deployed change to QA demo and verified restandardization and substructure search worked.