### PR TITLE
ACAS-951: Automatic startup restandardization with cluster coordination

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiStandardizationServicesController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiStandardizationServicesController.java
@@ -1,6 +1,9 @@
 package com.labsynch.labseer.api;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 
 import jakarta.persistence.TypedQuery;
@@ -15,6 +18,7 @@ import com.labsynch.labseer.service.StandardizationService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -123,6 +127,32 @@ public class ApiStandardizationServicesController {
 		// Get most recent standardization history
 		String outputFilePath = standardizationService.getStandardizationDryRunReportFiles(filePath);
 		return new ResponseEntity<String>(outputFilePath, headers, HttpStatus.OK);
+	}
+
+	@RequestMapping(value = "/dryRunAutoReportFile", method = RequestMethod.GET)
+	@ResponseBody
+	public ResponseEntity<InputStreamResource> dryRunAutoReportFile(
+			@RequestParam(value = "historyId", required = true) Long historyId) {
+		HttpHeaders headers = new HttpHeaders();
+		try {
+			String reportFilePath = standardizationService.getAutoRestandardizationDryRunReportFilePath(historyId);
+			if (reportFilePath == null) {
+				return new ResponseEntity<InputStreamResource>(headers, HttpStatus.NOT_FOUND);
+			}
+
+			File reportFile = new File(reportFilePath);
+			if (!reportFile.exists() || !reportFile.isFile()) {
+				return new ResponseEntity<InputStreamResource>(headers, HttpStatus.NOT_FOUND);
+			}
+
+			InputStream inputStream = new FileInputStream(reportFile);
+			headers.add("Content-Type", "chemical/x-mdl-sdfile");
+			headers.add("Content-Disposition", "attachment; filename=" + reportFile.getName());
+			return new ResponseEntity<InputStreamResource>(new InputStreamResource(inputStream), headers, HttpStatus.OK);
+		} catch (Exception e) {
+			logger.error("Error generating auto dry-run report file response for history id {}", historyId, e);
+			return new ResponseEntity<InputStreamResource>(headers, HttpStatus.INTERNAL_SERVER_ERROR);
+		}
 	}
 
 	@Transactional

