### PR TITLE
ACAS-850: Skip automatically failing running dry run or standardization on the start of roo

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiStandardizationServicesController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiStandardizationServicesController.java
@@ -212,4 +212,12 @@ public class ApiStandardizationServicesController {
 		return new ResponseEntity<String>(dryRunStats, headers, HttpStatus.OK);
 	}
 
+	@Transactional
+	@RequestMapping(value = "/failRunnningStandardization", method = RequestMethod.POST, headers = "Accept=application/json")
+	public ResponseEntity<String> failRunnningStandardization() {
+		HttpHeaders headers = new HttpHeaders();
+		standardizationService.failRunnningStandardization();
+		return new ResponseEntity<String>(headers, HttpStatus.OK);
+	}
+
 }

--- a/src/main/java/com/labsynch/labseer/service/StandardizationService.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationService.java
@@ -42,4 +42,6 @@ public interface StandardizationService {
 
 	StandardizationSettingsConfigCheckResponseDTO checkStandardizationState() throws StandardizerException;
 
+	void failRunnningStandardization();
+
 }

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -80,7 +80,7 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 	@Autowired
 	public CmpdRegSDFWriterFactory sdfWriterFactory;
 
-	private void failRunnningStandardization() {
+	public void failRunnningStandardization() {
 		// Cancel all running standardization histories as failed
 		List<StandardizationHistory> histories = StandardizationHistory.findAllStandardizationHistorys();
 		for (StandardizationHistory history : histories) {

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -108,8 +108,6 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			return;
 		}
 
-		// Fail any dry runs or standardizations that are still in progress from when the server was last up
-		failRunnningStandardization();
 		try{
 			checkStandardizationState();
 		} catch (Exception e) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Remove call to failRunnningStandardization on start of tomcat for case when multiple replicas of ACAS are running and may be actually running standardization.
 - Adds API route to fail any running standardization for case when process leaves standardization in running state but is killed.

## Related Issue
https://schrodinger.atlassian.net/browse/ACAS-850

## How Has This Been Tested?
Started up acas and ran the following sql:

```
update standardization_history set dry_run_status = 'running';
update standardization_history set standardization_status = 'running';
```

Restarted ACAS and verified the status was still "running" to test that Roo was no longer automatically failing running standardizations.
```
acas=> select dry_run_status, standardization_status from standardization_history where dry_run_status = 'running' or standardization_status = 
'running';
 dry_run_status | standardization_status 
----------------+------------------------
 running         | running
(1 row)
```

Ran the following `curl -X POST http://localhost:8080/acas/api/v1/standardization/failRunnningStandardization`
Then logged into the DB and verified that this query returned the row:

```
acas=> select dry_run_status, standardization_status from standardization_history where dry_run_status = 'failed' or standardization_status = 
'failed';
 dry_run_status | standardization_status 
----------------+------------------------
 failed         | failed
(1 row)
```

Typically you would not get both of these things with "running" at the same time but the test is still valid for the route.