### PR TITLE
ACAS-865: Only set ready changed structures

### DIFF
--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/ChemStructureServiceBBChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/ChemStructureServiceBBChemImpl.java
@@ -1234,6 +1234,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 
 
 	@Transactional
+	@Override
 	public void populateDuplicateChangedStructures(int batchSize) {
 		// Update existing, new and changed structures
 		updateExistingDuplicates();
@@ -1356,6 +1357,7 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 									 "    structure_comparison " +
 									 "WHERE " +
 									 "    sdr.id = structure_comparison.dry_run_id " +
+									 "    AND structure_comparison.changed_structure = true " + // Only update if structure has changed
 									 "    AND sdr.changed_structure IS NULL;"; // Skip rows already processed
 		em.createNativeQuery(changedStructureSql).executeUpdate();
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - While working on ACAS-855 I realized that my recent PR to improve duplicate checking was updating all standardization dry run compounds to sync_status = READY.  This causes the actual standardization to run all compounds regardless of whether there structures actually changed.
 - The fix for this is a one line change to the recent sql additions main in https://github.com/mcneilco/acas-roo-server/pull/480 to only update when the structure has actually changed.

## Related Issue
ACAS-865

## How Has This Been Tested?
Ran the same tests as described in https://github.com/mcneilco/acas-roo-server/pull/480
Verified that the sync_status was only set to "READY" for changed structures
Verified that standardization only ran on synced structures.