--- a/src/main/java/com/labsynch/labseer/api/ApiStandardizationServicesController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiStandardizationServicesController.java
@@ -79,6 +79,11 @@ public class ApiStandardizationServicesController {
 		if (!onlyReport) {
 			logger.info("reseting dry run table, populating dryrun table, dupe checking, and returning results");
 			standardizationService.executeDryRun();
+			// Generate dry-run report if enabled
+			StandardizationHistory latestHistory = standardizationService.getMostRecentStandardizationHistory();
+			if (latestHistory != null && "complete".equals(latestHistory.getDryRunStatus())) {
+				standardizationService.generateDryRunReport(latestHistory);
+			}
 		}
 		// Get most recent standardization history
 		String jsonReport = standardizationService.getStandardizationDryRunReport();

--- a/src/main/java/com/labsynch/labseer/chemclasses/bbchem/ChemStructureServiceBBChemImpl.java
+++ b/src/main/java/com/labsynch/labseer/chemclasses/bbchem/ChemStructureServiceBBChemImpl.java
@@ -1102,6 +1102,11 @@ public class ChemStructureServiceBBChemImpl implements ChemStructureService {
 
 
 	@Override
+	public boolean supportsAutoRestandardization() {
+		return true;
+	}
+
+	@Override
 	public void fillMissingStructures() throws CmpdRegMolFormatException {
 
 		// Parents

--- a/src/main/java/com/labsynch/labseer/domain/StandardizationHistory.java
+++ b/src/main/java/com/labsynch/labseer/domain/StandardizationHistory.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Transient;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.Version;
 
@@ -80,6 +81,9 @@ public class StandardizationHistory {
     private Integer standardizationErrorCount;
 
     private Integer registrationErrorCount;
+
+    @Transient
+    private Boolean autoDryRunReportAvailable;
 
     public StandardizationHistory() {
     }
@@ -431,5 +435,13 @@ public class StandardizationHistory {
 
     public void setRegistrationErrorCount(Integer registrationErrorCount) {
         this.registrationErrorCount = registrationErrorCount;
+    }
+
+    public Boolean getAutoDryRunReportAvailable() {
+        return this.autoDryRunReportAvailable;
+    }
+
+    public void setAutoDryRunReportAvailable(Boolean autoDryRunReportAvailable) {
+        this.autoDryRunReportAvailable = autoDryRunReportAvailable;
     }
 }

--- a/src/main/java/com/labsynch/labseer/service/ChemStructureService.java
+++ b/src/main/java/com/labsynch/labseer/service/ChemStructureService.java
@@ -167,6 +167,10 @@ public interface ChemStructureService {
 
 	public void fillMissingStructures() throws CmpdRegMolFormatException;
 
+	default boolean supportsAutoRestandardization() {
+		return false;
+	}
+
 	public StandardizationSettingsConfigCheckResponseDTO checkStandardizerSettings(StandardizationHistory mostRecentStandardizationHistory, StandardizerSettingsConfigDTO standardizationSettingsConfigDTO);
 	
 	default void populateDuplicateChangedStructures(int batchSize) {

--- a/src/main/java/com/labsynch/labseer/service/StandardizationService.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationService.java
@@ -44,4 +44,6 @@ public interface StandardizationService {
 
 	void failRunnningStandardization();
 
+	String getAutoRestandardizationDryRunReportFilePath(Long historyId);
+
 }

--- a/src/main/java/com/labsynch/labseer/service/StandardizationService.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationService.java
@@ -46,4 +46,8 @@ public interface StandardizationService {
 
 	String getAutoRestandardizationDryRunReportFilePath(Long historyId);
 
+	StandardizationHistory getMostRecentStandardizationHistory();
+
+	void generateDryRunReport(StandardizationHistory latestHistory);
+
 }

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -3,11 +3,16 @@ package com.labsynch.labseer.service;
 import java.io.File;
 import java.io.IOException;
 import java.text.DecimalFormat;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
+import javax.sql.DataSource;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
@@ -74,7 +79,81 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 	@Autowired
 	public CmpdRegSDFWriterFactory sdfWriterFactory;
 
+	@Autowired
+	private DataSource dataSource;
+
+	private static final long AUTO_RESTANDARDIZATION_CLUSTER_LOCK_KEY = 951001L;
+
 	Boolean standardizationDryRunRunningInThisWorker = false;
+
+	private boolean tryAcquireClusterLock(Connection connection, long lockKey) throws SQLException {
+		String sql = "SELECT pg_try_advisory_lock(?)";
+		try (PreparedStatement statement = connection.prepareStatement(sql)) {
+			statement.setLong(1, lockKey);
+			try (ResultSet rs = statement.executeQuery()) {
+				if (rs.next()) {
+					return rs.getBoolean(1);
+				}
+			}
+		}
+		return false;
+	}
+
+	private void releaseClusterLock(Connection connection, long lockKey) {
+		String sql = "SELECT pg_advisory_unlock(?)";
+		try (PreparedStatement statement = connection.prepareStatement(sql)) {
+			statement.setLong(1, lockKey);
+			statement.executeQuery();
+		} catch (SQLException e) {
+			logger.warn("Failed to release auto-restandardization cluster lock", e);
+		}
+	}
+
+	private void runAutomaticRestandardizationWithClusterLock() {
+		Connection lockConnection = null;
+		boolean lockAcquired = false;
+		try {
+			lockConnection = dataSource.getConnection();
+			lockAcquired = tryAcquireClusterLock(lockConnection, AUTO_RESTANDARDIZATION_CLUSTER_LOCK_KEY);
+			if (!lockAcquired) {
+				logger.info("Another pod already holds the auto-restandardization startup lock. Skipping startup initiation in this pod.");
+				return;
+			}
+
+			logger.info("Acquired auto-restandardization startup cluster lock.");
+			logger.info("Auto-restandardization: marking stale running standardization records as failed before startup run.");
+			failRunnningStandardization();
+
+			logger.info("Auto-restandardization: starting dry run");
+			executeDryRun();
+
+			StandardizationHistory latestHistory = getMostRecentStandardizationHistory();
+			if (latestHistory == null || !"complete".equals(latestHistory.getDryRunStatus())) {
+				String dryRunStatus = latestHistory == null ? "<missing-history>" : String.valueOf(latestHistory.getDryRunStatus());
+				logger.error("Auto-restandardization: dry run did not complete successfully (status: {}). Skipping execute phase.", dryRunStatus);
+				return;
+			}
+
+			logger.info("Auto-restandardization: dry run complete, starting standardization execution");
+			executeStandardization("acas", "Automatic restandardization triggered on startup");
+			logger.info("Auto-restandardization completed successfully");
+		} catch (SQLException e) {
+			logger.error("Auto-restandardization skipped because cluster lock could not be acquired via database advisory lock", e);
+		} catch (Exception e) {
+			logger.error("Auto-restandardization failed", e);
+		} finally {
+			if (lockAcquired && lockConnection != null) {
+				releaseClusterLock(lockConnection, AUTO_RESTANDARDIZATION_CLUSTER_LOCK_KEY);
+			}
+			if (lockConnection != null) {
+				try {
+					lockConnection.close();
+				} catch (SQLException e) {
+					logger.warn("Failed to close auto-restandardization lock connection", e);
+				}
+			}
+		}
+	}
 
 	public void failRunnningStandardization() {
 		// Cancel all running standardization histories as failed
@@ -126,15 +205,7 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			} else {
 				logger.info("Auto-restandardization is enabled and restandardization is needed. Starting automatic restandardization in background thread.");
 				Thread autoRestandardizationThread = new Thread(() -> {
-					try {
-						logger.info("Auto-restandardization: starting dry run");
-						executeDryRun();
-						logger.info("Auto-restandardization: dry run complete, starting standardization execution");
-						executeStandardization("acas", "Automatic restandardization triggered on startup");
-						logger.info("Auto-restandardization completed successfully");
-					} catch (Exception e) {
-						logger.error("Auto-restandardization failed", e);
-					}
+					runAutomaticRestandardizationWithClusterLock();
 				});
 				autoRestandardizationThread.setName("auto-restandardization");
 				autoRestandardizationThread.setDaemon(true);

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -322,7 +322,16 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 	public void populateStandardizationDryRunTable()
 			throws CmpdRegMolFormatException, IOException, StandardizerException {
 		while (true) {
-			int processedCount = dryrunStandardizeBatch();
+			int processedCount;
+			try {
+				processedCount = dryrunStandardizeBatch();
+			} catch (RuntimeException e) {
+				if (isDuplicateDryRunParentReservation(e)) {
+					logger.warn("Detected duplicate parent reservation while populating standardization dry run table. Another worker likely won the race for one or more parent IDs. Retrying.", e);
+					continue;
+				}
+				throw e;
+			}
 			int remainingToBeProcessed = StandardizationDryRunCompound.countRemainingParentsNotInStandardizationDryRunCompound();
 			if(processedCount > 0) {
 				int totalProcessed = StandardizationDryRunCompound.rowCount();
@@ -342,6 +351,20 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 				}
 			}
 		}
+	}
+
+	private boolean isDuplicateDryRunParentReservation(Throwable throwable) {
+		Throwable current = throwable;
+		while (current != null) {
+			String message = current.getMessage();
+			if (message != null
+					&& message.contains("stndzn_dry_run_parent_id_unique_idx")
+					&& message.contains("duplicate key value violates unique constraint")) {
+				return true;
+			}
+			current = current.getCause();
+		}
+		return false;
 	}
 
 	@Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -15,6 +15,8 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.sql.DataSource;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import java.util.stream.Collectors;
@@ -89,6 +91,7 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 
 	private final AtomicBoolean standardizationDryRunRunningInThisWorker = new AtomicBoolean(false);
 	private final AtomicBoolean autoRestandardizationStartupTriggeredInThisWorker = new AtomicBoolean(false);
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 	private boolean tryAcquireClusterLock(Connection connection, int lockNamespace, int lockId) throws SQLException {
 		String sql = "SELECT pg_try_advisory_lock(?, ?)";
@@ -102,6 +105,11 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			}
 		}
 		return false;
+	}
+
+	private String getPodName() {
+		String podName = System.getenv("HOSTNAME");
+		return StringUtils.isBlank(podName) ? "<unknown-pod>" : podName;
 	}
 
 	private void releaseClusterLock(Connection connection, int lockNamespace, int lockId) {
@@ -365,6 +373,20 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			current = current.getCause();
 		}
 		return false;
+	}
+
+	private boolean hasReadyStandardizerActions(StandardizerSettingsConfigDTO standardizerSettings) {
+		if (standardizerSettings == null || StringUtils.isBlank(standardizerSettings.getSettings())) {
+			return false;
+		}
+		try {
+			JsonNode parsedSettings = OBJECT_MAPPER.readTree(standardizerSettings.getSettings());
+			JsonNode standardizerActions = parsedSettings.get("standardizer_actions");
+			return standardizerActions != null && !standardizerActions.isNull() && !standardizerActions.isMissingNode();
+		} catch (IOException e) {
+			logger.warn("Unable to parse standardizer settings while checking readiness. Continuing with normal processing.", e);
+			return true;
+		}
 	}
 
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -838,6 +860,14 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		stndznHistory.setDryRunStart(new Date());
 		stndznHistory.setDryRunComplete(null);
 		stndznHistory.persist();
+		logger.info(
+				"Initialized dry-run history settings snapshot: pod={}, historyId={}, status={}, settingsHash={}, settings={}",
+				getPodName(),
+				stndznHistory.getId(),
+				status,
+				stndznHistory.getSettingsHash(),
+				stndznHistory.getSettings()
+		);
 		return stndznHistory;
 	}
 
@@ -918,13 +948,37 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			if (stndznHistory == null || stndznHistory.getDryRunStatus() == null || !stndznHistory.getDryRunStatus().equals("running")) {
 				return;
 			}
-			int currentConfigHash = chemStructureService.getStandardizerSettings(true).hashCode();
-			if (stndznHistory.getSettingsHash() != currentConfigHash) {
-				logger.warn("Skipping dry-run processing - config mismatch detected (history hash: {}, current hash: {}). "
-						+ "This pod may have a different configuration than the pod that initiated the dry run. "
-						+ "Waiting for pod to restart with consistent config.", stndznHistory.getSettingsHash(), currentConfigHash);
+			StandardizerSettingsConfigDTO currentSettings = chemStructureService.getStandardizerSettings(true);
+			if (!hasReadyStandardizerActions(currentSettings)) {
+				logger.info("Skipping dry-run processing - standardizer actions are not initialized yet: pod={}, historyId={}, dryRunStatus={}. Waiting for settings initialization before worker participation.",
+						getPodName(),
+						stndznHistory.getId(),
+						stndznHistory.getDryRunStatus());
 				return;
 			}
+			int currentConfigHash = currentSettings.hashCode();
+			if (stndznHistory.getSettingsHash() != currentConfigHash) {
+				logger.warn("Skipping dry-run processing - config mismatch detected: pod={}, historyId={}, dryRunStatus={}, history hash={}, current hash={}, history settings={}, current settings={}. "
+						+ "This pod may have a different configuration than the pod that initiated the dry run. "
+						+ "Waiting for pod to restart with consistent config.",
+						getPodName(),
+						stndznHistory.getId(),
+						stndznHistory.getDryRunStatus(),
+						stndznHistory.getSettingsHash(),
+						currentConfigHash,
+						stndznHistory.getSettings(),
+						currentSettings.toJson());
+				return;
+			}
+			logger.info(
+					"Dry-run worker settings match: pod={}, historyId={}, dryRunStatus={}, historyHash={}, currentHash={}, currentSettings={}",
+					getPodName(),
+					stndznHistory.getId(),
+					stndznHistory.getDryRunStatus(),
+					stndznHistory.getSettingsHash(),
+					currentConfigHash,
+					currentSettings.toJson()
+			);
 			logger.info("Dry run is running, executing dry run process");
 			runDryRun();
 			logger.info("Dry run process completed");

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -104,8 +104,9 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			return;
 		}
 
+		StandardizationSettingsConfigCheckResponseDTO standardizationState = null;
 		try{
-			checkStandardizationState();
+			standardizationState = checkStandardizationState();
 		} catch (Exception e) {
 			logger.warn("Error checking standardization state", e);
 		}
@@ -115,6 +116,26 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			chemStructureService.fillMissingStructures();
 		} catch (Exception e) {
 			logger.error("Error in trying to fill missing structures", e);
+		}
+
+		if (standardizationState != null
+				&& standardizationState.getNeedsRestandardization()
+				&& propertiesUtilService.getAutoRestandardize()) {
+			logger.info("Auto-restandardization is enabled and restandardization is needed. Starting automatic restandardization in background thread.");
+			Thread autoRestandardizationThread = new Thread(() -> {
+				try {
+					logger.info("Auto-restandardization: starting dry run");
+					executeDryRun();
+					logger.info("Auto-restandardization: dry run complete, starting standardization execution");
+					executeStandardization("acas", "Automatic restandardization triggered on startup");
+					logger.info("Auto-restandardization completed successfully");
+				} catch (Exception e) {
+					logger.error("Auto-restandardization failed", e);
+				}
+			});
+			autoRestandardizationThread.setName("auto-restandardization");
+			autoRestandardizationThread.setDaemon(true);
+			autoRestandardizationThread.start();
 		}
 	}
 

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -12,6 +12,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.sql.DataSource;
 
 import jakarta.persistence.EntityManager;
