### PR TITLE
ACAS-876: Add /health/live and health/ready endpoints for k8s

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiHealthController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiHealthController.java
@@ -65,4 +65,24 @@ public class ApiHealthController {
 		return new ResponseEntity<String>("{\"averageMsTime\": " + averageTime + ", \"totalTime\": " + totalTime + ", \"testsToRun\": " + testsToRun + ", \"logData\": " + finalLogData + "}", headers, HttpStatus.OK);
 	}
 
+    @RequestMapping(value = "/live", method = RequestMethod.GET, produces = "application/json")
+    public ResponseEntity<String> liveness() {
+        return ResponseEntity.ok("{\"status\":\"UP\"}");
+    }
+
+    @RequestMapping(value = "/ready", method = RequestMethod.GET, produces = "application/json")
+    public ResponseEntity<String> readiness() {
+        try {
+            // Quick DB check: try to fetch one ValueType
+            List<ValueType> valueTypes = ValueType.findAllValueTypes();
+            boolean dbOk = valueTypes != null;
+            return dbOk
+                ? ResponseEntity.ok("{\"status\":\"UP\"}")
+                : ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body("{\"status\":\"DOWN\"}");
+        } catch (Exception e) {
+            logger.error("Readiness check failed", e);
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body("{\"status\":\"DOWN\"}");
+        }
+    }
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - /health/live - Liveness probes check if the application is running and responsive; if the liveness probe fails, Kubernetes will restart the container.
 - /health/ready - Readiness probes check if the application is ready to serve traffic (e.g., can connect to dependencies like databases); if the readiness probe fails, Kubernetes will temporarily remove the pod from service endpoints until it is.  We already had this as checkDatabaseSpeed?testsToRun=1 but this is a dedicated/simpler endpoint which does a similar check of the database connection.

## Related Issue
 - https://schrodinger.atlassian.net/browse/ACAS-876

## How Has This Been Tested?
 - Verified that expected results of  acas/api/v1/live and acas/api/v1/ready both return `{"status":"UP"}` when a pod is up and healthy.  
