### PR TITLE
ACAS-988: Migrate roo runtime to minimal pinned glibc base (debian:12-slim)

### DIFF
--- a/Dockerfile-multistage
+++ b/Dockerfile-multistage
@@ -1,7 +1,11 @@
 ARG 	CHEMISTRY_PACKAGE=bbchem
-ARG     NODE_VERSION=20
-FROM maven:3-eclipse-temurin-21 AS builder
+ARG     NODE_VERSION=20.20.2
+ARG     TOMCAT_VERSION=10.1.55
+FROM maven:3.9.9-eclipse-temurin-21 AS builder
+# glibc node (Debian) so it matches the debian-slim runtime below
 FROM node:${NODE_VERSION}-slim AS node
+# Pinned source of the Temurin JRE + Tomcat distribution (copied into the runtime)
+FROM tomcat:${TOMCAT_VERSION}-jre21-temurin AS tomcat
 
 FROM 	builder AS compile
 ARG     CHEMISTRY_PACKAGE
@@ -13,29 +17,43 @@ WORKDIR /src
 RUN 	--mount=type=cache,target=/root/.m2 mvn dependency:resolve -P ${CHEMISTRY_PACKAGE}  -s /settings.xml
 ADD 	. /src
 
-# Slow Step - Caching this Layer Greatly Improves Build Time  (~6x Faster) 
+# Slow Step - Caching this Layer Greatly Improves Build Time  (~6x Faster)
 RUN 	--mount=type=cache,target=/root/.m2 mvn clean && \
-        mvn compile war:war -P ${CHEMISTRY_PACKAGE} 
+        mvn compile war:war -P ${CHEMISTRY_PACKAGE}
 
-FROM tomcat:10.1-jdk21-temurin
+# =============================================================================
+# Runtime: minimal Debian-slim (glibc) + Temurin JRE + Tomcat copied from the
+# pinned official image. glibc (not Alpine/musl) is required so the native
+# chemistry libraries (libindigo.so, bbchem/jchem) load via JNA at runtime.
+# =============================================================================
+FROM debian:12-slim
 
-# Third and Last Step That Requires Significant (Relative) Amount of Time 
-RUN apt-get update && \
-    apt-get install -y \
-      curl \ 
-      libfreetype6 \
-      libfontconfig \
-      openssl 
-    
-# Add nodejs for prepare config files - copy from official image to avoid SSL issues with nodesource
-COPY --from=node /usr/local/include/node /usr/local/include/node
-COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+# Temurin JRE + Tomcat distribution from the pinned official image
+ENV JAVA_HOME=/opt/java/openjdk
+ENV CATALINA_HOME=/usr/local/tomcat
+ENV PATH=$JAVA_HOME/bin:$CATALINA_HOME/bin:$PATH
+COPY --from=tomcat /opt/java/openjdk /opt/java/openjdk
+COPY --from=tomcat /usr/local/tomcat /usr/local/tomcat
+RUN mkdir -p "$CATALINA_HOME/logs" "$CATALINA_HOME/temp" "$CATALINA_HOME/work"
+WORKDIR $CATALINA_HOME
+
+# Runtime deps: bash for entrypoint/catalina + wait-for-it, freetype/fontconfig
+# for chemistry structure depiction, openssl/curl for TLS + readiness checks,
+# libstdc++6/libgomp1 for the native chemistry libraries.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash curl openssl ca-certificates \
+      libfreetype6 libfontconfig1 fontconfig fonts-dejavu \
+      libstdc++6 libgomp1 \
+  && rm -rf /var/lib/apt/lists/*
+
+# Add nodejs for prepare config files - copy from the official (glibc) slim image
 COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
 
 ENV NPM_CONFIG_LOGLEVEL=warn
 
-# Second Slowest Step 
+# Second Slowest Step
 RUN npm install -g \
     coffeescript@2.5.1 \
     dotenv@10.0.0 \
@@ -50,8 +68,7 @@ RUN npm install -g \
 ENV NODE_PATH=/usr/local/lib/node_modules
 
 # Add runner user so we don't run as root
-RUN	userdel -r ubuntu && \
-  useradd -u 1000 -ms /bin/bash runner && \
+RUN	useradd -u 1000 -ms /bin/bash runner && \
   chown -R runner:runner /usr/local/tomcat/
 
 # Allow certificates to be added by runner
@@ -67,7 +84,6 @@ COPY 	--chown=runner:runner --from=compile /src/target/acas* /usr/local/tomcat/w
 # Wait for it startup script
 COPY 	--chown=runner:runner wait-for-it.sh ./wait-for-it.sh
 RUN 	chmod 755 wait-for-it.sh
-WORKDIR $CATALINA_HOME
 ENV    ACAS_HOME=/home/runner/build
 ENV    CATALINA_OPTS="-Xms512M -Xmx1536M"
 
@@ -79,5 +95,5 @@ USER runner
 
 # Setup entrypoint
 COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/bin/bash", "/entrypoint.sh"] 
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 CMD 	["catalina.sh", "run"]


### PR DESCRIPTION
## Problem
The roo runtime base `tomcat:10.1-jdk21-temurin` is a full Ubuntu image, uses the JDK (not JRE), and is unpinned (floats the patch) — violating the [container image security baselines](https://schrodinger.atlassian.net/wiki/spaces/LDE/pages/1940160531) (minimal, version-pinned runtime). Build-stage bases (`maven:3-eclipse-temurin-21`, `node:20-slim`) were also unpinned.

## Change
- **Runtime → `debian:12-slim`** with the Temurin **JRE** + Tomcat copied from the pinned `tomcat:10.1.55-jre21-temurin` image. `-slim` is baseline-compliant.
- **glibc is required, not Alpine.** Indigo's native chemistry library (`libindigo.so`) is glibc-linked in every published version (verified: imports `GLIBC_2.x`, needs `libc.so.6`/`libgcc_s.so.1`; EPAM publishes no musl/Alpine build). An Alpine attempt deployed but the `/acas` context failed to start because JNA could not load `libindigo.so` on musl. `debian:12-slim` keeps glibc while still being minimal. `libstdc++6`/`libgomp1` are installed for the native chem libs; `node` is sourced from the glibc `node:20.20.2-slim`.
- **Build stages pinned:** `maven:3.9.9-eclipse-temurin-21`, node `20.20.2`.

## Testing
Built with `-P indigo` and run via docker-compose: roo deploys `/acas`, indigo loads, and `GET /acas/api/v1/protocoltypes` returns 200.

also ran acasclient tests

also ran bbchem flavor + acas loader files which do a bulk load against bbchem.
as part of that test ran open in LiveDesign button and also made sure curve rendering worked inline in LiveDesign.


Part of ACAS-988.