### PR TITLE
ACAS-699: Accept projects list to filter /api/experiments/protocolCodename/:code on from from nodejs

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/ExperimentService.java
+++ b/src/main/java/com/labsynch/labseer/service/ExperimentService.java
@@ -51,6 +51,10 @@ public interface ExperimentService {
 	public Collection<Experiment> findExperimentsByMetadataJson(
 			List<StringCollectionDTO> metaDataList);
 
+    
+    public Collection<Experiment> findExperimentsByProtocolCodeName(String query, List<String> projects)
+    throws TooManyResultsException;
+    
 	public Collection<Experiment> findExperimentsByGenericMetaDataSearch(String query, String userName, Boolean includeDeleted)
 			throws TooManyResultsException;
 

--- a/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
@@ -1124,7 +1124,7 @@ public class ExperimentServiceImpl implements ExperimentService {
 			
 		if (protocols.size() > 1) {
 			logger.error("ERROR: multiple protocols found with the same code name");
-			throw new RuntimeException("ERROR: multiple protocols found with the same code name");
+			throw new TooManyResultsException("ERROR: multiple protocols found with the same code name");
 		} else if (protocols.size() < 1) {
 			logger.warn("WARN: no protocols found with the query code name");
 			throw new NoResultException("WARN: no protocols found with the query code name");


### PR DESCRIPTION
## Description
 - Implement filtering on projects for route /api/experiments/protocolCode name

## Related Issue
ACAS-699

## How Has This Been Tested?
acasclient tests