### PR TITLE
ACAS-845: Patch ACAS for CVE-2025-24813 by upgrading to tomcat:9.0.102

### DIFF
--- a/Dockerfile-multistage
+++ b/Dockerfile-multistage
@@ -15,7 +15,7 @@ ADD 	. /src
 RUN 	--mount=type=cache,target=/root/.m2 mvn clean && \
         mvn compile war:war -P ${CHEMISTRY_PACKAGE} 
 
-FROM tomcat:9.0.97-jdk11-temurin-jammy
+FROM tomcat:9.0.102-jdk11-temurin-jammy
 
 # Third and Last Step That Requires Significant (Relative) Amount of Time 
 RUN apt-get update && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Patch ACAS for CVE-2025-24813 by upgrading to tomcat:9.0.102

https://www.bleepingcomputer.com/news/security/critical-rce-flaw-in-apache-tomcat-actively-exploited-in-attacks/

> Apache recommended that all users upgrade to Tomcat versions 11.0.3+, 10.1.35+, or 9.0.99+, which are patched against CVE-2025-24813.



## Related Issue
https://schrodinger.atlassian.net/browse/ACAS-845

## How Has This Been Tested?

None. Will let acasclient tests and QA catch issues.