### PR TITLE
ACAS-951: Fix dry-run restandardization deadlocks (stale snapshot + cross-replica DB deadlock)

### DIFF
--- a/src/main/java/com/labsynch/labseer/domain/StandardizationDryRunCompound.java
+++ b/src/main/java/com/labsynch/labseer/domain/StandardizationDryRunCompound.java
@@ -151,6 +151,16 @@ public class StandardizationDryRunCompound {
 				.intValue();
 	}
 
+	/**
+	 * Latest qc_date across all dry-run compounds, i.e. when the most recent populate batch was
+	 * written. Used as a liveness/progress signal for the active dry run (null if the table is empty).
+	 */
+	public static Date findLatestQcDate() {
+		return StandardizationDryRunCompound.entityManager()
+				.createQuery("SELECT max(o.qcDate) FROM StandardizationDryRunCompound o", Date.class)
+				.getSingleResult();
+	}
+
 	public StandardizationHistory fetchStats() {
 		StandardizationHistory stats = new StandardizationHistory();
 		stats.setStructuresStandardizedCount(toIntExact(StandardizationDryRunCompound.entityManager()

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -922,16 +922,17 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 	private StandardizationHistory setCurrentStandardizationDryRunStatus(String status) throws StandardizerException {
 		StandardizationHistory stndznHistory = getMostRecentStandardizationHistory();
 		StandardizerSettingsConfigDTO standardizationSettings = chemStructureService.getStandardizerSettings(true);
+		Date now = new Date();
 		if (stndznHistory == null
 				|| StringUtils.equalsIgnoreCase(stndznHistory.getStandardizationStatus(), "complete")) {
 			stndznHistory = new StandardizationHistory();
-			stndznHistory.setSettings(standardizationSettings.toJson());
-			stndznHistory.setSettingsHash(standardizationSettings.hashCode());
-			stndznHistory.setRecordedDate(new Date());
+			stndznHistory.setRecordedDate(now);
 		}
-		stndznHistory.setDryRunStatus(status);
-		stndznHistory.setDryRunStart(new Date());
-		stndznHistory.setDryRunComplete(null);
+		// Always snapshot the initiating pod's current settings for the dry run being (re)started.
+		// Reusing an incomplete prior record must NOT keep its stale snapshot, otherwise worker pods
+		// in runDryRunCriticalSection compare against a config that no longer exists and skip forever
+		// ("config mismatch") -- e.g. after a chemistry suite version bump (Build 058 -> Build 073).
+		applyDryRunInitialization(stndznHistory, standardizationSettings, status, now);
 		stndznHistory.persist();
 		logger.info(
 				"Initialized dry-run history settings snapshot: pod={}, historyId={}, status={}, settingsHash={}, settings={}",
@@ -942,6 +943,21 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 				stndznHistory.getSettings()
 		);
 		return stndznHistory;
+	}
+
+	/**
+	 * Applies the dry-run initialization snapshot to a history record. Pure (no DB/chemistry-engine
+	 * dependency) and package-private so it can be unit-tested without a Spring context. The settings
+	 * snapshot is what worker pods compare their live config against, so it must always reflect the
+	 * config of the run being initiated -- never a stale snapshot from a reused, incomplete record.
+	 */
+	static void applyDryRunInitialization(StandardizationHistory history,
+			StandardizerSettingsConfigDTO settings, String status, Date dryRunStart) {
+		history.setSettings(settings.toJson());
+		history.setSettingsHash(settings.hashCode());
+		history.setDryRunStatus(status);
+		history.setDryRunStart(dryRunStart);
+		history.setDryRunComplete(null);
 	}
 
 	@Override

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -963,16 +963,20 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 
 	@Override
 	public void executeDryRun() throws CmpdRegMolFormatException, IOException, StandardizerException {
-		// Initiator path (manual endpoint / startup auto-restandardization): reset + mark running, then run.
-		runDryRunCriticalSection(true);
+		// Initiator path (manual endpoint / startup auto-restandardization): start a fresh dry run if one
+		// isn't already active (cluster-serialized), then cooperatively participate in populating it.
+		initiateDryRunIfIdle();
+		participateInDryRun();
 	}
 
 	private void runDryRun() throws CmpdRegMolFormatException, IOException, StandardizerException {
+		// Population is cooperative across replicas (SELECT ... FOR UPDATE SKIP LOCKED), so it runs
+		// WITHOUT the cluster lock -- every pod claims disjoint batches of parents in parallel.
 		logger.info("step 2/3: populating dry run table");
 		populateStandardizationDryRunTable();
-		logger.info("step 3/3: checking for standardization duplicates");
-		dupeCheckStandardizationStructures();
-		finalizeDryRun("complete");
+		// Finishing (duplicate check + finalize) mutates shared rows, so it is serialized cluster-wide;
+		// only the first pod to drain the queue performs it.
+		finishDryRunUnderClusterLock();
 	}
 
 	@Transactional
@@ -1018,27 +1022,21 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 
 	@Scheduled(fixedDelayString = "${client.cmpdreg.serverSettings.checkForDryRunStandardizationDelay:60000}")
 	public void checkForDryRunStandardization() throws CmpdRegMolFormatException, IOException, StandardizerException {
-		// Scheduled worker path: only participate in an already-running dry run; never initiate.
-		runDryRunCriticalSection(false);
+		// Scheduled worker path on every replica: cooperatively participate in an already-running dry
+		// run; never initiate.
+		participateInDryRun();
 	}
 
 	/**
-	 * Runs the dry-run execution critical section under BOTH a per-pod re-entrancy flag and a
-	 * cluster-wide Postgres advisory lock, so only one worker across all replicas can reset/populate
-	 * the shared dry-run tables at a time. Concurrent execution caused TRUNCATE-vs-INSERT deadlocks
-	 * (standardization_dry_run_compound AccessExclusiveLock vs bbchem_standardization_dry_run_structure
-	 * RowExclusiveLock) that aborted transactions and marked the run failed.
-	 *
-	 * @param initiate true for the manual/startup initiator (reset tables and mark the history
-	 *                 "running" before running); false for the scheduled worker (participate only).
+	 * Starts a new dry run (reset tables + mark history "running") ONLY if no dry run is currently
+	 * active, guarded by a cluster-wide Postgres advisory lock so exactly one replica can initiate at a
+	 * time. This is the only place that resets/truncates the shared dry-run tables, and it never runs
+	 * while a dry run is active -- which prevents the reset() TRUNCATE from deadlocking against the
+	 * cooperative INSERTs of an in-flight run, and prevents two initiators from clashing on the history
+	 * record (optimistic-lock failure). Population is intentionally NOT held under this lock, so all
+	 * replicas populate in parallel via SELECT ... FOR UPDATE SKIP LOCKED.
 	 */
-	private void runDryRunCriticalSection(boolean initiate)
-			throws CmpdRegMolFormatException, IOException, StandardizerException {
-		// Avoid running the process if we are already in the middle of a dry run on this worker
-		// (manual call overlapping the scheduler, or a run that takes longer than the schedule delay).
-		if (!standardizationDryRunRunningInThisWorker.compareAndSet(false, true)) {
-			return;
-		}
+	private void initiateDryRunIfIdle() throws StandardizerException {
 		Connection lockConnection = null;
 		boolean lockAcquired = false;
 		try {
@@ -1049,19 +1047,40 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 					ADVISORY_LOCK_DRY_RUN_EXECUTION
 			);
 			if (!lockAcquired) {
-				logger.info("Another pod holds the dry-run execution lock; skipping dry-run work in this pod: pod={}, initiate={}",
-						getPodName(), initiate);
+				logger.info("Another pod is initiating/finalizing a dry run; skipping initiation in this pod: pod={}", getPodName());
 				return;
 			}
-
-			if (initiate) {
-				logger.info("standardization dry run initialized");
-				logger.info("step 1/3: resetting dry run table");
-				reset();
-				logger.info("setting dry run standardization status to running");
-				setCurrentStandardizationDryRunStatus("running");
+			StandardizationHistory stndznHistory = getMostRecentStandardizationHistory();
+			if (stndznHistory != null && "running".equals(stndznHistory.getDryRunStatus())) {
+				logger.info("A dry run is already running (historyId={}); not resetting. This pod will join the active run.",
+						stndznHistory.getId());
+				return;
 			}
+			logger.info("standardization dry run initialized");
+			logger.info("step 1/3: resetting dry run table");
+			reset();
+			logger.info("setting dry run standardization status to running");
+			setCurrentStandardizationDryRunStatus("running");
+		} catch (SQLException e) {
+			throw new StandardizerException(e);
+		} finally {
+			releaseDryRunClusterLock(lockConnection, lockAcquired);
+		}
+	}
 
+	/**
+	 * Cooperatively participates in the currently-running dry run: claims and standardizes batches of
+	 * parents (SELECT ... FOR UPDATE SKIP LOCKED) so multiple replicas process disjoint compounds in
+	 * parallel. Guarded only by a per-pod re-entrancy flag (NO cluster lock) so replicas run together.
+	 * No-op when no dry run is running or this pod's config doesn't match the run's snapshot.
+	 */
+	private void participateInDryRun() throws CmpdRegMolFormatException, IOException, StandardizerException {
+		// Avoid running multiple participations in parallel within this worker (manual call overlapping
+		// the scheduler, or a run that takes longer than the schedule delay).
+		if (!standardizationDryRunRunningInThisWorker.compareAndSet(false, true)) {
+			return;
+		}
+		try {
 			StandardizationHistory stndznHistory = getMostRecentStandardizationHistory();
 			if (stndznHistory == null || stndznHistory.getDryRunStatus() == null
 					|| !stndznHistory.getDryRunStatus().equals("running")) {
@@ -1120,21 +1139,59 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			}
 			throw new StandardizerException(e);
 		} finally {
-			if (lockAcquired && lockConnection != null) {
-				releaseClusterLock(
-						lockConnection,
-						ADVISORY_LOCK_NAMESPACE_ACAS,
-						ADVISORY_LOCK_DRY_RUN_EXECUTION
-				);
-			}
-			if (lockConnection != null) {
-				try {
-					lockConnection.close();
-				} catch (SQLException e) {
-					logger.warn("Failed to close dry-run execution lock connection", e);
-				}
-			}
 			standardizationDryRunRunningInThisWorker.set(false);
+		}
+	}
+
+	/**
+	 * Runs the finishing steps (duplicate check + finalize to "complete") under the cluster-wide
+	 * advisory lock, so that with cooperative multi-replica population exactly one pod performs the
+	 * shared mutating finish work. Other pods that have also drained the queue find the run already
+	 * finalized (or the lock held) and skip. Only meaningful once population is complete.
+	 */
+	private void finishDryRunUnderClusterLock() throws StandardizerException {
+		Connection lockConnection = null;
+		boolean lockAcquired = false;
+		try {
+			lockConnection = dataSource.getConnection();
+			lockAcquired = tryAcquireClusterLock(
+					lockConnection,
+					ADVISORY_LOCK_NAMESPACE_ACAS,
+					ADVISORY_LOCK_DRY_RUN_EXECUTION
+			);
+			if (!lockAcquired) {
+				logger.info("Another pod is finalizing the dry run; skipping finalize in this pod: pod={}", getPodName());
+				return;
+			}
+			StandardizationHistory stndznHistory = getMostRecentStandardizationHistory();
+			if (stndznHistory == null || !"running".equals(stndznHistory.getDryRunStatus())) {
+				logger.info("Dry run already finalized by another pod; nothing to finalize in this pod: pod={}", getPodName());
+				return;
+			}
+			logger.info("step 3/3: checking for standardization duplicates");
+			dupeCheckStandardizationStructures();
+			finalizeDryRun("complete");
+		} catch (SQLException e) {
+			throw new StandardizerException(e);
+		} finally {
+			releaseDryRunClusterLock(lockConnection, lockAcquired);
+		}
+	}
+
+	private void releaseDryRunClusterLock(Connection lockConnection, boolean lockAcquired) {
+		if (lockAcquired && lockConnection != null) {
+			releaseClusterLock(
+					lockConnection,
+					ADVISORY_LOCK_NAMESPACE_ACAS,
+					ADVISORY_LOCK_DRY_RUN_EXECUTION
+			);
+		}
+		if (lockConnection != null) {
+			try {
+				lockConnection.close();
+			} catch (SQLException e) {
+				logger.warn("Failed to close dry-run cluster lock connection", e);
+			}
 		}
 	}
 }

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -91,6 +91,7 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 	// Use stable Java String hashes from human-readable lock names so lock IDs remain readable and deterministic
 	private static final int ADVISORY_LOCK_NAMESPACE_ACAS = "acas".hashCode();
 	private static final int ADVISORY_LOCK_AUTO_RESTANDARDIZE_STARTUP = "auto-restandardize-startup".hashCode();
+	private static final int ADVISORY_LOCK_DRY_RUN_EXECUTION = "dry-run-execution".hashCode();
 	private static final String AUTO_RESTANDARDIZATION_REPORT_FILENAME_PREFIX = "standardization-dry-run-report";
 
 	private final AtomicBoolean standardizationDryRunRunningInThisWorker = new AtomicBoolean(false);
@@ -962,18 +963,8 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 
 	@Override
 	public void executeDryRun() throws CmpdRegMolFormatException, IOException, StandardizerException {
-		logger.info("standardization dry run initialized");
-		try {
-			logger.info("step 1/3: resetting dry run table");
-			reset();
-			logger.info("setting dry run standardization status to running");
-			setCurrentStandardizationDryRunStatus("running");
-			checkForDryRunStandardization();
-		} catch (Exception e) {
-			logger.error("error running dry run", e);
-			finalizeDryRun("failed");
-			throw e;
-		}
+		// Initiator path (manual endpoint / startup auto-restandardization): reset + mark running, then run.
+		runDryRunCriticalSection(true);
 	}
 
 	private void runDryRun() throws CmpdRegMolFormatException, IOException, StandardizerException {
@@ -1026,15 +1017,54 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 
 
 	@Scheduled(fixedDelayString = "${client.cmpdreg.serverSettings.checkForDryRunStandardizationDelay:60000}")
-    public void checkForDryRunStandardization() throws CmpdRegMolFormatException, IOException, StandardizerException {
-        //Avoid running the process if we are already in the middle of a dry run on this worker.
-		//i.e. if its manually called or if takes longer than a minute to run.
-		if(!standardizationDryRunRunningInThisWorker.compareAndSet(false, true)) {
-			return; // Avoid running multiple dry runs in parallel
+	public void checkForDryRunStandardization() throws CmpdRegMolFormatException, IOException, StandardizerException {
+		// Scheduled worker path: only participate in an already-running dry run; never initiate.
+		runDryRunCriticalSection(false);
+	}
+
+	/**
+	 * Runs the dry-run execution critical section under BOTH a per-pod re-entrancy flag and a
+	 * cluster-wide Postgres advisory lock, so only one worker across all replicas can reset/populate
+	 * the shared dry-run tables at a time. Concurrent execution caused TRUNCATE-vs-INSERT deadlocks
+	 * (standardization_dry_run_compound AccessExclusiveLock vs bbchem_standardization_dry_run_structure
+	 * RowExclusiveLock) that aborted transactions and marked the run failed.
+	 *
+	 * @param initiate true for the manual/startup initiator (reset tables and mark the history
+	 *                 "running" before running); false for the scheduled worker (participate only).
+	 */
+	private void runDryRunCriticalSection(boolean initiate)
+			throws CmpdRegMolFormatException, IOException, StandardizerException {
+		// Avoid running the process if we are already in the middle of a dry run on this worker
+		// (manual call overlapping the scheduler, or a run that takes longer than the schedule delay).
+		if (!standardizationDryRunRunningInThisWorker.compareAndSet(false, true)) {
+			return;
 		}
+		Connection lockConnection = null;
+		boolean lockAcquired = false;
 		try {
+			lockConnection = dataSource.getConnection();
+			lockAcquired = tryAcquireClusterLock(
+					lockConnection,
+					ADVISORY_LOCK_NAMESPACE_ACAS,
+					ADVISORY_LOCK_DRY_RUN_EXECUTION
+			);
+			if (!lockAcquired) {
+				logger.info("Another pod holds the dry-run execution lock; skipping dry-run work in this pod: pod={}, initiate={}",
+						getPodName(), initiate);
+				return;
+			}
+
+			if (initiate) {
+				logger.info("standardization dry run initialized");
+				logger.info("step 1/3: resetting dry run table");
+				reset();
+				logger.info("setting dry run standardization status to running");
+				setCurrentStandardizationDryRunStatus("running");
+			}
+
 			StandardizationHistory stndznHistory = getMostRecentStandardizationHistory();
-			if (stndznHistory == null || stndznHistory.getDryRunStatus() == null || !stndznHistory.getDryRunStatus().equals("running")) {
+			if (stndznHistory == null || stndznHistory.getDryRunStatus() == null
+					|| !stndznHistory.getDryRunStatus().equals("running")) {
 				return;
 			}
 			StandardizerSettingsConfigDTO currentSettings = chemStructureService.getStandardizerSettings(true);
@@ -1048,8 +1078,9 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			int currentConfigHash = currentSettings.hashCode();
 			if (stndznHistory.getSettingsHash() != currentConfigHash) {
 				logger.warn("Skipping dry-run processing - config mismatch detected: pod={}, historyId={}, dryRunStatus={}, history hash={}, current hash={}, history settings={}, current settings={}. "
-						+ "This pod may have a different configuration than the pod that initiated the dry run. "
-						+ "Waiting for pod to restart with consistent config.",
+						+ "This worker's config differs from the snapshot stored by the pod that initiated the dry run "
+						+ "(expected briefly during a rolling deploy). The initiating pod owns the run and re-snapshots "
+						+ "its own config on (re)start, so this resolves once the initiating pod runs with the current config.",
 						getPodName(),
 						stndznHistory.getId(),
 						stndznHistory.getDryRunStatus(),
@@ -1089,8 +1120,22 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 			}
 			throw new StandardizerException(e);
 		} finally {
+			if (lockAcquired && lockConnection != null) {
+				releaseClusterLock(
+						lockConnection,
+						ADVISORY_LOCK_NAMESPACE_ACAS,
+						ADVISORY_LOCK_DRY_RUN_EXECUTION
+				);
+			}
+			if (lockConnection != null) {
+				try {
+					lockConnection.close();
+				} catch (SQLException e) {
+					logger.warn("Failed to close dry-run execution lock connection", e);
+				}
+			}
 			standardizationDryRunRunningInThisWorker.set(false);
 		}
-    }
+	}
 }
 

--- a/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/StandardizationServiceImpl.java
@@ -45,6 +45,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -97,6 +98,13 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 	private final AtomicBoolean standardizationDryRunRunningInThisWorker = new AtomicBoolean(false);
 	private final AtomicBoolean autoRestandardizationStartupTriggeredInThisWorker = new AtomicBoolean(false);
 	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	// A "running" dry run is only treated as stale (safe to fail) once it has made no progress -- no
+	// new dry-run-compound batch written -- for this long. Must stay well above the populate batch
+	// interval so an actively-populated run (even a slow one) is never falsely failed out from under
+	// its cooperative workers, which would let reset()'s TRUNCATE race their INSERTs.
+	@Value("${client.cmpdreg.serverSettings.dryRunStaleMillis:300000}")
+	private long dryRunStaleMillis;
 
 	private boolean tryAcquireClusterLock(Connection connection, int lockNamespace, int lockId) throws SQLException {
 		String sql = "SELECT pg_try_advisory_lock(?, ?)";
@@ -195,11 +203,39 @@ public class StandardizationServiceImpl implements StandardizationService, Appli
 				history.merge();
 			}
 			if (history.getDryRunStatus() != null && history.getDryRunStatus().equals("running")) {
-				logger.info("Failing running standardization dry run for run id " + history.getId());
-				history.setDryRunStatus("failed");
-				history.merge();
+				// Only fail a running dry run if it has actually gone stale (a dead pod left it behind).
+				// A run that live workers are still populating must NOT be failed here: doing so lets the
+				// subsequent reset() TRUNCATE the dry-run tables while those workers are still INSERTing,
+				// which deadlocks. A genuinely-active run is instead left running so this pod joins it.
+				if (isDryRunStale(history)) {
+					logger.info("Failing stale running standardization dry run for run id {} (no progress for > {} ms)",
+							history.getId(), dryRunStaleMillis);
+					history.setDryRunStatus("failed");
+					history.merge();
+				} else {
+					logger.info("Standardization dry run for run id {} is still making progress; leaving it running so this pod can join it instead of resetting.",
+							history.getId());
+				}
 			}
 		}
+	}
+
+	/**
+	 * A running dry run is "stale" only if no populate batch has been written for longer than
+	 * {@code dryRunStaleMillis}. Progress is read from the latest {@code qc_date} in
+	 * standardization_dry_run_compound (every batch stamps it), with the run's start time as the
+	 * fallback before the first batch lands. Compared in Java to match how those timestamps are
+	 * written (`new Date()`), avoiding timestamp-without-time-zone pitfalls.
+	 */
+	private boolean isDryRunStale(StandardizationHistory history) {
+		Date lastProgress = StandardizationDryRunCompound.findLatestQcDate();
+		if (lastProgress == null) {
+			lastProgress = history.getDryRunStart();
+		}
+		if (lastProgress == null) {
+			return true;
+		}
+		return (System.currentTimeMillis() - lastProgress.getTime()) > dryRunStaleMillis;
 	}
 
 	@Override

--- a/src/test/java/com/labsynch/labseer/service/StandardizationServiceImplTest.java
+++ b/src/test/java/com/labsynch/labseer/service/StandardizationServiceImplTest.java
@@ -1,0 +1,61 @@
+package com.labsynch.labseer.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+import java.util.Date;
+
+import com.labsynch.labseer.domain.StandardizationHistory;
+import com.labsynch.labseer.dto.configuration.StandardizerSettingsConfigDTO;
+
+import org.junit.Test;
+
+/**
+ * Pure unit tests (no Spring context / DB) for the dry-run initialization snapshot logic.
+ * Guards against the config-mismatch deadlock seen when the chemistry suite version changes
+ * while an incomplete dry-run record is reused.
+ */
+public class StandardizationServiceImplTest {
+
+	private StandardizerSettingsConfigDTO settingsForSuite(String suiteVersion) {
+		StandardizerSettingsConfigDTO dto = new StandardizerSettingsConfigDTO();
+		dto.setShouldStandardize(true);
+		dto.setType("bbchem");
+		dto.setSettings("{\"standardizer_actions\":{\"NEUTRALIZE\":true},"
+				+ "\"hash_scheme\":\"TAUTOMER_INSENSITIVE_LAYERS\","
+				+ "\"schrodinger_suite_version\":\"" + suiteVersion + "\"}");
+		return dto;
+	}
+
+	@Test
+	public void reusedHistoryAdoptsCurrentSettingsSnapshot() {
+		// An orphaned, incomplete dry-run record snapshotted under an OLD suite build.
+		StandardizerSettingsConfigDTO oldSettings = settingsForSuite("Schrodinger Suite 2026-3, Build 058");
+		StandardizationHistory history = new StandardizationHistory();
+		history.setSettings(oldSettings.toJson());
+		history.setSettingsHash(oldSettings.hashCode());
+		history.setDryRunStatus("failed");
+		history.setDryRunComplete(new Date());
+
+		// The initiating pod now runs with a NEW suite build and re-initializes the dry run.
+		StandardizerSettingsConfigDTO currentSettings = settingsForSuite("Schrodinger Suite 2026-3, Build 073");
+		Date start = new Date();
+		StandardizationServiceImpl.applyDryRunInitialization(history, currentSettings, "running", start);
+
+		// Snapshot must reflect the CURRENT config so the worker guard matches and proceeds.
+		assertEquals(currentSettings.hashCode(), history.getSettingsHash());
+		assertEquals(currentSettings.toJson(), history.getSettings());
+		assertEquals("running", history.getDryRunStatus());
+		assertEquals(start, history.getDryRunStart());
+		assertNull(history.getDryRunComplete());
+	}
+
+	@Test
+	public void suiteVersionChangeChangesTheHash() {
+		// Documents the exact trigger: identical actions, different suite build => different hash.
+		int oldHash = settingsForSuite("Schrodinger Suite 2026-3, Build 058").hashCode();
+		int newHash = settingsForSuite("Schrodinger Suite 2026-3, Build 073").hashCode();
+		assertFalse("suite version must affect the settings hash", oldHash == newHash);
+	}
+}


### PR DESCRIPTION
Fixes three related defects in the restandardization dry-run flow (`StandardizationServiceImpl`) that surfaced after auto-restandardization-on-startup (#512), in a multi-replica cluster during/after a chemistry suite version bump.

## Bug 1 — a dry run keeps a stale copy of the chemistry settings

Each dry run is tracked by a `standardization_history` row with a `dry_run_status` (`running` → `complete`) and a `settings_hash` (the hash of the chemistry settings it started with). A worker pod only joins a run if its live settings hash equals the row's `settings_hash`. `setCurrentStandardizationDryRunStatus` starts a run by either creating a new row, or **reusing the most-recent row when its `standardization_status` isn't `complete`** — which is common, because a plain `/dryRun` (and `failRunnningStandardization`) leave `standardization_status` NULL. It wrote `settings_hash` only on the create path, so a reused row kept its **old** hash. After a suite upgrade (Build 058 → 073) the reused row still advertised 058; every pod's live hash (073) failed the check and skipped (`config mismatch detected … waiting for pod to restart`, every ~60s), and the row sat at `running` forever.

```
The most-recent standardization_history row is from a prior dry run that never ran a full
standardization, so its standardization_status is still NULL (a plain /dryRun never sets it).

A new dry run starts on a Build 073 pod. Because that row isn't 'complete', the code REUSES it:
it flips dry_run_status back to 'running' but does NOT refresh settings_hash -> stays 058.   <- bug

Worker check before joining:  live settings_hash 073  ==  row.settings_hash 058 ?
   -> no -> "config mismatch ... waiting for pod to restart" -> skip
   ...nothing is on 058 anymore, so it never matches and the row sits at 'running' forever.
```

**Fix:** always write the current `settings_hash` on initiation — new or reused row (pure, unit-tested helper `applyDryRunInitialization`).

## Bug 2 — starting a second dry run while one is running deadlocks the database

Dry-run population is intentionally cooperative — every replica claims disjoint batches via `SELECT … FOR UPDATE SKIP LOCKED`, in parallel. The defect was at the lifecycle edges: nothing stopped a *second* dry run from starting while one was already running. Starting calls `reset()`, which `TRUNCATE`s the dry-run tables; that TRUNCATE collided with the in-flight `INSERT`s (`standardization_dry_run_compound` AccessExclusiveLock vs `bbchem_standardization_dry_run_structure` RowExclusiveLock) → `deadlock detected`, and two pods marking the run `running` clashed on the history row (optimistic-lock). The run was marked `failed`.

```
Intended (kept):  one run "running"
   Pod A - claim batch 1 (SKIP LOCKED) -> INSERT
   Pod B - claim batch 2 (SKIP LOCKED) -> INSERT   <- disjoint rows, in parallel

Bug:  a 2nd dry run STARTS mid-populate
   Pod B - reset(): TRUNCATE standardization_dry_run_compound   (table lock)
   Pod A - still INSERTing bbchem_standardization_dry_run_structure (row locks)  -> deadlock -> "failed"
```

**Fix:** keep population parallel and lock-free; guard only the lifecycle edges with a cluster-wide `pg_try_advisory_lock` (`ADVISORY_LOCK_DRY_RUN_EXECUTION`) — **start** (`reset()` + mark running, only when no run is active) and **finish** (dupe-check + finalize, by whichever pod drains the queue first). A TRUNCATE then never overlaps population.

## Bug 3 — a pod dying mid-run lets the next pod reset on top of live workers

This is the trigger behind the original incident. On a (re)starting pod, auto-restandardization runs `failRunnningStandardization()` — which marked **every** `running` dry run as `failed` — and then `executeDryRun()` (reset + start). If the pod running a dry run was terminated mid-populate while *other* pods were still cooperatively populating that run, the new pod's `failRunnningStandardization` flipped the still-active run to `failed`, so the `reset()` that follows `TRUNCATE`d the dry-run tables while those workers were still `INSERT`ing → the Bug 2 deadlock again, plus re-processed parents. It slips past Bug 2's "only reset if not running" guard because the status was changed out from under live workers.

```
Auto-restandardization on a (re)starting pod runs:  failRunnningStandardization()  then  reset()

Bug:  the pod running the dry run is terminated mid-populate; another pod keeps INSERTing.
   New pod : failRunnningStandardization() flips the still-active run 'running' -> 'failed'
             reset(): TRUNCATE  ──┐ races
   Other pod: still INSERTing  ───┴► deadlock detected (+ parents re-processed)

Fix:  only fail a run with NO progress for > dryRunStaleMillis (default 5 min).
   "progress" = newest qc_date in standardization_dry_run_compound (every batch stamps it).
   An actively-progressing run is left 'running' -> the new pod JOINS it, never resets.
```

**Fix:** `failRunnningStandardization` only fails a `running` dry run if it's **stale** — no new populate batch (`qc_date`) for `dryRunStaleMillis` (default 5 min, configurable). An actively-progressing run is left running so the new pod joins it. (A run abandoned by a dead pod but still valid is simply resumed; only one that genuinely can't progress is failed after the timeout and cleanly re-initiated.)

## Changes
- `StandardizationServiceImpl`:
  - `setCurrentStandardizationDryRunStatus` always snapshots current settings (pure helper `applyDryRunInitialization`).
  - New `ADVISORY_LOCK_DRY_RUN_EXECUTION`. `executeDryRun` → `initiateDryRunIfIdle()` (cluster-locked; `reset()` + mark running only if idle) then `participateInDryRun()`. `@Scheduled checkForDryRunStandardization` → `participateInDryRun()` (cooperative, no lock). `runDryRun` populates lock-free, then `finishDryRunUnderClusterLock()` (cluster-locked dupe-check + finalize).
  - `failRunnningStandardization` fails a dry run only if stale (`isDryRunStale`, threshold `dryRunStaleMillis`, default 5 min).
  - Clarified the config-mismatch log message.
- `StandardizationDryRunCompound.findLatestQcDate()` — `max(qc_date)` progress signal for staleness.
- New pure unit test `StandardizationServiceImplTest` (no Spring/DB).

## Why this was missed previously
- Earlier testing changed `hash_scheme` and ran a restandardization **to completion** — that exercises the *create-a-new-row* path, which always wrote `settings_hash` correctly. The bug lives in the *reuse-an-existing-row* path.
- The reuse path only triggers when the latest `standardization_history` row isn't `complete` (e.g. after a plain `/dryRun`, or an interrupted/auto run). A clean "edit config → restandardize → done" loop never leaves such a row around.
- `schrodinger_suite_version` isn't an editable setting — it's read from the BBChem health endpoint, so it only changes when a **new chemistry image is deployed**, i.e. alongside a pod restart. That restart is exactly what both leaves a reusable not-yet-`complete` row *and* changes the hash (Bug 1), and what kills a pod mid-run (Bug 3).
- The whole class only became reachable after #512 made restarts **auto-initiate** a dry run.

## Testing performed
All on dev cluster `shared-dev-cluster-26-2` (bbolt-darwin), BBChem engine, 2–4 roo replicas, ~5,257 parents.

- **Build:** `StandardizationServiceImplTest` 2/2; `-P indigo` test-compile BUILD SUCCESS (Docker JDK 21).
- **Bug 1:** reproduced on the old image (config-mismatch spam, no recovery); fixed image re-snapshots on reuse → live hash matches → run `complete`, spam stops.
- **Bug 2:** reproduced on the old image (two overlapping `/dryRun` → pod A `deadlock detected`, pod B optimistic-lock, run `failed`); fixed image → both pods populate disjoint batches in parallel, the 2nd initiator skips reset, one pod finalizes, run `complete`, **0** deadlock/optimistic-lock (incl. a 300m-CPU slow run for a wide overlap window).
- **Bug 3:** reproduced on the pre-staleness build (pod terminated mid-run during a rolling restart → the next pod's `failRunnningStandardization` clobbered the active run → reset-vs-populate `deadlock detected` + re-processing). With the staleness guard: invoked `failRunnningStandardization` against a genuinely-active run (record `running`, fresh `qc_date`) → it logged `… still making progress; leaving it running so this pod can join it instead of resetting`, did **not** fail the run, the run completed, and there were **0 deadlocks** across all pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