@@ -86,7 +87,8 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 	private static final int ADVISORY_LOCK_NAMESPACE_ACAS = "acas".hashCode();
 	private static final int ADVISORY_LOCK_AUTO_RESTANDARDIZE_STARTUP = "auto-restandardize-startup".hashCode();
 
-	Boolean standardizationDryRunRunningInThisWorker = false;
+	private final AtomicBoolean standardizationDryRunRunningInThisWorker = new AtomicBoolean(false);
+	private final AtomicBoolean autoRestandardizationStartupTriggeredInThisWorker = new AtomicBoolean(false);
 
 	private boolean tryAcquireClusterLock(Connection connection, int lockNamespace, int lockId) throws SQLException {
 		String sql = "SELECT pg_try_advisory_lock(?, ?)";
@@ -212,6 +214,10 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		if (standardizationState != null
 				&& standardizationState.getNeedsRestandardization()
 				&& propertiesUtilService.getAutoRestandardize()) {
+			if (!autoRestandardizationStartupTriggeredInThisWorker.compareAndSet(false, true)) {
+				logger.info("Auto-restandardization startup flow already triggered in this worker. Skipping duplicate trigger.");
+				return;
+			}
 			if (!chemStructureService.supportsAutoRestandardization()) {
 				logger.warn("Auto-restandardization is enabled but the active chemistry engine does not support it (BBChem required). Skipping automatic restandardization.");
 			} else {
@@ -855,9 +861,13 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		//  -- getRegistrationStatus is ERROR
 		//  -- or dryRunCompound changedStructure is filled in
 		StandardizationHistory stndznHistory = getMostRecentStandardizationHistory();
+		if (stndznHistory == null) {
+			logger.warn("No standardization history found while attempting to finalize dry run with status {}", status);
+			return;
+		}
 		logger.info("Most recent standardization history id: " + stndznHistory.getId() + " status: " + stndznHistory.getDryRunStatus());
 		//Refresh the stndznHistory to get the latest status
-        if (!stndznHistory.getDryRunStatus().equals("running")) {
+		if (stndznHistory.getDryRunStatus() == null || !stndznHistory.getDryRunStatus().equals("running")) {
             return;
         }
 		stndznHistory.setDryRunComplete(new Date());
@@ -875,14 +885,12 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
     public void checkForDryRunStandardization() throws CmpdRegMolFormatException, IOException, StandardizerException {
         //Avoid running the process if we are already in the middle of a dry run on this worker.
 		//i.e. if its manually called or if takes longer than a minute to run.
-		if(standardizationDryRunRunningInThisWorker) {
+		if(!standardizationDryRunRunningInThisWorker.compareAndSet(false, true)) {
 			return; // Avoid running multiple dry runs in parallel
 		}
-		standardizationDryRunRunningInThisWorker = true;
 		try {
 			StandardizationHistory stndznHistory = getMostRecentStandardizationHistory();
 			if (stndznHistory == null || stndznHistory.getDryRunStatus() == null || !stndznHistory.getDryRunStatus().equals("running")) {
-				standardizationDryRunRunningInThisWorker = false;
 				return;
 			}
 			logger.info("Dry run is running, executing dry run process");
@@ -890,10 +898,24 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			logger.info("Dry run process completed");
 		} catch (Exception e) {
 			logger.error("Error during dry run process", e);
-			standardizationDryRunRunningInThisWorker = false;
+			try {
+				finalizeDryRun("failed");
+			} catch (Exception finalizeException) {
+				logger.error("Failed to finalize dry run as failed after error", finalizeException);
+			}
+			if (e instanceof CmpdRegMolFormatException) {
+				throw (CmpdRegMolFormatException) e;
+			}
+			if (e instanceof IOException) {
+				throw (IOException) e;
+			}
+			if (e instanceof StandardizerException) {
+				throw (StandardizerException) e;
+			}
+			throw new StandardizerException(e);
+		} finally {
+			standardizationDryRunRunningInThisWorker.set(false);
 		}
-		// Set the status to complete if we reach here.
-		standardizationDryRunRunningInThisWorker = false;
     }
 }
 

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -9,6 +9,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -420,6 +422,38 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		} catch (Exception e) {
 			logger.error("Auto-restandardization: failed to generate dry-run SDF report at {}", reportFile.getAbsolutePath(), e);
 		}
+	}
+
+	@Override
+	public String getAutoRestandardizationDryRunReportFilePath(Long historyId) {
+		if (historyId == null) {
+			return null;
+		}
+
+		String reportDirectoryPath = propertiesUtilService.getAutoRestandardizationReportDirectory();
+		if (StringUtils.isBlank(reportDirectoryPath)) {
+			reportDirectoryPath = "/tmp";
+		}
+
+		File reportDirectory = new File(reportDirectoryPath);
+		if (!reportDirectory.exists() || !reportDirectory.isDirectory()) {
+			return null;
+		}
+
+		final String prefix = AUTO_RESTANDARDIZATION_REPORT_FILENAME_PREFIX + "-history-" + historyId + "-";
+		File[] reportCandidates = reportDirectory.listFiles((dir, name) ->
+				name != null && name.startsWith(prefix) && name.endsWith(".sdf"));
+
+		if (reportCandidates == null || reportCandidates.length == 0) {
+			return null;
+		}
+
+		File newestReport = Arrays.stream(reportCandidates)
+				.filter(File::isFile)
+				.max(Comparator.comparingLong(File::lastModified))
+				.orElse(null);
+
+		return newestReport == null ? null : newestReport.getAbsolutePath();
 	}
 
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -875,6 +909,12 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 	public List<StandardizationHistory> getStandardizationHistory() {
 		List<StandardizationHistory> standardizationSettingses = StandardizationHistory
 				.findStandardizationHistoryEntries(0, 500, "dateOfStandardization", "DESC");
+		for (StandardizationHistory historyEntry : standardizationSettingses) {
+			Long historyId = historyEntry.getId();
+			boolean reportAvailable = historyId != null
+					&& getAutoRestandardizationDryRunReportFilePath(historyId) != null;
+			historyEntry.setAutoDryRunReportAvailable(reportAvailable);
+		}
 		return standardizationSettingses;
 	}
 

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -3,6 +3,7 @@ package com.labsynch.labseer.service;
 import java.io.File;
 import java.io.IOException;
 import java.text.DecimalFormat;
+import java.text.SimpleDateFormat;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -151,6 +152,8 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 				logger.error("Auto-restandardization: dry run did not complete successfully (status: {}). Skipping execute phase.", dryRunStatus);
 				return;
 			}
+
+			maybeGenerateAutoRestandardizationDryRunReport(latestHistory);
 
 			logger.info("Auto-restandardization: dry run complete, starting standardization execution");
 			executeStandardization("acas", reason);
@@ -386,6 +389,39 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		} catch (IOException e) {
 			logger.warn("Unable to parse standardizer settings while checking readiness. Continuing with normal processing.", e);
 			return true;
+		}
+	}
+
+	private void maybeGenerateAutoRestandardizationDryRunReport(StandardizationHistory latestHistory) {
+		if (!Boolean.TRUE.equals(propertiesUtilService.getAutoRestandardizationReportEnabled())) {
+			return;
+		}
+
+		String reportDirectoryPath = propertiesUtilService.getAutoRestandardizationReportDirectory();
+		String filenamePrefix = propertiesUtilService.getAutoRestandardizationReportFilenamePrefix();
+		if (StringUtils.isBlank(filenamePrefix)) {
+			filenamePrefix = "standardization-dry-run-report";
+		}
+		if (StringUtils.isBlank(reportDirectoryPath)) {
+			reportDirectoryPath = "/tmp";
+		}
+
+		File reportDirectory = new File(reportDirectoryPath);
+		if (!reportDirectory.exists() && !reportDirectory.mkdirs()) {
+			logger.error("Auto-restandardization: failed to create report directory {}. Skipping dry-run report export.", reportDirectory.getAbsolutePath());
+			return;
+		}
+
+		String timestamp = new SimpleDateFormat("yyyyMMdd-HHmmss").format(new Date());
+		String historyId = latestHistory == null || latestHistory.getId() == null ? "unknown" : String.valueOf(latestHistory.getId());
+		String fileName = filenamePrefix + "-history-" + historyId + "-" + timestamp + ".sdf";
+		File reportFile = new File(reportDirectory, fileName);
+
+		try {
+			String outputPath = getStandardizationDryRunReportFiles(reportFile.getAbsolutePath());
+			logger.info("Auto-restandardization: dry-run SDF report generated at {}", outputPath);
+		} catch (Exception e) {
+			logger.error("Auto-restandardization: failed to generate dry-run SDF report at {}", reportFile.getAbsolutePath(), e);
 		}
 	}
 

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -89,6 +89,7 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 	// Use stable Java String hashes from human-readable lock names so lock IDs remain readable and deterministic
 	private static final int ADVISORY_LOCK_NAMESPACE_ACAS = "acas".hashCode();
 	private static final int ADVISORY_LOCK_AUTO_RESTANDARDIZE_STARTUP = "auto-restandardize-startup".hashCode();
