### PR TITLE
ACAS-853: Renaming Salt Abbrev where Salt Abbrev is Appended to Lot Corp Name results in loss of reference to experiment/assay data 

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/SaltServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltServiceImpl.java
@@ -389,14 +389,15 @@ public class SaltServiceImpl implements SaltService {
 			// Update Lot Corp Name If Format Uses Salt Abbrev
 			if (!propertiesUtilService.getCorpBatchFormat().equalsIgnoreCase("cas_style_format")) {
 				String newCorpName = lotService.generateCorpName(lot);
-				if (! newCorpName.equals(lot.getCorpName())) // Check to See If There is Indded a Change in the Name
+				if (! newCorpName.equals(lot.getCorpName())) // Check to See If There is Indeed a Change in the Name
 				{
+					String oldCorpName = lot.getCorpName();
 					lot.setCorpName(newCorpName);
-					// If Lot Corp Name Change, Cascade the Udpdate to “Batch Code” Values Within Analysis Groups and Lot Inventory Containers	
-					assayService.renameBatchCode(lot.getCorpName(), newCorpName, "SaltService");
-					containerService.renameBatchCode(lot.getCorpName(), newCorpName, "SaltService", null);
+					// If Lot Corp Name Change, Cascade the Update to “Batch Code” Values Within Analysis Groups and Lot Inventory Containers	
+					assayService.renameBatchCode(oldCorpName, newCorpName, "SaltService");
+					containerService.renameBatchCode(oldCorpName, newCorpName, "SaltService", null);
 
-					logger.info("new lot corp name: " + lot.getCorpName());
+					logger.info("new lot corp name: " + newCorpName);
 					// Recalculate Lot Molecular Weights
 					lot.setLotMolWeight(Lot.calculateLotMolWeight(lot));	
 				} 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Ticket: [Renaming Salt Abbrev where Salt Abbrev is Appended to Lot Corp Name results in loss of reference to experiment/assay data](https://schrodinger.atlassian.net/browse/ACAS-853)

## Description
<!--- Describe your changes in detail -->

**Reproduction Steps**

1. For the given server the following should be set `ACAS_CLIENT_CMPDREG_SERVERSETTINGS_APPENDSALTCODETOLOTNAME: "true"`. Therefore the corp batch format should be `corp_batch_saltcode` 
2. Create a given salt 
3. Register compound with salt created in previous step (i.e. The lot corp name should look like `<Prefix>-000XXXX-<SaltAbbrev>`)
4. Register assay data using the lot corp name  
5. Go to the salt browser and edit the salt 
6. Only edit and change the Salt Abbrev 
7. There should be warnings like the following 

`The abbreviation of this salt will be changed`
`This salt is referenced by <x> lots. `
`<x> Associated Batch Code(s): [...]`
`<y> Associated Experiment(s): [...]`
`<z> Associated Container(s): [...] `
`Lot corp names references salt abbreviations. Any associated lot corp names will be updated.`

8. Click to update the salt 

**Previous Bug**

The lot corp name is updated. However, the references to experiments, containers, etc. (like those mentioned above) will be lost. 

**After Fix**

The lot corp names are updated as well as the batch codes referencing the downstream data.

See testing notes below. 


## How Has This Been Tested?
<!--- Describe how this has been tested -->

Followed above reproduction steps 

**Looking at Database...**

```
acas=> SELECT id, ignored, code_kind, code_origin, code_type, code_type_and_kind, code_value, ls_kind, modified_by, modified_date, numeric_value, public_data, recorded_by, recorded_date FROM analysis_group_value;
 id | ignored | code_kind  | code_origin  | code_type | code_type_and_kind  |            code_value            |    ls_kind     | modified_by |      modified_date      |     numeric_value     | public_data | recorded_by |      recorded_date
----+---------+------------+--------------+-----------+---------------------+----------------------------------+----------------+-------------+-------------------------+-----------------------+-------------+-------------+-------------------------
 42 | f       |            |              |           | null_null           |                                  | In vitro Clint |             |                         | 12.100000000000000000 | t           | bob         | 2025-03-27 14:57:43.803
 43 | f       |            |              |           | null_null           |                                  | t1/2           |             |                         | 23.130000000000000000 | t           | bob         | 2025-03-27 14:57:43.808
 48 | f       | batch name | ACAS CmpdReg | compound  | compound_batch name | CMPD-0000001-001HydrochloricAcid | batch code     |             |                         |                       | f           | SaltService | 2025-03-27 15:31:26.522
 44 | t       | batch name | ACAS CmpdReg | compound  | compound_batch name | CMPD-0000001-001HCl              | batch code     | SaltService | 2025-03-27 15:31:26.522 |                       | t           | bob         | 2025-03-27 14:57:43.809
(4 rows)
``` 

**Checked to See if Disconnected Lots**

```
acas=> select distinct analysis_group_value.code_value as old_lot_corp_name
acas->     from protocol
acas->     join experiment on protocol.id = experiment.protocol_id
acas->     join experiment_analysisgroup on experiment.id = experiment_analysisgroup.experiment_id
acas->     join analysis_group on experiment_analysisgroup.analysis_group_id = analysis_group.id
acas->     join analysis_group_state on analysis_group.id = analysis_group_state.analysis_group_id
acas->     join analysis_group_value on analysis_group_state.id = analysis_group_value.analysis_state_id
acas->     left join lot on analysis_group_value.code_value = lot.corp_name
acas->     where protocol.ignored is not true AND
acas->         experiment.ignored is not true AND
acas->         analysis_group.ignored is not true AND
acas->         analysis_group_state.ignored is not true AND
acas->         analysis_group_value.ignored is not true AND
acas->         analysis_group_value.ls_kind = 'batch code' AND
acas->         lot.corp_name is null;
 old_lot_corp_name
-------------------
(0 rows)
```

Further testing notes on ticket [ACAS-853](https://schrodinger.atlassian.net/browse/ACAS-853?focusedCommentId=3232483)