### PR TITLE
ACAS-819: Update tomcat to 9.0.97

### DIFF
--- a/Dockerfile-multistage
+++ b/Dockerfile-multistage
@@ -15,7 +15,7 @@ ADD 	. /src
 RUN 	--mount=type=cache,target=/root/.m2 mvn clean && \
         mvn compile war:war -P ${CHEMISTRY_PACKAGE} 
 
-FROM tomcat:9.0.62-jre11-openjdk-slim-buster
+FROM tomcat:9.0.97-jdk11-temurin-jammy
 
 # Third and Last Step That Requires Significant (Relative) Amount of Time 
 RUN apt-get update && \
@@ -50,10 +50,10 @@ RUN	useradd -u 1000 -ms /bin/bash runner && \
   chown -R runner:runner /usr/local/tomcat/
 
 # Allow certificates to be added by runner
-RUN chgrp runner /usr/local/openjdk-11/lib/security/cacerts && \
-    chmod g+w /usr/local/openjdk-11/lib/security/cacerts && \
+RUN chgrp runner $JAVA_HOME/lib/security/cacerts && \
+    chmod g+w $JAVA_HOME/lib/security/cacerts && \
     mkdir -p /usr/lib/jvm/java/jre/lib/security && \
-    ln -s /usr/local/openjdk-11/lib/security/cacerts /usr/lib/jvm/java/jre/lib/security/cacerts
+    ln -s $JAVA_HOME/lib/security/cacerts /usr/lib/jvm/java/jre/lib/security/cacerts
 
 # Get acas-roo-server compiled code
 COPY 	--chown=runner:runner --from=compile /src/target/acas*.war /usr/local/tomcat/webapps/acas.war

--- a/Dockerfile-multistage
+++ b/Dockerfile-multistage
@@ -1,7 +1,7 @@
 ARG 	CHEMISTRY_PACKAGE=bbchem
-FROM maven:3-openjdk-11 as builder
+FROM maven:3-openjdk-11 AS builder
 
-FROM 	builder as compile
+FROM 	builder AS compile
 ARG     CHEMISTRY_PACKAGE
 ENV     CHEMISTRY_PACKAGE=${CHEMISTRY_PACKAGE}
 
@@ -26,8 +26,8 @@ RUN apt-get update && \
       openssl 
     
 # Add nodejs for prepare config files
-ENV NPM_CONFIG_LOGLEVEL warn
-ENV NODE_VERSION 20.x
+ENV NPM_CONFIG_LOGLEVEL=warn
+ENV NODE_VERSION=20.x
 
 # Second Slowest Step 
 RUN curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION | bash - && \
@@ -43,7 +43,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION | bash - && \
     underscore@1.12.0 \
     underscore-deep-extend@1.1.5
 
-ENV NODE_PATH /usr/lib/node_modules
+ENV NODE_PATH=/usr/lib/node_modules
 
 # Add runner user so we don't run as root
 RUN	useradd -u 1000 -ms /bin/bash runner && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - acas-roo-server is currently using version tomcat:9.0.62-jre11-openjdk-slim-buster which is subject to [NVD - CVE-2022-29885](https://nvd.nist.gov/vuln/detail/CVE-2022-29885).  Update to tomcat:9.0.97-jdk11-temurin-jammy which is the latest tomcat 9 version https://hub.docker.com/_/tomcat .  Also of note is that the slim-buster image is no longer available but this build works and seems to function properly so I went with it over the others which would have required more docker file build changes.
 - I considered upgrading to latest tomcat [11.0.1](https://github.com/docker-library/tomcat/blob/37acdb35f2684d2c41e3c6ed96cc0403bec02447/11.0/jdk21/temurin-noble/Dockerfile) but decided against it for now
 - Also added a few small fixes to fix legacy warning in docker builds:

```
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 29)
 ```

## Related Issue
https://schrodinger.atlassian.net/browse/ACAS-819

## How Has This Been Tested?
Built the OSS Indigo version and ran acasclient tests.