### PR TITLE
Fix Bug: Hitting cancel on cmpdreg file upload widget new line causes "error..."

### DIFF
--- a/src/main/java/com/labsynch/labseer/dto/FileSaveSendDTO.java
+++ b/src/main/java/com/labsynch/labseer/dto/FileSaveSendDTO.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import javax.persistence.Transient;
@@ -58,6 +59,11 @@ public class FileSaveSendDTO {
 		List<String> descriptionList = this.description;
 
 		List<String> writeupList = this.writeup;
+
+		// If writeupList is empty, fill it with empty strings to match the size of fileList
+		if (writeupList.isEmpty()) {
+			writeupList = new ArrayList<>(Collections.nCopies(fileList.size(), ""));
+		}	
 
 		List<FileSaveReturnDTO> fileSaveArray = new ArrayList<FileSaveReturnDTO>();
 


### PR DESCRIPTION
## Description

### Original Bug:
To reproduce:

- Click View/Edit files
- Upload a new file to the list
- The UI automatically adds another file chooser below the new file uploaded. 
- Click the "cancel" button on this new file chooser line
- Click the "Upload" button

Expectation:

- The file I chose to upload is uploaded

Actual results:

- "error..." is displayed and the file is not uploaded.

### Fix
Narrowed down the issue to this line in ```FileSaveSendDTO.java```:
```String writeup = writeupList.get(i);```

If the user inserted text (even a blank space) in writeup even if they hit "cancel" on the new file chooser line, there would be no issue BUT if they left the writeup field in the form blank and hit cancel, the writeupList would be blank and the code would fail on this line.

I'm guessing maybe there is some weird logic happening on the frontend when the user hits cancel? Since when the user inserts any text into the field it is fine, I'm not as worried about altering the logic there and just added this line to handle weird cases where writeupList is empty and doesn't match the length of files. 

## How Has This Been Tested?
Reproduced the steps before and after the fix, and saw that the failure no longer occurred. 