### PR TITLE
ACAS-867: CmpdReg standardization may not respond when dry run is complete

### DIFF
--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -731,7 +731,11 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		List<StandardizationHistory> standardizationSettingses = StandardizationHistory
 				.findStandardizationHistoryEntries(0, 1, "id", "DESC");
 		if (standardizationSettingses.size() > 0) {
-			return standardizationSettingses.get(0);
+			StandardizationHistory mostRecentHistory = standardizationSettingses.get(0);
+			// Refresh the entity to ensure it is up-to-date
+			EntityManager em = StandardizationHistory.entityManager();
+			em.refresh(mostRecentHistory);
+			return mostRecentHistory;
 		} else {
 			return null;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Fix for no UI response when multiple workers pick up dry run standardization

## Related Issue
https://schrodinger.atlassian.net/browse/ACAS-867

## How Has This Been Tested?
 - Ran dry run on an instance with 6 replicas to make sure this issue was reproducible.  Deployed the code and verified the UI consistently responded.