### PR TITLE
ACAS-710: Code table label text search and short name match query parameters

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiDDictValueController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiDDictValueController.java
@@ -357,7 +357,10 @@ public class ApiDDictValueController {
 
 		if (format != null && format.equalsIgnoreCase("codeTable")) {
 			List<CodeTableDTO> codeTables = dataDictionaryService.convertToCodeTables(dDictResults);
-			codeTables = CodeTableDTO.sortCodeTables(codeTables);
+			// labelText searches have their own sort order so we don't need to sort them
+			if (labelTextSearchTerm.isEmpty()) {
+				codeTables = CodeTableDTO.sortCodeTables(codeTables);
+			}
 			return new ResponseEntity<String>(CodeTableDTO.toJsonArray(codeTables), headers, HttpStatus.OK);
 		} else if (format != null && format.equalsIgnoreCase("csv")) {
 			String outputString = dataDictionaryService.getCsvList(dDictResults);

--- a/src/main/java/com/labsynch/labseer/api/ApiDDictValueController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiDDictValueController.java
@@ -323,6 +323,7 @@ public class ApiDDictValueController {
 			@PathVariable("lsType") String lsType,
 			@PathVariable("lsKind") String lsKind,
 			@PathVariable("format") String format,
+			@RequestParam(value = "maxHits", defaultValue = "100", required = false) Integer maxHits,
 			@RequestParam(value = "shortName", defaultValue = "", required = false) String shortName,
 			@RequestParam(value = "labelTextSearchTerm", defaultValue = "", required = false) String labelTextSearchTerm) {
 
@@ -343,11 +344,15 @@ public class ApiDDictValueController {
 
 		List<DDictValue> dDictResults;
 		if (labelTextSearchTerm.isEmpty() && shortName.isEmpty()) {
-			dDictResults = DDictValue.findDDictValuesByLsTypeEqualsAndLsKindEquals(lsType, lsKind).getResultList();
+			dDictResults = DDictValue.findDDictValuesByLsTypeEqualsAndLsKindEquals(lsType, lsKind)
+				.setMaxResults(maxHits)
+				.getResultList();
 		} else if (!shortName.isEmpty()) {
-			dDictResults = DDictValue.findDDictValuesByLsTypeEqualsAndLsKindEqualsAndShortNameEquals(lsType, lsKind, shortName).getResultList();
+			dDictResults = DDictValue.findDDictValuesByLsTypeEqualsAndLsKindEqualsAndShortNameEquals(lsType, lsKind, shortName)
+				.setMaxResults(maxHits)
+				.getResultList();
 		} else {
-			dDictResults = DDictValue.findDDictValuesByLsTypeEqualsAndLsKindEqualsAndLabelTextSearch(lsType, lsKind, labelTextSearchTerm);
+			dDictResults = DDictValue.findDDictValuesByLsTypeEqualsAndLsKindEqualsAndLabelTextSearch(lsType, lsKind, labelTextSearchTerm, maxHits);
 		}
 
 		if (format != null && format.equalsIgnoreCase("codeTable")) {

--- a/src/main/java/com/labsynch/labseer/api/ApiDDictValueController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiDDictValueController.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import javax.persistence.TypedQuery;
+
 import com.labsynch.labseer.domain.DDictValue;
 import com.labsynch.labseer.dto.CodeTableDTO;
 import com.labsynch.labseer.exceptions.ErrorMessage;
@@ -323,7 +325,7 @@ public class ApiDDictValueController {
 			@PathVariable("lsType") String lsType,
 			@PathVariable("lsKind") String lsKind,
 			@PathVariable("format") String format,
-			@RequestParam(value = "maxHits", defaultValue = "100", required = false) Integer maxHits,
+			@RequestParam(value = "maxHits", required = false) Integer maxHits,
 			@RequestParam(value = "shortName", defaultValue = "", required = false) String shortName,
 			@RequestParam(value = "labelTextSearchTerm", defaultValue = "", required = false) String labelTextSearchTerm) {
 
@@ -344,13 +346,17 @@ public class ApiDDictValueController {
 
 		List<DDictValue> dDictResults;
 		if (labelTextSearchTerm.isEmpty() && shortName.isEmpty()) {
-			dDictResults = DDictValue.findDDictValuesByLsTypeEqualsAndLsKindEquals(lsType, lsKind)
-				.setMaxResults(maxHits)
-				.getResultList();
+			TypedQuery<DDictValue> dDictResultsQuery = DDictValue.findDDictValuesByLsTypeEqualsAndLsKindEquals(lsType, lsKind);
+			if (maxHits != null) {
+				dDictResultsQuery = dDictResultsQuery.setMaxResults(maxHits);
+			}
+			dDictResults = dDictResultsQuery.getResultList();
 		} else if (!shortName.isEmpty()) {
-			dDictResults = DDictValue.findDDictValuesByLsTypeEqualsAndLsKindEqualsAndShortNameEquals(lsType, lsKind, shortName)
-				.setMaxResults(maxHits)
-				.getResultList();
+			TypedQuery<DDictValue> dDictResultsQuery = DDictValue.findDDictValuesByLsTypeEqualsAndLsKindEqualsAndShortNameEquals(lsType, lsKind, shortName);
+			if (maxHits != null) {
+				dDictResultsQuery = dDictResultsQuery.setMaxResults(maxHits);
+			}
+			dDictResults = dDictResultsQuery.getResultList();
 		} else {
 			dDictResults = DDictValue.findDDictValuesByLsTypeEqualsAndLsKindEqualsAndLabelTextSearch(lsType, lsKind, labelTextSearchTerm, maxHits);
 		}

--- a/src/main/java/com/labsynch/labseer/domain/DDictValue.java
+++ b/src/main/java/com/labsynch/labseer/domain/DDictValue.java
@@ -599,8 +599,12 @@ public class DDictValue {
         q.setParameter("lsKind", lsKind);
         q.setParameter("labelText", labelText.toLowerCase());
         q.setParameter("formattedLabelText", formattedLabelText);
+        if (maxHits != null) {
+            q = q.setMaxResults(maxHits);
+        }
+
         @SuppressWarnings("unchecked")
-        List<DDictValue> results = q.setMaxResults(maxHits).getResultList();
+        List<DDictValue> results = q.getResultList();
         return results;
     }
 

--- a/src/main/java/com/labsynch/labseer/domain/DDictValue.java
+++ b/src/main/java/com/labsynch/labseer/domain/DDictValue.java
@@ -569,7 +569,7 @@ public class DDictValue {
         return q;
     }
 
-    public static List<DDictValue> findDDictValuesByLsTypeEqualsAndLsKindEqualsAndLabelTextSearch(String lsType, String lsKind, String labelText) {
+    public static List<DDictValue> findDDictValuesByLsTypeEqualsAndLsKindEqualsAndLabelTextSearch(String lsType, String lsKind, String labelText, Integer maxHits) {
         if (lsType == null || lsType.length() == 0)
             throw new IllegalArgumentException("The lsType argument is required");
         if (lsKind == null || lsKind.length() == 0)
@@ -598,7 +598,7 @@ public class DDictValue {
         q.setParameter("lsKind", lsKind);
         q.setParameter("labelText", formattedLabelText);
         @SuppressWarnings("unchecked")
-        List<DDictValue> results = q.getResultList();
+        List<DDictValue> results = q.setMaxResults(maxHits).getResultList();
         return results;
     }
 

--- a/src/main/java/com/labsynch/labseer/domain/DDictValue.java
+++ b/src/main/java/com/labsynch/labseer/domain/DDictValue.java
@@ -590,13 +590,15 @@ public class DDictValue {
         "FROM ddict_value " +
         "WHERE ls_type = :lsType " +
         "AND ls_kind = :lsKind " +
-        "AND to_tsvector('english', lower(label_text)) @@ to_tsquery('english', :labelText) " +
-        "ORDER BY ts_rank(to_tsvector('english', lower(label_text)), to_tsquery('english', :labelText)) DESC";
-        
+        "AND to_tsvector('english', lower(label_text)) @@ to_tsquery('english', :formattedLabelText) " +
+        "ORDER BY (lower(label_text) = :labelText) DESC, " +
+        "ts_rank(to_tsvector('english', lower(label_text)), to_tsquery('english', :formattedLabelText)) DESC";
+
         Query q = em.createNativeQuery(sql, DDictValue.class);
         q.setParameter("lsType", lsType);
         q.setParameter("lsKind", lsKind);
-        q.setParameter("labelText", formattedLabelText);
+        q.setParameter("labelText", labelText.toLowerCase());
+        q.setParameter("formattedLabelText", formattedLabelText);
         @SuppressWarnings("unchecked")
         List<DDictValue> results = q.setMaxResults(maxHits).getResultList();
         return results;

--- a/src/main/resources/db/migration/postgres/V2.4.2.2__ddict_value_label_text_search_index.sql
+++ b/src/main/resources/db/migration/postgres/V2.4.2.2__ddict_value_label_text_search_index.sql
@@ -1,0 +1,13 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM   pg_class c
+        JOIN   pg_namespace n ON n.oid = c.relnamespace
+        WHERE  c.relname = 'ddict_value_labeltext_web_idx'
+    )
+    THEN
+        CREATE INDEX ddict_value_labeltext_web_idx ON ddict_value USING GIN (to_tsvector('english', label_text));
+    END IF;
+END
+$$;

--- a/src/main/resources/db/migration/postgres/V2.4.2.2__ddict_value_label_text_search_index.sql
+++ b/src/main/resources/db/migration/postgres/V2.4.2.2__ddict_value_label_text_search_index.sql
@@ -4,10 +4,24 @@ BEGIN
         SELECT 1
         FROM   pg_class c
         JOIN   pg_namespace n ON n.oid = c.relnamespace
-        WHERE  c.relname = 'ddict_value_labeltext_web_idx'
+        WHERE  c.relname = 'ddict_value_labeltext_tsvector_idx'
     )
     THEN
-        CREATE INDEX ddict_value_labeltext_web_idx ON ddict_value USING GIN (to_tsvector('english', label_text));
+        CREATE INDEX ddict_value_labeltext_tsvector_idx ON ddict_value USING GIN (to_tsvector('english', label_text));
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM   pg_class c
+        JOIN   pg_namespace n ON n.oid = c.relnamespace
+        WHERE  c.relname = 'idx_ddictvalue_labeltext_lower_pattern'
+    )
+    THEN
+        CREATE INDEX idx_ddictvalue_labeltext_lower_pattern ON ddict_value(lower(label_text) varchar_pattern_ops);
     END IF;
 END
 $$;


### PR DESCRIPTION
## Description
 - Add code table/ddict value label text search which searches for label text and orders by a "best match"
 - Add code table/ddict value short name match which finds the ddict value based on short name in the same route
 - Added maxHits argument to limit results where the default is to not update.
 - Added indexes on label_text to facilitate faster search including tsvector and a lower varcharops which was new to me and handles both lower case seraches and wildcard like search cases:


> The operator classes text_pattern_ops, varchar_pattern_ops, and bpchar_pattern_ops support B-tree indexes on the types text, varchar, and char respectively. The difference from the default operator classes is that the values are compared strictly character by character rather than according to the locale-specific collation rules. This makes these operator classes suitable for use by queries involving pattern matching expressions (LIKE or POSIX regular expressions) when the database does not use the standard “C” locale. As an example, you might index a varchar column like this:

```
CREATE INDEX test_index ON test_table (col varchar_pattern_ops);
```

## Related Issue
ACAS-710

## How Has This Been Tested?
- Ran acasclient tests to verify compatability.
- Uploaded thousands of `data column`/ `column tree` ls_type / ls_kind values to ddict value and verified the code table fields behaved properly in Experiment editor and protocol editor as well as those in each of the endpoint manage fields.
- See related https://github.com/mcneilco/acas/pull/1148 for demo video