+	private static final String AUTO_RESTANDARDIZATION_REPORT_FILENAME_PREFIX = "standardization-dry-run-report";
 
 	private final AtomicBoolean standardizationDryRunRunningInThisWorker = new AtomicBoolean(false);
 	private final AtomicBoolean autoRestandardizationStartupTriggeredInThisWorker = new AtomicBoolean(false);
@@ -398,10 +399,6 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		}
 
 		String reportDirectoryPath = propertiesUtilService.getAutoRestandardizationReportDirectory();
-		String filenamePrefix = propertiesUtilService.getAutoRestandardizationReportFilenamePrefix();
-		if (StringUtils.isBlank(filenamePrefix)) {
-			filenamePrefix = "standardization-dry-run-report";
-		}
 		if (StringUtils.isBlank(reportDirectoryPath)) {
 			reportDirectoryPath = "/tmp";
 		}
@@ -414,7 +411,7 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 
 		String timestamp = new SimpleDateFormat("yyyyMMdd-HHmmss").format(new Date());
 		String historyId = latestHistory == null || latestHistory.getId() == null ? "unknown" : String.valueOf(latestHistory.getId());
-		String fileName = filenamePrefix + "-history-" + historyId + "-" + timestamp + ".sdf";
+		String fileName = AUTO_RESTANDARDIZATION_REPORT_FILENAME_PREFIX + "-history-" + historyId + "-" + timestamp + ".sdf";
 		File reportFile = new File(reportDirectory, fileName);
 
 		try {

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -893,6 +893,13 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			if (stndznHistory == null || stndznHistory.getDryRunStatus() == null || !stndznHistory.getDryRunStatus().equals("running")) {
 				return;
 			}
+			int currentConfigHash = chemStructureService.getStandardizerSettings(true).hashCode();
+			if (stndznHistory.getSettingsHash() != currentConfigHash) {
+				logger.warn("Skipping dry-run processing - config mismatch detected (history hash: {}, current hash: {}). "
+						+ "This pod may have a different configuration than the pod that initiated the dry run. "
+						+ "Waiting for pod to restart with consistent config.", stndznHistory.getSettingsHash(), currentConfigHash);
+				return;
+			}
 			logger.info("Dry run is running, executing dry run process");
 			runDryRun();
 			logger.info("Dry run process completed");

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -115,7 +115,7 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		}
 	}
 
