### PR TITLE
ACAS-843: Fix molWeight comparison when no changes are made

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/SaltServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltServiceImpl.java
@@ -232,7 +232,7 @@ public class SaltServiceImpl implements SaltService {
 		newSalt.setMolWeight(saltStructureService.calculateWeight(newSalt));
 		newSalt.setCharge(saltStructureService.calculateCharge(newSalt));
 
-		if(newSalt.getMolWeight() != oldSalt.getMolWeight()){
+		if(Double.compare(newSalt.getMolWeight(), oldSalt.getMolWeight()) != 0){
 			ErrorMessage warning = new ErrorMessage();
 			warning.setLevel("warning");
 			warning.setMessage("The weight of this salt will be changed.");


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The Salt editor was reporting MW changes when none were present. This was due to how Java handles Doubles, and comparing them with `!=` / `==` doesn't work well. Switched to `Double.compare` and tested.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Describe how this has been tested -->
- Tested editing a salt and not changing structure, and confirmed there's no warning shown
- Tested making a structure change to a salt and confirmed that there was a warning about MW change