### PR TITLE
ACAS-656: Expand comment fields of bbchem structure tables

### DIFF
--- a/src/main/resources/db/migration/bbchem/postgres/V2.4.2.3__bbchem_structure_comment_field_expansion.sql
+++ b/src/main/resources/db/migration/bbchem/postgres/V2.4.2.3__bbchem_structure_comment_field_expansion.sql
@@ -1,0 +1,33 @@
+-- Set the comment fields of the bbchem structure tables to be of type text
+DO $$ 
+DECLARE
+	table_names text[] := array[ 
+        'bbchem_standardization_dry_run_structure',
+        'bbchem_dry_run_structure',
+        'bbchem_parent_structure',
+        'bbchem_salt_form_structure',
+        'bbchem_salt_structure'
+    ];
+    column_names text[] := array[ 'registration_comment', 'standardization_comment' ];
+    tbl_name text;
+    col_name text;
+BEGIN
+    FOREACH tbl_name IN ARRAY table_names
+    LOOP 
+        FOREACH col_name IN ARRAY column_names
+        LOOP
+            -- Check if the registration_comment and standardization_comment columns are already text columns.
+            -- If they are not, then alter them to be text columns.
+            IF NOT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_name = tbl_name
+                AND column_name = col_name
+                AND data_type = 'text'
+            ) THEN
+                RAISE NOTICE 'Altering column % in table % to be of type text', col_name, tbl_name;
+                EXECUTE 'ALTER TABLE ' || tbl_name || ' ALTER COLUMN ' || col_name || ' TYPE text';
+            END IF;
+        END LOOP;
+    END LOOP;
+END $$;


### PR DESCRIPTION
## Description
 - Expands the bbchem structure comment fields to be of type text to accommodate for longer error messages and comments produced by bbchem service

## Related Issue
ACAS-656

## How Has This Been Tested?
Reproduced the issue by:

 - Loaded a structure into Creg
 - Updated the structure to an invalid structure which produces a long error message

```
update lot set as_drawn_struct = '
  Mrv2305 05012323552D          

  0  0  0     0  0            999 V3000
M  V30 BEGIN CTAB
M  V30 COUNTS 1 0 0 0 0
M  V30 BEGIN ATOM
M  V30 1 NHBoc -8.6265 2.645 0 0
M  V30 END ATOM
M  V30 END CTAB
M  END
`
```
 - Ran CmpdReg standardization and verified CmpdReg standardization broke with `ERROR: value too long for type character varying(255)`
 - Upgraded the system to version with this fix and verified CmpdReg standardization ran successfully and that the UI displayed the long error message.

