### PR TITLE
ACAS-674: Order corporate name based on similarity match.

### DIFF
--- a/src/main/java/com/labsynch/labseer/dto/SearchFormReturnDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/SearchFormReturnDTO.java
@@ -15,7 +15,7 @@ import flexjson.transformer.DateTransformer;
 
 public class SearchFormReturnDTO {
 
-	private Collection<SearchCompoundReturnDTO> foundCompounds = new HashSet<SearchCompoundReturnDTO>();
+	private Collection<SearchCompoundReturnDTO> foundCompounds = new ArrayList<SearchCompoundReturnDTO>();
 
 	private boolean lotsWithheld;
 

--- a/src/main/java/com/labsynch/labseer/service/SearchFormServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SearchFormServiceImpl.java
@@ -613,7 +613,7 @@ public class SearchFormServiceImpl implements SearchFormService {
 
 	private SearchFormReturnDTO filterSearchResultsByProject(SearchFormReturnDTO searchResults, List<String> projects) {
 		if (!searchResults.getFoundCompounds().isEmpty()) {
-			Collection<SearchCompoundReturnDTO> filteredFoundCompounds = new HashSet<SearchCompoundReturnDTO>();
+			Collection<SearchCompoundReturnDTO> filteredFoundCompounds = new ArrayList<SearchCompoundReturnDTO>();
 			for (SearchCompoundReturnDTO foundCompound : searchResults.getFoundCompounds()) {
 				List<SearchLotDTO> filteredFoundLots = new ArrayList<SearchLotDTO>();
 				for (SearchLotDTO foundLot : foundCompound.getLotIDs()) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

In the current Compound Registration search form, user has the option to specify "CPMD Number List". ACAS allows users to provide incomplete search terms e.g CMPD-0000004, 4, CMPD-004. It'll also return other results matching the `%X` & `%CMPD-XXX...` pattern. When returning results, we don't apply sorting on the results and it could be the case that CMPD-004 could be filtered out based on the maximum upper limit of results. 

We would here want to apply order, such that results that match the criteria the most are returned first in the results.

## Description
<!--- Describe your changes in detail -->
We have two steps in the workflow,
1. Get data sorted from the database.
2. Don't reorder database returned results.

In order to do the first step, we are using [pg_trgm.similarity](https://www.postgresql.org/docs/current/pgtrgm.html#id-1.11.7.44.6) to do a similarity match on the corporate name and user specified search corporate name, and then find the maximum similarity value and then order the results.

We also have other tools to do the similarity match which are stricter, but in the use cases I tried with trigram similarity things worked well. (cloudsql does support [pg_trgm](https://cloud.google.com/sql/docs/postgres/extensions)extension)

In order to do the next step, we are now using an array list instead of a hash set to ensure the order is maintained.

## TODO:
~I have here only updated the similarity logic, but haven't added `pg_trgm` as a dependency and so the search as of now will fail unless you manually install the extension.~

K8s: (@brianbolt 🙏 ) https://crucible.bb.schrodinger.com/cru/SB-21821
Non-K8s: https://github.com/mcneilco/acas-postgres/pull/5

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ACAS-674](https://jira.schrodinger.com/browse/ACAS-674)

## How Has This Been Tested?
<!--- Describe how this has been tested -->
I verified now ordering is consistently getting applied and we have results where the term that matches the best is shown as the first item.

Also added acasclient tests.

I have an updated deployment on: https://anakumar-darwin.k8s.dev.bb.schrodinger.com/acas. Please feel free to experiment any particular use cases.