-	private void runAutomaticRestandardizationWithClusterLock() {
+	private void runAutomaticRestandardizationWithClusterLock(String reason) {
 		Connection lockConnection = null;
 		boolean lockAcquired = false;
 		try {
@@ -145,7 +145,7 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			}
 
 			logger.info("Auto-restandardization: dry run complete, starting standardization execution");
-			executeStandardization("acas", "Automatic restandardization triggered on startup");
+			executeStandardization("acas", reason);
 			logger.info("Auto-restandardization completed successfully");
 		} catch (SQLException e) {
 			logger.error("Auto-restandardization skipped because cluster lock could not be acquired via database advisory lock", e);
@@ -222,8 +222,10 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 				logger.warn("Auto-restandardization is enabled but the active chemistry engine does not support it (BBChem required). Skipping automatic restandardization.");
 			} else {
 				logger.info("Auto-restandardization is enabled and restandardization is needed. Starting automatic restandardization in background thread.");
+				String restandardizationReason = standardizationState.getNeedsRestandardizationReasons().stream()
+						.collect(Collectors.joining("; ")) + ". Automatic restandardization triggered on startup.";
 				Thread autoRestandardizationThread = new Thread(() -> {
-					runAutomaticRestandardizationWithClusterLock();
+					runAutomaticRestandardizationWithClusterLock(restandardizationReason);
 				});
 				autoRestandardizationThread.setName("auto-restandardization");
 				autoRestandardizationThread.setDaemon(true);

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -121,21 +121,25 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		if (standardizationState != null
 				&& standardizationState.getNeedsRestandardization()
 				&& propertiesUtilService.getAutoRestandardize()) {
-			logger.info("Auto-restandardization is enabled and restandardization is needed. Starting automatic restandardization in background thread.");
-			Thread autoRestandardizationThread = new Thread(() -> {
-				try {
-					logger.info("Auto-restandardization: starting dry run");
-					executeDryRun();
-					logger.info("Auto-restandardization: dry run complete, starting standardization execution");
-					executeStandardization("acas", "Automatic restandardization triggered on startup");
-					logger.info("Auto-restandardization completed successfully");
-				} catch (Exception e) {
-					logger.error("Auto-restandardization failed", e);
-				}
-			});
-			autoRestandardizationThread.setName("auto-restandardization");
-			autoRestandardizationThread.setDaemon(true);
-			autoRestandardizationThread.start();
+			if (!chemStructureService.supportsAutoRestandardization()) {
+				logger.warn("Auto-restandardization is enabled but the active chemistry engine does not support it (BBChem required). Skipping automatic restandardization.");
+			} else {
+				logger.info("Auto-restandardization is enabled and restandardization is needed. Starting automatic restandardization in background thread.");
+				Thread autoRestandardizationThread = new Thread(() -> {
+					try {
+						logger.info("Auto-restandardization: starting dry run");
+						executeDryRun();
+						logger.info("Auto-restandardization: dry run complete, starting standardization execution");
+						executeStandardization("acas", "Automatic restandardization triggered on startup");
+						logger.info("Auto-restandardization completed successfully");
+					} catch (Exception e) {
+						logger.error("Auto-restandardization failed", e);
+					}
+				});
+				autoRestandardizationThread.setName("auto-restandardization");
+				autoRestandardizationThread.setDaemon(true);
+				autoRestandardizationThread.start();
+			}
 		}
 	}
 

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -82,14 +82,17 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 	@Autowired
 	private DataSource dataSource;
 
-	private static final long AUTO_RESTANDARDIZATION_CLUSTER_LOCK_KEY = 951001L;
+	// Use stable Java String hashes from human-readable lock names so lock IDs remain readable and deterministic
+	private static final int ADVISORY_LOCK_NAMESPACE_ACAS = "acas".hashCode();
+	private static final int ADVISORY_LOCK_AUTO_RESTANDARDIZE_STARTUP = "auto-restandardize-startup".hashCode();
 
 	Boolean standardizationDryRunRunningInThisWorker = false;
 
-	private boolean tryAcquireClusterLock(Connection connection, long lockKey) throws SQLException {
-		String sql = "SELECT pg_try_advisory_lock(?)";
+	private boolean tryAcquireClusterLock(Connection connection, int lockNamespace, int lockId) throws SQLException {
+		String sql = "SELECT pg_try_advisory_lock(?, ?)";
 		try (PreparedStatement statement = connection.prepareStatement(sql)) {
-			statement.setLong(1, lockKey);
+			statement.setInt(1, lockNamespace);
+			statement.setInt(2, lockId);
 			try (ResultSet rs = statement.executeQuery()) {
 				if (rs.next()) {
 					return rs.getBoolean(1);
@@ -99,10 +102,11 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		return false;
 	}
 
-	private void releaseClusterLock(Connection connection, long lockKey) {
-		String sql = "SELECT pg_advisory_unlock(?)";
+	private void releaseClusterLock(Connection connection, int lockNamespace, int lockId) {
+		String sql = "SELECT pg_advisory_unlock(?, ?)";
 		try (PreparedStatement statement = connection.prepareStatement(sql)) {
-			statement.setLong(1, lockKey);
+			statement.setInt(1, lockNamespace);
+			statement.setInt(2, lockId);
 			statement.executeQuery();
 		} catch (SQLException e) {
 			logger.warn("Failed to release auto-restandardization cluster lock", e);
@@ -114,7 +118,11 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		boolean lockAcquired = false;
 		try {
 			lockConnection = dataSource.getConnection();
-			lockAcquired = tryAcquireClusterLock(lockConnection, AUTO_RESTANDARDIZATION_CLUSTER_LOCK_KEY);
+			lockAcquired = tryAcquireClusterLock(
+					lockConnection,
+					ADVISORY_LOCK_NAMESPACE_ACAS,
+					ADVISORY_LOCK_AUTO_RESTANDARDIZE_STARTUP
+			);
 			if (!lockAcquired) {
 				logger.info("Another pod already holds the auto-restandardization startup lock. Skipping startup initiation in this pod.");
 				return;
@@ -143,7 +151,11 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			logger.error("Auto-restandardization failed", e);
 		} finally {
 			if (lockAcquired && lockConnection != null) {
-				releaseClusterLock(lockConnection, AUTO_RESTANDARDIZATION_CLUSTER_LOCK_KEY);
+				releaseClusterLock(
+						lockConnection,
+						ADVISORY_LOCK_NAMESPACE_ACAS,
+						ADVISORY_LOCK_AUTO_RESTANDARDIZE_STARTUP
+				);
 			}
 			if (lockConnection != null) {
 				try {

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -156,7 +156,7 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 				return;
 			}
 
-			generateAutoRestandardizationDryRunReport(latestHistory);
+			generateDryRunReport(latestHistory);
 
 			logger.info("Auto-restandardization: dry run complete, starting standardization execution");
 			executeStandardization("acas", reason);
@@ -395,12 +395,12 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		}
 	}
 
-	private void generateAutoRestandardizationDryRunReport(StandardizationHistory latestHistory) {
-		if (!Boolean.TRUE.equals(propertiesUtilService.getAutoRestandardizationReportEnabled())) {
+	public void generateDryRunReport(StandardizationHistory latestHistory) {
+		if (!Boolean.TRUE.equals(propertiesUtilService.getStandardizationDryRunReportEnabled())) {
 			return;
 		}
 
-		String reportDirectoryPath = propertiesUtilService.getAutoRestandardizationReportDirectory();
+		String reportDirectoryPath = propertiesUtilService.getStandardizationDryRunReportDirectory();
 		if (StringUtils.isBlank(reportDirectoryPath)) {
 			reportDirectoryPath = "/tmp";
 		}
@@ -430,7 +430,7 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			return null;
 		}
 
-		String reportDirectoryPath = propertiesUtilService.getAutoRestandardizationReportDirectory();
+		String reportDirectoryPath = propertiesUtilService.getStandardizationDryRunReportDirectory();
 		if (StringUtils.isBlank(reportDirectoryPath)) {
 			reportDirectoryPath = "/tmp";
 		}

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -156,7 +156,7 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 				return;
 			}
 
-			maybeGenerateAutoRestandardizationDryRunReport(latestHistory);
+			generateAutoRestandardizationDryRunReport(latestHistory);
 
 			logger.info("Auto-restandardization: dry run complete, starting standardization execution");
 			executeStandardization("acas", reason);
@@ -395,7 +395,7 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 		}
 	}
 
-	private void maybeGenerateAutoRestandardizationDryRunReport(StandardizationHistory latestHistory) {
+	private void generateAutoRestandardizationDryRunReport(StandardizationHistory latestHistory) {
 		if (!Boolean.TRUE.equals(propertiesUtilService.getAutoRestandardizationReportEnabled())) {
 			return;
 		}

--- a/src/main/java/com/labsynch/labseer/utils/PropertiesUtilService.java
+++ b/src/main/java/com/labsynch/labseer/utils/PropertiesUtilService.java
@@ -147,4 +147,10 @@ public interface PropertiesUtilService {
 
 	Boolean getAutoRestandardize();
 
+	Boolean getAutoRestandardizationReportEnabled();
+
+	String getAutoRestandardizationReportDirectory();
+
+	String getAutoRestandardizationReportFilenamePrefix();
+
 }

--- a/src/main/java/com/labsynch/labseer/utils/PropertiesUtilService.java
+++ b/src/main/java/com/labsynch/labseer/utils/PropertiesUtilService.java
@@ -145,4 +145,6 @@ public interface PropertiesUtilService {
 
 	long getCheckForDryRunStandardizationDelay();
 
+	Boolean getAutoRestandardize();
+
 }

--- a/src/main/java/com/labsynch/labseer/utils/PropertiesUtilService.java
+++ b/src/main/java/com/labsynch/labseer/utils/PropertiesUtilService.java
@@ -151,6 +151,4 @@ public interface PropertiesUtilService {
 
 	String getAutoRestandardizationReportDirectory();
 
-	String getAutoRestandardizationReportFilenamePrefix();
-
 }

--- a/src/main/java/com/labsynch/labseer/utils/PropertiesUtilService.java
+++ b/src/main/java/com/labsynch/labseer/utils/PropertiesUtilService.java
@@ -147,8 +147,8 @@ public interface PropertiesUtilService {
 
 	Boolean getAutoRestandardize();
 
-	Boolean getAutoRestandardizationReportEnabled();
+	Boolean getStandardizationDryRunReportEnabled();
 
-	String getAutoRestandardizationReportDirectory();
+	String getStandardizationDryRunReportDirectory();
 
 }

--- a/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
@@ -1000,4 +1000,40 @@ public class PropertiesUtilServiceImpl implements PropertiesUtilService {
 		return this.autoRestandardize;
 	}
 
+	boolean autoRestandardizationReportEnabled;
+
+	@Value("${client.cmpdreg.serverSettings.autoRestandardizationReportEnabled:false}")
+	public void setAutoRestandardizationReportEnabled(boolean autoRestandardizationReportEnabled) {
+		this.autoRestandardizationReportEnabled = autoRestandardizationReportEnabled;
+	}
+
+	@Override
+	public Boolean getAutoRestandardizationReportEnabled() {
+		return this.autoRestandardizationReportEnabled;
+	}
+
+	String autoRestandardizationReportDirectory;
+
+	@Value("${client.cmpdreg.serverSettings.autoRestandardizationReportDirectory:/tmp}")
+	public void setAutoRestandardizationReportDirectory(String autoRestandardizationReportDirectory) {
+		this.autoRestandardizationReportDirectory = autoRestandardizationReportDirectory;
+	}
+
+	@Override
+	public String getAutoRestandardizationReportDirectory() {
+		return this.autoRestandardizationReportDirectory;
+	}
+
+	String autoRestandardizationReportFilenamePrefix;
+
+	@Value("${client.cmpdreg.serverSettings.autoRestandardizationReportFilenamePrefix:standardization-dry-run-report}")
+	public void setAutoRestandardizationReportFilenamePrefix(String autoRestandardizationReportFilenamePrefix) {
+		this.autoRestandardizationReportFilenamePrefix = autoRestandardizationReportFilenamePrefix;
+	}
+
+	@Override
+	public String getAutoRestandardizationReportFilenamePrefix() {
+		return this.autoRestandardizationReportFilenamePrefix;
+	}
+
 }

--- a/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
@@ -1024,16 +1024,4 @@ public class PropertiesUtilServiceImpl implements PropertiesUtilService {
 		return this.autoRestandardizationReportDirectory;
 	}
 
-	String autoRestandardizationReportFilenamePrefix;
-
-	@Value("${client.cmpdreg.serverSettings.autoRestandardizationReportFilenamePrefix:standardization-dry-run-report}")
-	public void setAutoRestandardizationReportFilenamePrefix(String autoRestandardizationReportFilenamePrefix) {
-		this.autoRestandardizationReportFilenamePrefix = autoRestandardizationReportFilenamePrefix;
-	}
-
-	@Override
-	public String getAutoRestandardizationReportFilenamePrefix() {
-		return this.autoRestandardizationReportFilenamePrefix;
-	}
-
 }

--- a/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
@@ -988,4 +988,16 @@ public class PropertiesUtilServiceImpl implements PropertiesUtilService {
 		return this.checkForDryRunStandardizationDelay;
 	}
 
+	boolean autoRestandardize;
+
+	@Value("${client.cmpdreg.serverSettings.autoRestandardize:false}")
+	public void setAutoRestandardize(boolean autoRestandardize) {
+		this.autoRestandardize = autoRestandardize;
+	}
+
+	@Override
+	public Boolean getAutoRestandardize() {
+		return this.autoRestandardize;
+	}
+
 }

--- a/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
@@ -1002,7 +1002,7 @@ public class PropertiesUtilServiceImpl implements PropertiesUtilService {
 
 	boolean autoRestandardizationReportEnabled;
 
-	@Value("${client.cmpdreg.serverSettings.autoRestandardizationReportEnabled:false}")
+	@Value("${client.cmpdreg.serverSettings.autoRestandardizationReportEnabled:true}")
 	public void setAutoRestandardizationReportEnabled(boolean autoRestandardizationReportEnabled) {
 		this.autoRestandardizationReportEnabled = autoRestandardizationReportEnabled;
 	}
@@ -1014,7 +1014,7 @@ public class PropertiesUtilServiceImpl implements PropertiesUtilService {
 
 	String autoRestandardizationReportDirectory;
 
-	@Value("${client.cmpdreg.serverSettings.autoRestandardizationReportDirectory:/tmp}")
+	@Value("${client.cmpdreg.serverSettings.autoRestandardizationReportDirectory:/home/runner/build/privateUploads/cmpdreg/standardizationReports/}")
 	public void setAutoRestandardizationReportDirectory(String autoRestandardizationReportDirectory) {
 		this.autoRestandardizationReportDirectory = autoRestandardizationReportDirectory;
 	}

--- a/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/utils/PropertiesUtilServiceImpl.java
@@ -1000,28 +1000,28 @@ public class PropertiesUtilServiceImpl implements PropertiesUtilService {
 		return this.autoRestandardize;
 	}
 
-	boolean autoRestandardizationReportEnabled;
+	boolean standardizationDryRunReportEnabled;
 
-	@Value("${client.cmpdreg.serverSettings.autoRestandardizationReportEnabled:true}")
-	public void setAutoRestandardizationReportEnabled(boolean autoRestandardizationReportEnabled) {
-		this.autoRestandardizationReportEnabled = autoRestandardizationReportEnabled;
+	@Value("${client.cmpdreg.serverSettings.standardizationDryRunReportEnabled:true}")
+	public void setStandardizationDryRunReportEnabled(boolean standardizationDryRunReportEnabled) {
+		this.standardizationDryRunReportEnabled = standardizationDryRunReportEnabled;
 	}
 
 	@Override
-	public Boolean getAutoRestandardizationReportEnabled() {
-		return this.autoRestandardizationReportEnabled;
+	public Boolean getStandardizationDryRunReportEnabled() {
+		return this.standardizationDryRunReportEnabled;
 	}
 
-	String autoRestandardizationReportDirectory;
+	String standardizationDryRunReportDirectory;
 
-	@Value("${client.cmpdreg.serverSettings.autoRestandardizationReportDirectory:/home/runner/build/privateUploads/cmpdreg/standardizationReports/}")
-	public void setAutoRestandardizationReportDirectory(String autoRestandardizationReportDirectory) {
-		this.autoRestandardizationReportDirectory = autoRestandardizationReportDirectory;
+	@Value("${client.cmpdreg.serverSettings.standardizationDryRunReportDirectory:/home/runner/build/privateUploads/cmpdreg/standardizationReports/}")
+	public void setStandardizationDryRunReportDirectory(String standardizationDryRunReportDirectory) {
+		this.standardizationDryRunReportDirectory = standardizationDryRunReportDirectory;
 	}
 
 	@Override
-	public String getAutoRestandardizationReportDirectory() {
-		return this.autoRestandardizationReportDirectory;
+	public String getStandardizationDryRunReportDirectory() {
+		return this.standardizationDryRunReportDirectory;
 	}
 
 }


### PR DESCRIPTION
## Summary

Implements ACAS-951 startup auto-restandardization with Kubernetes-safe coordination and rollout hardening, plus auto dry-run report retrieval support.

## Companion PR

This server-side implementation is paired with the ACAS UI/config PR:
- https://github.com/mcneilco/acas/pull/1243

## What Changed

- Adds startup auto-restandardization orchestration in StandardizationServiceImpl.
- Coordinates startup initiation across pods with PostgreSQL advisory locking.
- Adds worker settings-hash guard so mixed-generation pods skip incompatible dry-run work.
- Adds readiness gating so workers wait for standardizer actions initialization before attempting hash-match participation.
- Adds duplicate reservation race tolerance during dry-run population.
- Adds auto dry-run report support:
  - deterministic report naming by history id,
  - endpoint to download report by history id,
  - report-availability flag on history rows (used by ACAS UI to avoid dead links).

## Detailed Rollout Analysis (from summary-sofar)

### Environment setup used to reproduce and verify mixed rollout behavior

- Forced slower processing to make worker behavior visible:
  - client.cmpdreg.serverSettings.checkForDryRunStandardizationDelay=1000
  - externalStructureProcessingBatchSize: 1
  - standardizationBatchSize: 1
- Verified initial config consistency across running pods:
  - ConfigMap hash scheme: ALL_LAYERS
  - Pod-local conf.properties hash scheme: ALL_LAYERS
- Tailed live pod logs through rolling replacement while changing hash scheme to TAUTOMER_INSENSITIVE_LAYERS.

### Observed rollout sequence

- After ConfigMap update, old and new generations briefly coexisted as expected.
- New pods came online with TAUTOMER_INSENSITIVE_LAYERS while old pods still had ALL_LAYERS.
- Log stream showed expected pod churn: old generation terminating, new generation scaling up.

### What I tested (latest rerun)

- Confirmed startup lock coordination still works:
  - Pod acas-59d6c946fd-kn227 acquired startup cluster lock at 18:22:27.
- Confirmed dry-run history initialization captured expected settings snapshot:
  - historyId=18, settingsHash=810646643, hash_scheme=TAUTOMER_INSENSITIVE_LAYERS.
- Confirmed old-generation pods were correctly excluded:
  - Pod acas-7c855d8599-l7b7j repeatedly logged config mismatch for historyId=18.
  - Mismatch was expected: history hash 810646643 vs pod hash 2081901503 (ALL_LAYERS).
- Confirmed readiness check behavior:
  - New pods first logged readiness wait (standardizer actions are not initialized yet), then joined normally.
  - Examples:
    - acas-59d6c946fd-p7z8g: waits at 18:23:01 and 18:23:02, match at 18:23:03.
    - acas-59d6c946fd-cbvv5: waits at 18:23:47 and 18:23:48, match at 18:23:49.
- Confirmed multi-pod participation and race tolerance:
  - Multiple workers processed batches.
  - Duplicate reservation warnings occurred but processing continued without abort.
- Confirmed end-to-end completion:
  - Dry run completed at 18:23:53.
  - Execute phase started immediately.
  - Auto-restandardization completed successfully at 18:24:41.

## Conclusion

- Readiness gating fixed transient startup false negatives: pods now wait and then join, instead of being misclassified while initializing.
- Settings-hash guard continues to block truly incompatible old-generation workers.
- Mixed rollout behavior is now robust and completes successfully end-to-end.

## How startup cluster lock works

1. A pod opens a dedicated DB connection.
2. It attempts non-blocking advisory lock acquire using string-derived lock ids.
3. If lock is not acquired, that pod exits startup initiation.
4. Lock holder runs: fail stale runs, dry run, verify completion, execute.
5. In finally: advisory unlock attempt plus connection close (session-scoped safety).

This ensures a single startup coordinator pod while preserving distributed dry-run worker processing.


## Detailed testing notes

Building:
acas
```
export DOCKER_HOST=tcp://containerbuilder.onschrodinger.com:23755 SSH_AUTH_SOCK=~/.ssh/ssh_auth_sock && docker build -t mcneilco/acas-oss:$USER .
```

acas-roo-server:
```
export DOCKER_HOST=tcp://containerbuilder.onschrodinger.com:23755 SSH_AUTH_SOCK=~/.ssh/ssh_auth_sock && docker build --build-arg CHEMISTRY_PACKAGE=bbchem -f Dockerfile-multistage -t mcneilco/acas-roo-server-oss:$USER-bbchem .
```

Added these builds to the acas_custom_schrodinger Dockerfiles for roo and acas
Loaded 1000 compounds with stereo category unknown
Then again same file with another stereo to make 2k compounds.


In overrides.yaml added this to make it take a while to restandardize.
```
acas:
  configs:
    client:
      cmpdreg:
        serverSettings:
          checkForDryRunStandardizationDelay: 1000
    server:
      acas:
        externalStructureProcessingBatchSize: 1
        standardizationBatchSize: 1
```

make init

Loaded 1000 compounds with stereo category unknown
Then again same file with another stereo to make 2k compounds.

Requires kubectl krew (plugins)
```
kubectl krew install stern 
```

Functions to log all pods instead of just one:
```
klogpod () {
 APP=$1 
 local CONTAINER=$2 
 local context=$(kubectl config current-context) 
 local PROJECT_ID=$(echo $context | cut -d'_' -f2) 
 local REGION=$(echo $context | cut -d'_' -f3) 
 local CLUSTER=$(echo $context | cut -d'_' -f4-) 
 local QUERY="resource.type=\"k8s_container\" AND resource.labels.cluster_name=\"${CLUSTER}\" AND resource.labels.pod_name=~\"^${APP}\"" 
 if [[ -n "$CONTAINER" ]]
 then
  QUERY="$QUERY AND resource.labels.container_name=\"${CONTAINER}\"" 
 fi
 echo "tailing with query: $QUERY"
 gcloud beta logging tail "$QUERY" --project="$PROJECT_ID" --format='value(timestamp,resource.labels.pod_name,resource.labels.container_name,textPayload)'
}
klogacas () {
 klogpod acas
}
```


With these pods runnings:

```
echo "== configmap =="
kubectl get cm acas-env -o jsonpath='{.data.ACAS_CLIENT_CMPDREG_SERVERSETTINGS_LIVEDESIGN_PREPROCESSORSETTINGS}' | jq '.process_options.hash_scheme'
for pod in $(kubectl get pods -l app.kubernetes.io/name=acas -o jsonpath='{.items[*].metadata.name}'); do
  echo "=== $pod ==="
  kubectl exec "$pod" -c acas -- cat conf/compiled/conf.properties \
    | grep hash_scheme \
    | sed 's/^[^=]*=//' \
    | jq '.process_options.hash_scheme'
done
== configmap ==
"ALL_LAYERS"
=== acas-7c855d8599-l7b7j ===
"ALL_LAYERS"
=== acas-7c855d8599-wb8f6 ===
"ALL_LAYERS"

```

And tailing logs like this (which outputs to stderr the pods starting and stopping.

```
klogacas roo > /tmp/output.txt
+ acas-7c855d8599-l7b7j › roo
+ acas-7c855d8599-wb8f6 › roo
```

Flipped the hash scheme back and forth and watched as things restandardized (had to save values.yaml a few times to get things rolling:
https://github.com/schrodinger/acas_custom_schrodinger/blob/fe1fd0e183b0c078715a44b28f35eaecf9965330/helm/values.yaml#L235

Update the config map to a different has scheme (TAUTOMER_INSENSITIVE_LAYERS)

config map changes take effect:

```
== configmap ==
"TAUTOMER_INSENSITIVE_LAYERS"
=== acas-59d6c946fd-kn227 ===
"TAUTOMER_INSENSITIVE_LAYERS"
=== acas-7c855d8599-l7b7j ===
"ALL_LAYERS"
```


logging also shows new pod generation coming on line and adding additional workers:
```
klogacas roo > /tmp/output.txt
+ acas-7c855d8599-l7b7j › roo
+ acas-7c855d8599-wb8f6 › roo
- acas-7c855d8599-wb8f6 › roo
+ acas-59d6c946fd-kn227 › roo
- acas-7c855d8599-l7b7j › roo
+ acas-59d6c946fd-p7z8g › roo
+ acas-59d6c946fd-cbvv5 › roo
+ acas-59d6c946fd-9jf82 › roo
```


Output analyzed by claude: [output.txt](https://github.com/user-attachments/files/26473289/output.txt)


```
I finished parsing the filtered run output and extracted the latest rollout sequence. Next I’ll give you a ready-to-paste What I’ve tested section with concrete evidence and a short conclusion on what this rerun proves.What I’ve tested (latest rerun)
	•	Verified startup lock behavior:
	◦	One pod acquired the startup cluster lock and initiated auto-restandardization.
	◦	Other pods logged that startup initiation was skipped because lock was already held.
	•	Verified dry-run history initialization captured full settings:
	◦	New dry run history (historyId 17) was initialized with hash 2081901503 and hash_scheme ALL_LAYERS.
	•	Verified config-mismatch guard during mixed rollout generations:
	◦	Old generation pods (5c549b49f8-*) repeatedly skipped dry-run processing due to hash mismatch against historyId 17.
	◦	Their current settings showed TAUTOMER_INSENSITIVE_LAYERS while history expected ALL_LAYERS.
	◦	This confirms old-config pods were blocked from participating.
	•	Verified transient startup instability still occurs on new pods:
	◦	Newly started same-generation pods initially reported mismatch with current settings showing standardizer_actions null.
	◦	After initialization completed, those same pods later logged settings match and started processing dry-run work.
	◦	This reproduces the timing window where effective settings are temporarily incomplete.
	•	Verified multi-pod participation after stabilization:
	◦	Multiple new-generation pods eventually logged Dry-run worker settings match and executed dry-run processing.
	•	Verified duplicate reservation race is now tolerated:
	◦	Many duplicate parent reservation warnings occurred across workers.
	◦	Dry run still progressed to completion instead of failing, confirming retry behavior is active.
	•	Verified full end-to-end completion:
	◦	Dry run transitioned to complete.
	◦	Auto execution started, restandardization ran, and completed successfully.
	◦	Final success log for auto-restandardization was present.
Conclusion
	•	The guard is working as intended for mixed config rollouts.
	•	The duplicate reservation retries prevent run abortion under contention.
	•	The remaining issue is the transient standardizer_actions null window during pod startup, which temporarily blocks otherwise-correct same-generation pods until initialization settles.
If you want, I can draft a second section for your notes called Remaining Risk / Follow-up that proposes one concrete mitigation (readiness gate or delayed scheduler start) in 3-4 bullets.


```

