### PR TITLE
Including lot chemist in creg meta data

### DIFF
--- a/src/main/java/com/labsynch/labseer/domain/Lot.java
+++ b/src/main/java/com/labsynch/labseer/domain/Lot.java
@@ -614,7 +614,7 @@ public class Lot {
 
         EntityManager em = Lot.entityManager();
         String query = "SELECT new com.labsynch.labseer.dto.LotsByProjectDTO( "
-                + "lt.id as id, lt.corpName as lotCorpName, lt.lotNumber as lotNumber, lt.registrationDate as registrationDate, prnt.corpName as parentCorpName, lt.project as project) "
+                + "lt.id as id, lt.corpName as lotCorpName, lt.lotNumber as lotNumber, lt.registrationDate as registrationDate, prnt.corpName as parentCorpName, lt.project as project, lt.chemist as chemist) "
                 + "FROM Lot AS lt "
                 + "JOIN lt.saltForm sltfrm "
                 + "JOIN sltfrm.parent prnt "

--- a/src/main/java/com/labsynch/labseer/dto/LotsByProjectDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/LotsByProjectDTO.java
@@ -13,6 +13,7 @@ public class LotsByProjectDTO {
     private Date registrationDate;
     private String parentCorpName;
     private String project;
+    private String chemist;
 
     public LotsByProjectDTO(
             long id,
@@ -20,7 +21,8 @@ public class LotsByProjectDTO {
             int lotNumber,
             Date registrationDate,
             String parentCorpName,
-            String project) {
+            String project,
+            String chemist) {
 
         this.id = id;
         this.lotCorpName = lotCorpName;
@@ -28,6 +30,7 @@ public class LotsByProjectDTO {
         this.registrationDate = registrationDate;
         this.parentCorpName = parentCorpName;
         this.project = project;
+        this.chemist = chemist;
     }
 
     public LotsByProjectDTO() {
@@ -48,6 +51,14 @@ public class LotsByProjectDTO {
 
     public void setLotCorpName(String lotCorpName) {
         this.lotCorpName = lotCorpName;
+    }
+
+    public String getChemist() {
+        return this.chemist;
+    }
+
+    public void setChemist(String chemist) {
+        this.chemist = chemist;
     }
 
     public Integer getLotNumber() {


### PR DESCRIPTION
## Description
Users requested including lot chemist as an attribute for each record in creg metadata when calling the `cmpdReg/parentLot/getAllAuthorizedLots` endpoint with the goal of helping analyze and categorize records by using lot chemist. 


## How Has This Been Tested?
Tested locally by hit the route `http://localhost:3000/cmpdReg/parentLot/getAllAuthorizedLots`.

Before with test data, the route returned:
```
[
  {
    "id": 55,
    "lotCorpName": "CMPD-0000001-001",
    "lotNumber": 1,
    "parentCorpName": "CMPD-0000001",
    "project": "PROJ-00000001",
    "registrationDate": 1675314000000
  },
  {
    "id": 59,
    "lotCorpName": "CMPD-0000002-001",
    "lotNumber": 1,
    "parentCorpName": "CMPD-0000002",
    "project": "PROJ-00000001",
    "registrationDate": 1675314000000
  }
]
```

After the change, chemist was included in the response:
```
[
  {
    "chemist": "bob",
    "id": 55,
    "lotCorpName": "CMPD-0000001-001",
    "lotNumber": 1,
    "parentCorpName": "CMPD-0000001",
    "project": "PROJ-00000001",
    "registrationDate": 1675314000000
  },
  {
    "chemist": "bob",
    "id": 59,
    "lotCorpName": "CMPD-0000002-001",
    "lotNumber": 1,
    "parentCorpName": "CMPD-0000002",
    "project": "PROJ-00000001",
    "registrationDate": 1675314000000
  }
]
```