### PR TITLE
ACAS-856: Changing salts on lots with append salt code to corp name disassociates assay data 

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/SaltFormServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltFormServiceImpl.java
@@ -250,8 +250,10 @@ public class SaltFormServiceImpl implements SaltFormService {
 					// numbering
 					lot.setCorpName(lotService.generateCorpName(lot));
 					newLotCorpName = lot.getCorpName();
-					assayService.renameBatchCode(oldLotCorpName, newLotCorpName, "SaltFormService");
-					containerService.renameBatchCode(oldLotCorpName, newLotCorpName, "SaltFormService", null);
+					if (!oldLotCorpName.equals(newLotCorpName)) {
+						assayService.renameBatchCode(oldLotCorpName, newLotCorpName, "SaltFormService");
+						containerService.renameBatchCode(oldLotCorpName, newLotCorpName, "SaltFormService", null);
+					}
 				}
 				lot.merge();
 				if (!oldLotCorpName.equals(newLotCorpName))

--- a/src/main/java/com/labsynch/labseer/service/SaltFormServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/SaltFormServiceImpl.java
@@ -27,7 +27,13 @@ import org.springframework.stereotype.Service;
 public class SaltFormServiceImpl implements SaltFormService {
 
 	@Autowired
+	private AssayService assayService;
+
+	@Autowired
 	private ChemStructureService chemService;
+
+	@Autowired
+	private ContainerService containerService;
 
 	@Autowired
 	private CorpNameService corpNameService;
@@ -244,6 +250,8 @@ public class SaltFormServiceImpl implements SaltFormService {
 					// numbering
 					lot.setCorpName(lotService.generateCorpName(lot));
 					newLotCorpName = lot.getCorpName();
+					assayService.renameBatchCode(oldLotCorpName, newLotCorpName, "SaltFormService");
+					containerService.renameBatchCode(oldLotCorpName, newLotCorpName, "SaltFormService", null);
 				}
 				lot.merge();
 				if (!oldLotCorpName.equals(newLotCorpName))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

**Previous Bug:** 

Changing the salt on a given lot with append salt code to corp name setting causes dissociation of assay data. The lot corp name is updated. However, the references to experiments, containers, etc. are lost. 

**Steps to Reproduce:** 

- For the given server the following should be set `ACAS_CLIENT_CMPDREG_SERVERSETTINGS_APPENDSALTCODETOLOTNAME: "true"` 
- Therefore the corp batch format should be `corp_batch_saltcode` 
- Create two salts 
- Register compound with one of the salts 
- Register assay data using the lot corp name  
- Go to the lot details page 
- Change the salt to the 2nd salt you created 
- Update the lot which renames the lot to  <Prefix>-000XXXX-NewSaltAbbrev

**Fix Results:** 

- Data associated with lot is modified to the new Lot Corp Name and relationship to assay data is preserved 

## Jira Ticket 
[ACAS-856](https://schrodinger.atlassian.net/browse/ACAS-856 )

## Related Issue
https://github.com/mcneilco/acas-roo-server/pull/477 

## How Has This Been Tested?
<!--- Describe how this has been tested -->

Followed reproduction steps prior to bug fix and confirmed issue on local checkout of `2025.2.x` 

Made corresponding changes to `SaltFormServiceImpl.java`. Setup debugger to follow the flow of the `SaltForm` update.

Received confirmation of lot corp name being updated successfully. 

![Salt A none](https://github.com/user-attachments/assets/5ca9e3b1-614a-4600-a961-c67108e4277b)

Because this is a similar issue to https://github.com/mcneilco/acas-roo-server/pull/477 , I did a quick check of the database and saw the batch code was updated successfully in one of the assay data tables. 

`select code_value, ignored, deleted, recorded_by, recorded_date  from analysis_group_value agv where ignored = false and code_value is not null;` 

![Screenshot 2025-04-07 at 4 36 18 PM](https://github.com/user-attachments/assets/e9086471-bbbc-42f7-8e71-c12864359083)




