### PR TITLE
ACAS-831: Remove extra bit for bio/small molecule flag

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemParentStructure.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemParentStructure.java
@@ -32,7 +32,7 @@ public class BBChemParentStructure extends AbstractBBChemStructure {
         EntityManager em = BBChemParentStructure.entityManager();
         String fingerprintString = SimpleUtil.bitSetToString(substructure);
         Query q = em.createNativeQuery(
-                "SELECT o.* FROM bbchem_parent_structure AS o WHERE (o.substructure \\& CAST(:fingerprintString AS bit(2112))) = CAST(:fingerprintString AS bit(2112))  ",
+                "SELECT o.* FROM bbchem_parent_structure AS o WHERE (o.substructure \\& CAST(:fingerprintString AS bit(2048))) = CAST(:fingerprintString AS bit(2048))  ",
                 BBChemParentStructure.class);
         q.setParameter("fingerprintString", fingerprintString);
         if (maxResults > -1) {

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemSaltFormStructure.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/BBChemSaltFormStructure.java
@@ -32,7 +32,7 @@ public class BBChemSaltFormStructure extends AbstractBBChemStructure {
         EntityManager em = BBChemSaltFormStructure.entityManager();
         String fingerprintString = SimpleUtil.bitSetToString(substructure);
         Query q = em.createNativeQuery(
-                "SELECT o.* FROM bbchem_salt_form_structure AS o WHERE (o.substructure \\& CAST(:fingerprintString AS bit(2112))) = CAST(:fingerprintString AS bit(2112)) ",
+                "SELECT o.* FROM bbchem_salt_form_structure AS o WHERE (o.substructure \\& CAST(:fingerprintString AS bit(2048))) = CAST(:fingerprintString AS bit(2048)) ",
                 BBChemSaltFormStructure.class);
         q.setParameter("fingerprintString", fingerprintString);
         if (maxResults > -1) {

--- a/src/main/resources/db/migration/bbchem/postgres/V2.4.2.6__bbchem_remove_small_vs_bio_molecule_fingerprint_bit.sql
+++ b/src/main/resources/db/migration/bbchem/postgres/V2.4.2.6__bbchem_remove_small_vs_bio_molecule_fingerprint_bit.sql
@@ -1,0 +1,20 @@
+-- Alter each of the bbchem structure.substructure columns to be of type bit(2048) from bit(2112) by adding 1 to the length.
+-- This is because the new substructure column is 64 bits shorter than the old one with a removal of 1 for the small vs bio molecule fingerprint which is handled differently now.
+DO $$ 
+DECLARE
+	table_names text[] := array[ 
+        'bbchem_standardization_dry_run_structure',
+        'bbchem_dry_run_structure',
+        'bbchem_parent_structure',
+        'bbchem_salt_form_structure',
+        'bbchem_salt_structure'
+    ];
+    table_name text;
+BEGIN
+    FOREACH table_name IN ARRAY table_names
+    LOOP 
+        -- Truncate the table to avoid any issues with the new column length acas will fill it back on startup.
+        EXECUTE 'TRUNCATE TABLE ' || table_name;
+        EXECUTE 'ALTER TABLE ' || table_name || ' ALTER COLUMN substructure TYPE bit(2048)';
+    END LOOP;
+END $$;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Set substructure fields to be 2048 instead of 2112 (opposite of https://github.com/mcneilco/acas-roo-server/pull/438/files)
 
## Related Issue
ACAS-831

## How Has This Been Tested?
 - Started a 25-1 instance with the broken (larger bit column) and verified the same error when trying to register a structure or do a structure search (ERROR: bit string length 2048 does not match type bit(2112))
 - Updated to this fixed version
 - Verified the columns were all changed from 2112 to 2048.
 - Registered a structure and verified substructure was also working.
 - I didn't test the upgrade path where there were structures registered prior to the upgrade but I did truncate the bbchem_parent_structure table and restarted acas and verified the finger print was detected as missing and added back.