### PR TITLE
ACAS-667

### DIFF
--- a/src/main/resources/db/migration/bbchem/postgres/V2.4.2.3__bbchem_structure_comment_field_expansion.sql
+++ b/src/main/resources/db/migration/bbchem/postgres/V2.4.2.3__bbchem_structure_comment_field_expansion.sql
@@ -16,6 +16,18 @@ BEGIN
     LOOP 
         FOREACH col_name IN ARRAY column_names
         LOOP
+            -- If this is fresh instance then the columns won't exist at all so we create them
+            IF NOT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_name = tbl_name
+                AND column_name = col_name
+            ) THEN
+                RAISE NOTICE 'Column % does not exist in table % so creating it', col_name, tbl_name;
+                EXECUTE 'ALTER TABLE ' || tbl_name || ' ADD COLUMN ' || col_name || ' text';
+                CONTINUE;
+            END IF;
+            -- If we got here, then the columns exist but may be the wrong type varchar(255) created by hibernate
             -- Check if the registration_comment and standardization_comment columns are already text columns.
             -- If they are not, then alter them to be text columns.
             IF NOT EXISTS (


### PR DESCRIPTION
## Description
 - Previous version of this script did not work on fresh instances where hibernate had not yet created the columns. This change installs the columns using flyway.

## Related Issue
ACAS-667

## How Has This Been Tested?
Ran roo code on fresh database and verified the correct columns were created.
Verified upgrading from 2023.1.x, where columns were of the wrong type but exist, resulted in the columns being altered from varchar(255) -> text
