### PR TITLE
ACAS-923: Return 404 for missing protocol experiments

### DIFF
--- a/src/main/java/com/labsynch/labseer/api/ApiExperimentController.java
+++ b/src/main/java/com/labsynch/labseer/api/ApiExperimentController.java
@@ -1644,7 +1644,7 @@ public class ApiExperimentController {
 			return new ResponseEntity<String>(
 					Experiment.toJsonArrayStub(experiments),
 					headers, HttpStatus.OK);
-		} catch (NoResultException e) {
+		} catch (NotFoundException e) {
 			return new ResponseEntity<String>("[ ]", headers, HttpStatus.NOT_FOUND);
 
 		} catch (TooManyResultsException e) {

--- a/src/main/java/com/labsynch/labseer/service/ExperimentService.java
+++ b/src/main/java/com/labsynch/labseer/service/ExperimentService.java
@@ -54,7 +54,7 @@ public interface ExperimentService {
 
     
     public Collection<Experiment> findExperimentsByProtocolCodeName(String query, List<String> projects)
-    throws TooManyResultsException;
+    throws TooManyResultsException, NotFoundException;
     
 	public Collection<Experiment> findExperimentsByGenericMetaDataSearch(String query, String userName, Boolean includeDeleted)
 			throws TooManyResultsException;

--- a/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
+++ b/src/main/java/com/labsynch/labseer/service/ExperimentServiceImpl.java
@@ -1120,7 +1120,7 @@ public class ExperimentServiceImpl implements ExperimentService {
 	}
 
 	public Collection<Experiment> findExperimentsByProtocolCodeName(String codeName, List<String> projects)
-			throws TooManyResultsException, NoResultException {
+			throws TooManyResultsException, NotFoundException {
 		List<Protocol> protocols = Protocol.findProtocolsByCodeNameEqualsAndIgnoredNot(codeName, true).getResultList();
 			
 		if (protocols.size() > 1) {
@@ -1128,11 +1128,14 @@ public class ExperimentServiceImpl implements ExperimentService {
 			throw new TooManyResultsException("ERROR: multiple protocols found with the same code name");
 		} else if (protocols.size() < 1) {
 			logger.warn("WARN: no protocols found with the query code name");
-			throw new NoResultException("WARN: no protocols found with the query code name");
+			throw new NotFoundException("WARN: no protocols found with the query code name");
 		}
 
 		Collection<Experiment> rawResults = Experiment.findExperimentsByProtocol(protocols.get(0)).getResultList();
 		if (propertiesUtilService.getRestrictExperiments()) {
+			if (projects == null) {
+				projects = new ArrayList<String>();
+			}
 			projects.add("unassigned");
 			Collection<Experiment> results = new HashSet<Experiment>();
 			for (Experiment rawResult : rawResults) {

--- a/src/test/java/com/labsynch/labseer/api/ApiExperimentControllerTest.java
+++ b/src/test/java/com/labsynch/labseer/api/ApiExperimentControllerTest.java
@@ -110,6 +110,14 @@ public class ApiExperimentControllerTest {
 		Assert.assertFalse(results.isEmpty());
 	}
 
+	@Test
+	public void getExperimentsByMissingProtocolCodeNameReturnsNotFound() throws Exception {
+		this.mockMvc.perform(get("/api/v1/experiments/protocol/FAKECODE")
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isNotFound());
+	}
+
 	// @Test
 	public void genericSearchByDate() throws Exception {
 		String searchString = "2015-03-05";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A while ago I noticed a quirk in our API where we were returning 500 errors when trying to look up non-existent protocols. This got in the way of my troubleshooting of a legitimate issue (OOM errors caused by protocols with many experiments) so I'm trying to clean it up. The fix is over 3 PRs:
- This PR to update the `throws` and ensure Roo responds with a 404 when the protocol code doesn't exist
- https://github.com/mcneilco/acas/pull/1248 Node PR to bypass "throw 500 on any non-200 response" rule built into node layer
- https://github.com/mcneilco/acasclient/pull/189 acasclient test & removal of workaround that was converting 500s to `None`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?
<!--- Describe how this has been tested -->
On local docker compose stack:
- http://localhost:8080/acas/api/v1/experiments/protocol/FAKECODE returns 404 rather than 500