### PR TITLE
ACAS-696: Fix vendorID updates

### DIFF
--- a/src/main/java/com/labsynch/labseer/domain/Lot.java
+++ b/src/main/java/com/labsynch/labseer/domain/Lot.java
@@ -148,7 +148,7 @@ public class Lot {
 
     @Size(max = 255)
     @Column(name = "vendorid")
-    private String vendorId;
+    private String vendorID;
 
     @ManyToOne
     @JoinColumn(name = "salt_form")
@@ -898,12 +898,12 @@ public class Lot {
         this.vendor = vendor;
     }
 
-    public String getVendorId() {
-        return this.vendorId;
+    public String getVendorID() {
+        return this.vendorID;
     }
 
-    public void setVendorId(String vendorId) {
-        this.vendorId = vendorId;
+    public void setVendorID(String vendorID) {
+        this.vendorID = vendorID;
     }
 
     public Set<FileList> getFileLists() {
@@ -1074,7 +1074,7 @@ public class Lot {
             "registeredBy", "modifiedDate", "modifiedBy", "barcode", "color", "notebookPage", "amount", "amountUnits",
             "solutionAmount", "solutionAmountUnits", "supplier", "supplierID", "purity", "purityOperator",
             "purityMeasuredBy", "chemist", "percentEE", "comments", "isVirtual", "ignore", "physicalState", "vendor",
-            "vendorId", "saltForm", "fileLists", "retain", "retainUnits", "retainLocation", "meltingPoint",
+            "vendorID", "saltForm", "fileLists", "retain", "retainUnits", "retainLocation", "meltingPoint",
             "boilingPoint", "supplierLot", "project", "parent", "bulkLoadFile", "lambda", "absorbance", "stockSolvent",
             "stockLocation", "observedMassOne", "observedMassTwo", "tareWeight", "tareWeightUnits", "totalAmountStored",
             "totalAmountStoredUnits", "lotAliases", "storageLocation");

--- a/src/main/java/com/labsynch/labseer/dto/LotDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/LotDTO.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.labsynch.labseer.domain.IsoSalt;
 import com.labsynch.labseer.domain.Lot;
 import com.labsynch.labseer.domain.LotAlias;
@@ -67,7 +68,7 @@ public class LotDTO {
 	private Double totalAmountStored;
 	private String totalAmountStoredUnitsCode;
 	private String vendorCode;
-	private String vendorId;
+	private String vendorID;
 	private String saltFormCorpName;
 	private String casNumber;
 	private String saltAbbrevs;
@@ -598,12 +599,12 @@ public class LotDTO {
 		this.vendorCode = vendorCode;
 	}
 
-	public String getVendorId() {
-		return this.vendorId;
+	public String getVendorID() {
+		return this.vendorID;
 	}
 
-	public void setVendorId(String vendorId) {
-		this.vendorId = vendorId;
+	public void setVendorID(String vendorID) {
+		this.vendorID = vendorID;
 	}
 
 	public String getSaltFormCorpName() {

--- a/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/BulkLoadServiceImpl.java
@@ -725,8 +725,8 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 					((metalotReturn.getMetalot().getLot().getSupplierID() == null) ? ""
 							: metalotReturn.getMetalot().getLot().getSupplierID()));
 			mol.setProperty("Registered Lot Vendor ID",
-					((metalotReturn.getMetalot().getLot().getVendorId() == null) ? ""
-							: metalotReturn.getMetalot().getLot().getVendorId()));
+					((metalotReturn.getMetalot().getLot().getVendorID() == null) ? ""
+							: metalotReturn.getMetalot().getLot().getVendorID()));
 			if (!parentAliasList.isEmpty()) {
 				for (String alias : parentAliasList) {
 					if (allParentAliases.length() == 0)
@@ -1384,7 +1384,7 @@ public class BulkLoadServiceImpl implements BulkLoadService {
 		lot.setColor(getStringValueFromMappings(mol, "Lot Color", mappings, results, recordNumber));
 		lot.setSupplier(getStringValueFromMappings(mol, "Lot Supplier", mappings, results, recordNumber));
 		lot.setSupplierID(getStringValueFromMappings(mol, "Lot Supplier ID", mappings, results, recordNumber));
-		lot.setVendorId(getStringValueFromMappings(mol, "Lot Vendor ID", mappings, results, recordNumber));
+		lot.setVendorID(getStringValueFromMappings(mol, "Lot Vendor ID", mappings, results, recordNumber));
 		lot.setComments(getStringValueFromMappings(mol, "Lot Comments", mappings, results, recordNumber));
 		lot.setSupplierLot(getStringValueFromMappings(mol, "Lot Supplier Lot", mappings, results, recordNumber));
 		lot.setMeltingPoint(getNumericValueFromMappings(mol, "Lot Melting Point", mappings, results, recordNumber));

--- a/src/main/java/com/labsynch/labseer/service/ExportServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ExportServiceImpl.java
@@ -181,8 +181,8 @@ public class ExportServiceImpl implements ExportService {
 				mol.setProperty("Supplier", lotDTO.getSupplier());
 			if (lotDTO.getSupplierID() != null)
 				mol.setProperty("Supplier ID", lotDTO.getSupplierID());
-			if (lotDTO.getVendorId() != null)
-				mol.setProperty("Vendor ID", lotDTO.getVendorId());
+			if (lotDTO.getVendorID() != null)
+				mol.setProperty("Vendor ID", lotDTO.getVendorID());
 			if (lotDTO.getSupplierLot() != null)
 				mol.setProperty("Supplier Lot", lotDTO.getSupplierLot());
 			if (lotDTO.getSynthesisDate() != null)

--- a/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/MetalotServiceImpl.java
@@ -618,7 +618,7 @@ public class MetalotServiceImpl implements MetalotService {
 					//
 					oldLot.setObservedMassOne(lot.getObservedMassOne());
 					oldLot.setObservedMassTwo(lot.getObservedMassTwo());
-					oldLot.setVendorId(lot.getVendorId());
+					oldLot.setVendorID(lot.getVendorID());
 					oldLot.setTareWeight(lot.getTareWeight());
 					oldLot.setTareWeightUnits(lot.getTareWeightUnits());
 					oldLot.setTotalAmountStored(lot.getTotalAmountStored());


### PR DESCRIPTION
## Description
 - Setters and gets with name `vendorID` instead of `vendorId`
 - I believe this was all due to the change in 1.13.7 where we massively updated the roo dependencies (spring and hibernate) and removed roo.  The UI code has always sent and watched for "vendorID" but the roo services were now expecting "vendorId".
 - I also verified that even with this bug, if you saved a lot via the user interface (sending `vendorID` instead of `vendorId`, this did not update the lot.vendorid field.  i.e. The UI was not deleting data.
 
## Related Issue
https://jira.schrodinger.com/browse/ACAS-696

## How Has This Been Tested?
Ran acasclient tests. See new test https://github.com/mcneilco/acasclient/pull/144
Verified manually via the UI that vendorID is properly saved and shown in the UI.